### PR TITLE
RFC: Clamp floats to ints

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -32,6 +32,7 @@
 
 
 # Variable
+(-)(lhs::Variable) = AffExpr([lhs],[-1.0],0.0)
 # Variable--Number
 (+)(lhs::Variable, rhs::Number) = (+)( rhs,lhs)
 (-)(lhs::Variable, rhs::Number) = (+)(-rhs,lhs)

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -6,19 +6,19 @@ maff = Model()
 @defVar(maff, 0 <= LongName <= 99)
 # Test affToStr
 a1 = x[1] + LongName + 5
-@test affToStr(a1) == "1.0 x[1] + 1.0 LongName + 5.0"
+@test affToStr(a1) == "x[1] + LongName + 5"
 # Test like term collection
 a2 = 2*(x[2] + LongName + x[2]) + 0
-@test affToStr(a2) == "4.0 x[2] + 2.0 LongName"
+@test affToStr(a2) == "4 x[2] + 2 LongName"
 # Test appending functionality
 push!(a1, 5.0, x[2])
-@test affToStr(a1) == "1.0 x[1] + 1.0 LongName + 5.0 x[2] + 5.0"
+@test affToStr(a1) == "x[1] + LongName + 5 x[2] + 5"
 append!(a1, a2)
-@test affToStr(a1) == "1.0 x[1] + 3.0 LongName + 9.0 x[2] + 5.0"
+@test affToStr(a1) == "x[1] + 3 LongName + 9 x[2] + 5"
 
 # Test quadToStr
 q1 = x[1]*x[2] + 27.2*LongName + 5
-@test quadToStr(q1) == "1.0 x[1]*x[2] + 27.2 LongName + 5.0"
+@test quadToStr(q1) == "x[1]*x[2] + 27.2 LongName + 5"
 # Test like term collection
 q2 = x[1]*x[2] + x[2]*x[1]
-@test quadToStr(q2) == "2.0 x[1]*x[2]"
+@test quadToStr(q2) == "2 x[1]*x[2]"

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -37,13 +37,13 @@ let
     t = 10
 
     @addConstraint(m, 3x - y == 3.3(w + 2z) + 5) 
-    @test conToStr(m.linconstr[end]) == "3.0 x - 1.0 y - 3.3 w - 6.6 z == 5.0"
+    @test conToStr(m.linconstr[end]) == "3 x - y - 3.3 w - 6.6 z == 5"
     @addConstraint(m, (x+y)/2 == 1) 
-    @test conToStr(m.linconstr[end]) == "0.5 x + 0.5 y == 1.0"
+    @test conToStr(m.linconstr[end]) == "0.5 x + 0.5 y == 1"
     @addConstraint(m, -1 <= x-y <= t) 
-    @test conToStr(m.linconstr[end]) == "-1.0 <= 1.0 x - 1.0 y <= 10.0"
+    @test conToStr(m.linconstr[end]) == "-1 <= x - y <= 10"
     @addConstraint(m, -1 <= x+1 <= 1)
-    @test conToStr(m.linconstr[end]) == "-2.0 <= 1.0 x <= 0.0"
+    @test conToStr(m.linconstr[end]) == "-2 <= x <= 0"
     @test_throws @addConstraint(m, x <= t <= y)
 end
 
@@ -53,12 +53,12 @@ let
     @defVar(m, y)
     C = [1 2 3; 4 5 6; 7 8 9]
     @addConstraint(m, sum{ C[i,j]*x[i,j], i = 1:2, j = 2:3 } <= 1)
-    @test conToStr(m.linconstr[end]) == "2.0 x[1,2] + 3.0 x[1,3] + 5.0 x[2,2] + 6.0 x[2,3] <= 1.0"
+    @test conToStr(m.linconstr[end]) == "2 x[1,2] + 3 x[1,3] + 5 x[2,2] + 6 x[2,3] <= 1"
     @addConstraint(m, sum{ C[i,j]*x[i,j], i = 1:3, j = 1:3; i != j} == y)
-    @test conToStr(m.linconstr[end]) == "2.0 x[1,2] + 3.0 x[1,3] + 4.0 x[2,1] + 6.0 x[2,3] + 7.0 x[3,1] + 8.0 x[3,2] - 1.0 y == 0.0"
+    @test conToStr(m.linconstr[end]) == "2 x[1,2] + 3 x[1,3] + 4 x[2,1] + 6 x[2,3] + 7 x[3,1] + 8 x[3,2] - y == 0"
 
     @addConstraint(m, sum{ C[i,j]*x[i,j], i = 1:3, j = 1:i} == 0);
-    @test conToStr(m.linconstr[end]) == "1.0 x[1,1] + 4.0 x[2,1] + 5.0 x[2,2] + 7.0 x[3,1] + 8.0 x[3,2] + 9.0 x[3,3] == 0.0"
+    @test conToStr(m.linconstr[end]) == "x[1,1] + 4 x[2,1] + 5 x[2,2] + 7 x[3,1] + 8 x[3,2] + 9 x[3,3] == 0"
 end
 
 let
@@ -66,13 +66,13 @@ let
     @defVar(m, x[1:3,1:3])
     C = [1 2 3; 4 5 6; 7 8 9]
     con = @addConstraint(m, sum{ C[i,j]*x[i,j], i = 1:3, j = 1:3; i != j} == 0)
-    @test conToStr(m.linconstr[end]) == "2.0 x[1,2] + 3.0 x[1,3] + 4.0 x[2,1] + 6.0 x[2,3] + 7.0 x[3,1] + 8.0 x[3,2] == 0.0"
+    @test conToStr(m.linconstr[end]) == "2 x[1,2] + 3 x[1,3] + 4 x[2,1] + 6 x[2,3] + 7 x[3,1] + 8 x[3,2] == 0"
 
     @defVar(m, y, 0, [con], [-1.0])
-    @test conToStr(m.linconstr[end]) == "2.0 x[1,2] + 3.0 x[1,3] + 4.0 x[2,1] + 6.0 x[2,3] + 7.0 x[3,1] + 8.0 x[3,2] - 1.0 y == 0.0"
+    @test conToStr(m.linconstr[end]) == "2 x[1,2] + 3 x[1,3] + 4 x[2,1] + 6 x[2,3] + 7 x[3,1] + 8 x[3,2] - y == 0"
 
     chgConstrRHS(con, 3)
-    @test conToStr(m.linconstr[end]) == "2.0 x[1,2] + 3.0 x[1,3] + 4.0 x[2,1] + 6.0 x[2,3] + 7.0 x[3,1] + 8.0 x[3,2] - 1.0 y == 3.0"
+    @test conToStr(m.linconstr[end]) == "2 x[1,2] + 3 x[1,3] + 4 x[2,1] + 6 x[2,3] + 7 x[3,1] + 8 x[3,2] - y == 3"
 end
 
 let
@@ -81,7 +81,7 @@ let
     @defVar(m, y)
     temp = x + 2y + 1
     @addConstraint(m, 3*temp - x - 2 >= 0)
-    @test conToStr(m.linconstr[end]) == "6.0 y + 2.0 x >= -1.0"
+    @test conToStr(m.linconstr[end]) == "6 y + 2 x >= -1"
 end
 
 # test ranges in @defVar

--- a/test/model.jl
+++ b/test/model.jl
@@ -210,7 +210,7 @@ let
     @addConstraint(modC, a + b - 10c - 2x + c1 <= 1)
 
     str = string(modC)
-    @test str == "Max 1.0 a - 1.0 b + 2.0 a1 - 10.0 x\nSubject to \n1.0 a + 1.0 b - 10.0 c - 2.0 x + 1.0 c1 <= 1.0\na ≥ 1.0\nb ≤ 1.0\n-1.0 ≤ c ≤ 1.0\na1 ≥ 1.0, integer\nb1 ≤ 1.0, integer\n-1.0 ≤ c1 ≤ 1.0, integer\nx, binary\ny free\nz free, integer\n"
+    @test str == "Max a - b + 2 a1 - 10 x\nSubject to \na + b - 10 c - 2 x + c1 <= 1\na ≥ 1\nb ≤ 1\n-1 ≤ c ≤ 1\na1 ≥ 1, integer\nb1 ≤ 1, integer\n-1 ≤ c1 ≤ 1, integer\nx, binary\ny free\nz free, integer\n"
 end
 
 #####################################################################

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -14,10 +14,10 @@ aff2 = 1.2 * y + 1.2
 @test affToStr(aff2) == "1.2 y + 1.2"
 q = 2.5 * y * z + aff
 @test quadToStr(q) == "2.5 y*z + 7.1 x + 2.5"
-q2 = 8.0 * x * z + aff2
-@test quadToStr(q2) == "8.0 x*z + 1.2 y + 1.2"
-q3 = 2.0 * x * x + 1.0 * y * y + z + 3.0
-@test quadToStr(q3) == "2.0 x² + 1.0 y² + 1.0 z + 3.0"
+q2 = 8 * x * z + aff2
+@test quadToStr(q2) == "8 x*z + 1.2 y + 1.2"
+q3 = 2 * x * x + 1 * y * y + z + 3
+@test quadToStr(q3) == "2 x² + y² + z + 3"
 
 # Different objects that must all interact:
 # 1. Number
@@ -28,111 +28,111 @@ q3 = 2.0 * x * x + 1.0 * y * y + z + 3.0
 # 1. Number tests
 # 1-1 Number--Number - nope!
 # 1-2 Number--Variable
-@test affToStr(4.13 + w) == "1.0 w + 4.13"
-@test affToStr(3.16 - w) == "-1.0 w + 3.16"
+@test affToStr(4.13 + w) == "w + 4.13"
+@test affToStr(3.16 - w) == "-w + 3.16"
 @test affToStr(5.23 * w) == "5.23 w"
 @test_throws 2.94 / w
-@test conToStr(2.1 <= w) == "1.0 w >= 2.1"
-@test conToStr(2.1 == w) == "1.0 w == 2.1"
-@test conToStr(2.1 >= w) == "1.0 w <= 2.1"
+@test conToStr(2.1 <= w) == "w >= 2.1"
+@test conToStr(2.1 == w) == "w == 2.1"
+@test conToStr(2.1 >= w) == "w <= 2.1"
 # 1-3 Number--AffExpr
-@test affToStr(1.5 + aff) == "7.1 x + 4.0"
-@test affToStr(1.5 - aff) == "-7.1 x - 1.0"
-@test affToStr(2.0 * aff) == "14.2 x + 5.0"
-@test_throws 2.0 / aff
-@test conToStr(1.0 <= aff) == "7.1 x >= -1.5"
-@test conToStr(1.0 == aff) == "7.1 x == -1.5"
-@test conToStr(1.0 >= aff) == "7.1 x <= -1.5"
+@test affToStr(1.5 + aff) == "7.1 x + 4"
+@test affToStr(1.5 - aff) == "-7.1 x - 1"
+@test affToStr(2 * aff) == "14.2 x + 5"
+@test_throws 2 / aff
+@test conToStr(1 <= aff) == "7.1 x >= -1.5"
+@test conToStr(1 == aff) == "7.1 x == -1.5"
+@test conToStr(1 >= aff) == "7.1 x <= -1.5"
 # 1-4 Number--QuadExpr
-@test quadToStr(1.5 + q) == "2.5 y*z + 7.1 x + 4.0"
-@test quadToStr(1.5 - q) == "-2.5 y*z - 7.1 x - 1.0"
-@test quadToStr(2.0 * q) == "5.0 y*z + 14.2 x + 5.0"
-@test_throws 2.0 / q
-@test conToStr(1.0 <= q) == "2.5 y*z + 7.1 x + 1.5 >= 0"
-@test conToStr(1.0 == q) == "2.5 y*z + 7.1 x + 1.5 == 0"
-@test conToStr(1.0 >= q) == "2.5 y*z + 7.1 x + 1.5 <= 0"
+@test quadToStr(1.5 + q) == "2.5 y*z + 7.1 x + 4"
+@test quadToStr(1.5 - q) == "-2.5 y*z - 7.1 x - 1"
+@test quadToStr(2 * q) == "5 y*z + 14.2 x + 5"
+@test_throws 2 / q
+@test conToStr(1 <= q) == "2.5 y*z + 7.1 x + 1.5 >= 0"
+@test conToStr(1 == q) == "2.5 y*z + 7.1 x + 1.5 == 0"
+@test conToStr(1 >= q) == "2.5 y*z + 7.1 x + 1.5 <= 0"
 
 # 2. Variable tests
 # 2-1 Variable--Number
-@test affToStr(w + 4.13) == "1.0 w + 4.13"
-@test affToStr(w - 4.13) == "1.0 w - 4.13"
+@test affToStr(w + 4.13) == "w + 4.13"
+@test affToStr(w - 4.13) == "w - 4.13"
 @test affToStr(w * 4.13) == "4.13 w"
 @test affToStr(w / 2.00) == "0.5 w"
-@test conToStr(w <= 1.0) == "1.0 w <= 1.0"
-@test conToStr(w == 1.0) == "1.0 w == 1.0"
-@test conToStr(w >= 1.0) == "1.0 w >= 1.0"
-@test conToStr(x*y <= 1.0) == "1.0 x*y - 1.0 <= 0"
-@test conToStr(x*y == 1.0) == "1.0 x*y - 1.0 == 0"
-@test conToStr(x*y >= 1.0) == "1.0 x*y - 1.0 >= 0"
+@test conToStr(w <= 1) == "w <= 1"
+@test conToStr(w == 1) == "w == 1"
+@test conToStr(w >= 1) == "w >= 1"
+@test conToStr(x*y <= 1) == "x*y - 1 <= 0"
+@test conToStr(x*y == 1) == "x*y - 1 == 0"
+@test conToStr(x*y >= 1) == "x*y - 1 >= 0"
 # 2-2 Variable--Variable
-@test affToStr(w + x) == "1.0 w + 1.0 x"
-@test affToStr(w - x) == "1.0 w - 1.0 x"
-@test quadToStr(w * x) == "1.0 w*x"
-@test affToStr(x - x) == "0.0"
+@test affToStr(w + x) == "w + x"
+@test affToStr(w - x) == "w - x"
+@test quadToStr(w * x) == "w*x"
+@test affToStr(x - x) == "0"
 @test_throws w / x
-@test conToStr(w <= x) == "1.0 w - 1.0 x <= 0.0"
-@test conToStr(w == x) == "1.0 w - 1.0 x == 0.0"
-@test conToStr(w >= x) == "1.0 w - 1.0 x >= 0.0"
-@test conToStr(y*z <= x) == "1.0 y*z - 1.0 x <= 0"
-@test conToStr(y*z == x) == "1.0 y*z - 1.0 x == 0"
-@test conToStr(y*z >= x) == "1.0 y*z - 1.0 x >= 0"
-@test conToStr(x <= x) == "0.0 <= 0.0"
-@test conToStr(x == x) == "0.0 == 0.0"
-@test conToStr(x >= x) == "0.0 >= 0.0"
+@test conToStr(w <= x) == "w - x <= 0"
+@test conToStr(w == x) == "w - x == 0"
+@test conToStr(w >= x) == "w - x >= 0"
+@test conToStr(y*z <= x) == "y*z - x <= 0"
+@test conToStr(y*z == x) == "y*z - x == 0"
+@test conToStr(y*z >= x) == "y*z - x >= 0"
+@test conToStr(x <= x) == "0 <= 0"
+@test conToStr(x == x) == "0 == 0"
+@test conToStr(x >= x) == "0 >= 0"
 # 2-3 Variable--AffExpr
-@test affToStr(z + aff) == "7.1 x + 1.0 z + 2.5"
-@test affToStr(z - aff) == "-7.1 x + 1.0 z - 2.5"
+@test affToStr(z + aff) == "7.1 x + z + 2.5"
+@test affToStr(z - aff) == "-7.1 x + z - 2.5"
 @test quadToStr(z * aff) == "7.1 x*z + 2.5 z"
 @test_throws z / aff
-@test conToStr(z <= aff) == "-7.1 x + 1.0 z <= 2.5"
-@test conToStr(z == aff) == "-7.1 x + 1.0 z == 2.5"
-@test conToStr(z >= aff) == "-7.1 x + 1.0 z >= 2.5"
-@test conToStr(7.1 * x - aff <= 0) == "0.0 <= 2.5"
-@test conToStr(7.1 * x - aff == 0) == "0.0 == 2.5"
-@test conToStr(7.1 * x - aff >= 0) == "0.0 >= 2.5"
+@test conToStr(z <= aff) == "-7.1 x + z <= 2.5"
+@test conToStr(z == aff) == "-7.1 x + z == 2.5"
+@test conToStr(z >= aff) == "-7.1 x + z >= 2.5"
+@test conToStr(7.1 * x - aff <= 0) == "0 <= 2.5"
+@test conToStr(7.1 * x - aff == 0) == "0 == 2.5"
+@test conToStr(7.1 * x - aff >= 0) == "0 >= 2.5"
 # 2-4 Variable--QuadExpr
-@test quadToStr(w + q) == "2.5 y*z + 7.1 x + 1.0 w + 2.5"
-@test quadToStr(w - q) == "-2.5 y*z - 7.1 x + 1.0 w - 2.5"
+@test quadToStr(w + q) == "2.5 y*z + 7.1 x + w + 2.5"
+@test quadToStr(w - q) == "-2.5 y*z - 7.1 x + w - 2.5"
 @test_throws w*q
 @test_throws w/q
-@test conToStr(w <= q) == "-2.5 y*z - 7.1 x + 1.0 w - 2.5 <= 0"
-@test conToStr(w == q) == "-2.5 y*z - 7.1 x + 1.0 w - 2.5 == 0"
-@test conToStr(w >= q) == "-2.5 y*z - 7.1 x + 1.0 w - 2.5 >= 0"
+@test conToStr(w <= q) == "-2.5 y*z - 7.1 x + w - 2.5 <= 0"
+@test conToStr(w == q) == "-2.5 y*z - 7.1 x + w - 2.5 == 0"
+@test conToStr(w >= q) == "-2.5 y*z - 7.1 x + w - 2.5 >= 0"
 
 # 3. AffExpr tests
 # 3-1 AffExpr--Number
-@test affToStr(aff + 1.5) == "7.1 x + 4.0"
-@test affToStr(aff - 1.5) == "7.1 x + 1.0"
-@test affToStr(aff * 2.0) == "14.2 x + 5.0"
-@test affToStr(aff / 2.0) == "3.55 x + 1.25"
-@test conToStr(aff <= 1.0) == "7.1 x <= -1.5"
-@test conToStr(aff == 1.0) == "7.1 x == -1.5"
-@test conToStr(aff >= 1.0) == "7.1 x >= -1.5"
+@test affToStr(aff + 1.5) == "7.1 x + 4"
+@test affToStr(aff - 1.5) == "7.1 x + 1"
+@test affToStr(aff * 2) == "14.2 x + 5"
+@test affToStr(aff / 2) == "3.55 x + 1.25"
+@test conToStr(aff <= 1) == "7.1 x <= -1.5"
+@test conToStr(aff == 1) == "7.1 x == -1.5"
+@test conToStr(aff >= 1) == "7.1 x >= -1.5"
 
 # 3-2 AffExpr--Variable
-@test affToStr(aff + z) == "7.1 x + 1.0 z + 2.5"
-@test affToStr(aff - z) == "7.1 x - 1.0 z + 2.5"
+@test affToStr(aff + z) == "7.1 x + z + 2.5"
+@test affToStr(aff - z) == "7.1 x - z + 2.5"
 @test quadToStr(aff * z) == "7.1 x*z + 2.5 z"
 @test_throws aff/z
-@test conToStr(aff <= z) == "7.1 x - 1.0 z <= -2.5"
-@test conToStr(aff == z) == "7.1 x - 1.0 z == -2.5"
-@test conToStr(aff >= z) == "7.1 x - 1.0 z >= -2.5"
-@test conToStr(aff - 7.1 * x <= 0) == "0.0 <= -2.5"
-@test conToStr(aff - 7.1 * x == 0) == "0.0 == -2.5"
-@test conToStr(aff - 7.1 * x >= 0) == "0.0 >= -2.5"
+@test conToStr(aff <= z) == "7.1 x - z <= -2.5"
+@test conToStr(aff == z) == "7.1 x - z == -2.5"
+@test conToStr(aff >= z) == "7.1 x - z >= -2.5"
+@test conToStr(aff - 7.1 * x <= 0) == "0 <= -2.5"
+@test conToStr(aff - 7.1 * x == 0) == "0 == -2.5"
+@test conToStr(aff - 7.1 * x >= 0) == "0 >= -2.5"
 
 
 # 3-3 AffExpr--AffExpr
 @test affToStr(aff + aff2) == "7.1 x + 1.2 y + 3.7"
 @test affToStr(aff - aff2) == "7.1 x - 1.2 y + 1.3"
-@test quadToStr(aff * aff2) == "8.52 x*y + 3.0 y + 8.52 x + 3.0"
+@test quadToStr(aff * aff2) == "8.52 x*y + 3 y + 8.52 x + 3"
 @test_throws aff/aff2
 @test conToStr(aff <= aff2) == "7.1 x - 1.2 y <= -1.3"
 @test conToStr(aff == aff2) == "7.1 x - 1.2 y == -1.3"
 @test conToStr(aff >= aff2) == "7.1 x - 1.2 y >= -1.3"
-@test conToStr(aff-aff <= 0) == "0.0 <= 0.0"
-@test conToStr(aff-aff == 0) == "0.0 == 0.0"
-@test conToStr(aff-aff >= 0) == "0.0 >= 0.0"
+@test conToStr(aff-aff <= 0) == "0 <= 0"
+@test conToStr(aff-aff == 0) == "0 == 0"
+@test conToStr(aff-aff >= 0) == "0 >= 0"
 # 3-4 AffExpr--QuadExpr
 @test quadToStr(aff2 + q) == "2.5 y*z + 1.2 y + 7.1 x + 3.7"
 @test quadToStr(aff2 - q) == "-2.5 y*z + 1.2 y - 7.1 x - 1.3"
@@ -144,21 +144,21 @@ q3 = 2.0 * x * x + 1.0 * y * y + z + 3.0
 
 # 4. QuadExpr
 # 4-1 QuadExpr--Number
-@test quadToStr(q + 1.5) == "2.5 y*z + 7.1 x + 4.0"
-@test quadToStr(q - 1.5) == "2.5 y*z + 7.1 x + 1.0"
-@test quadToStr(q * 2.0) == "5.0 y*z + 14.2 x + 5.0"
-@test quadToStr(q / 2.0) == "1.25 y*z + 3.55 x + 1.25"
-@test conToStr(q >= 1.0) == "2.5 y*z + 7.1 x + 1.5 >= 0"
-@test conToStr(q == 1.0) == "2.5 y*z + 7.1 x + 1.5 == 0"
-@test conToStr(q <= 1.0) == "2.5 y*z + 7.1 x + 1.5 <= 0"
+@test quadToStr(q + 1.5) == "2.5 y*z + 7.1 x + 4"
+@test quadToStr(q - 1.5) == "2.5 y*z + 7.1 x + 1"
+@test quadToStr(q * 2) == "5 y*z + 14.2 x + 5"
+@test quadToStr(q / 2) == "1.25 y*z + 3.55 x + 1.25"
+@test conToStr(q >= 1) == "2.5 y*z + 7.1 x + 1.5 >= 0"
+@test conToStr(q == 1) == "2.5 y*z + 7.1 x + 1.5 == 0"
+@test conToStr(q <= 1) == "2.5 y*z + 7.1 x + 1.5 <= 0"
 # 4-2 QuadExpr--Variable
-@test quadToStr(q + w) == "2.5 y*z + 7.1 x + 1.0 w + 2.5"
-@test quadToStr(q - w) == "2.5 y*z + 7.1 x - 1.0 w + 2.5"
+@test quadToStr(q + w) == "2.5 y*z + 7.1 x + w + 2.5"
+@test quadToStr(q - w) == "2.5 y*z + 7.1 x - w + 2.5"
 @test_throws w*q
 @test_throws w/q
-@test conToStr(q <= w) == "2.5 y*z + 7.1 x - 1.0 w + 2.5 <= 0"
-@test conToStr(q == w) == "2.5 y*z + 7.1 x - 1.0 w + 2.5 == 0"
-@test conToStr(q >= w) == "2.5 y*z + 7.1 x - 1.0 w + 2.5 >= 0"
+@test conToStr(q <= w) == "2.5 y*z + 7.1 x - w + 2.5 <= 0"
+@test conToStr(q == w) == "2.5 y*z + 7.1 x - w + 2.5 == 0"
+@test conToStr(q >= w) == "2.5 y*z + 7.1 x - w + 2.5 >= 0"
 # 4-3 QuadExpr--AffExpr
 @test quadToStr(q + aff2) == "2.5 y*z + 7.1 x + 1.2 y + 3.7"
 @test quadToStr(q - aff2) == "2.5 y*z + 7.1 x - 1.2 y + 1.3"
@@ -168,13 +168,13 @@ q3 = 2.0 * x * x + 1.0 * y * y + z + 3.0
 @test conToStr(q == aff2) == "2.5 y*z + 7.1 x - 1.2 y + 1.3 == 0"
 @test conToStr(q >= aff2) == "2.5 y*z + 7.1 x - 1.2 y + 1.3 >= 0"
 # 4-4 QuadExpr--QuadExpr
-@test quadToStr(q + q2) == "8.0 x*z + 2.5 y*z + 7.1 x + 1.2 y + 3.7"
-@test quadToStr(q - q2) == "-8.0 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3"
+@test quadToStr(q + q2) == "8 x*z + 2.5 y*z + 7.1 x + 1.2 y + 3.7"
+@test quadToStr(q - q2) == "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3"
 @test_throws q * q2
 @test_throws q / q2
-@test conToStr(q <= q2) == "-8.0 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 <= 0"
-@test conToStr(q == q2) == "-8.0 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 == 0"
-@test conToStr(q >= q2) == "-8.0 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 >= 0"
+@test conToStr(q <= q2) == "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 <= 0"
+@test conToStr(q == q2) == "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 == 0"
+@test conToStr(q >= q2) == "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 >= 0"
 
 
 # Higher-level operators
@@ -183,17 +183,17 @@ let
     sum_m = Model()
     @defVar(sum_m, 0 <= matrix[1:3,1:3] <= 1)
     # sum(j::JuMPDict{Variable}) 
-    @test affToStr(sum(matrix)) == "1.0 matrix[1,1] + 1.0 matrix[2,1] + 1.0 matrix[3,1] + 1.0 matrix[1,2] + 1.0 matrix[2,2] + 1.0 matrix[3,2] + 1.0 matrix[1,3] + 1.0 matrix[2,3] + 1.0 matrix[3,3]"
+    @test affToStr(sum(matrix)) == "matrix[1,1] + matrix[2,1] + matrix[3,1] + matrix[1,2] + matrix[2,2] + matrix[3,2] + matrix[1,3] + matrix[2,3] + matrix[3,3]"
     # sum(j::JuMPDict{Variable}) in a macro
     @setObjective(sum_m, Max, sum(matrix))
-    @test quadToStr(sum_m.obj) == "1.0 matrix[1,1] + 1.0 matrix[2,1] + 1.0 matrix[3,1] + 1.0 matrix[1,2] + 1.0 matrix[2,2] + 1.0 matrix[3,2] + 1.0 matrix[1,3] + 1.0 matrix[2,3] + 1.0 matrix[3,3]"
+    @test quadToStr(sum_m.obj) == "matrix[1,1] + matrix[2,1] + matrix[3,1] + matrix[1,2] + matrix[2,2] + matrix[3,2] + matrix[1,3] + matrix[2,3] + matrix[3,3]"
     solve(sum_m)
     # sum{T<:Real}(j::JuMPDict{T})
-    @test_approx_eq_eps sum(getValue(matrix)) 9.0 1e-6
+    @test_approx_eq_eps sum(getValue(matrix)) 9 1e-6
     # sum(j::Array{Variable})
     @test affToStr(sum(matrix[1:3,1:3])) == affToStr(sum(matrix))
     # sum(affs::Array{AffExpr})
-    @test affToStr(sum([2.0*matrix[i,j] for i in 1:3, j in 1:3])) == "2.0 matrix[1,1] + 2.0 matrix[2,1] + 2.0 matrix[3,1] + 2.0 matrix[1,2] + 2.0 matrix[2,2] + 2.0 matrix[3,2] + 2.0 matrix[1,3] + 2.0 matrix[2,3] + 2.0 matrix[3,3]"
+    @test affToStr(sum([2*matrix[i,j] for i in 1:3, j in 1:3])) == "2 matrix[1,1] + 2 matrix[2,1] + 2 matrix[3,1] + 2 matrix[1,2] + 2 matrix[2,2] + 2 matrix[3,2] + 2 matrix[1,3] + 2 matrix[2,3] + 2 matrix[3,3]"
 end
 
 # dot
@@ -201,23 +201,23 @@ let
     dot_m = Model()
     @defVar(dot_m, 0 <= x[1:3] <= 1)
     c = [1:3]
-    @test affToStr(dot(c,x)) == "1.0 x[1] + 2.0 x[2] + 3.0 x[3]"
-    @test affToStr(dot(x,c)) == "1.0 x[1] + 2.0 x[2] + 3.0 x[3]"
+    @test affToStr(dot(c,x)) == "x[1] + 2 x[2] + 3 x[3]"
+    @test affToStr(dot(x,c)) == "x[1] + 2 x[2] + 3 x[3]"
 
     A = [1 3 ; 2 4]
     @defVar(dot_m, 1 <= y[1:2,1:2] <= 1)
-    @test affToStr(dot(A,y)) == "1.0 y[1,1] + 2.0 y[2,1] + 3.0 y[1,2] + 4.0 y[2,2]"
-    @test affToStr(dot(y,A)) == "1.0 y[1,1] + 2.0 y[2,1] + 3.0 y[1,2] + 4.0 y[2,2]"
+    @test affToStr(dot(A,y)) == "y[1,1] + 2 y[2,1] + 3 y[1,2] + 4 y[2,2]"
+    @test affToStr(dot(y,A)) == "y[1,1] + 2 y[2,1] + 3 y[1,2] + 4 y[2,2]"
 
     B = ones(2,2,2)
     @defVar(dot_m, 0 <= z[1:2,1:2,1:2] <= 1)
-    @test affToStr(dot(B,z)) == "1.0 z[1,1,1] + 1.0 z[2,1,1] + 1.0 z[1,2,1] + 1.0 z[2,2,1] + 1.0 z[1,1,2] + 1.0 z[2,1,2] + 1.0 z[1,2,2] + 1.0 z[2,2,2]"
-    @test affToStr(dot(z,B)) == "1.0 z[1,1,1] + 1.0 z[2,1,1] + 1.0 z[1,2,1] + 1.0 z[2,2,1] + 1.0 z[1,1,2] + 1.0 z[2,1,2] + 1.0 z[1,2,2] + 1.0 z[2,2,2]"
+    @test affToStr(dot(B,z)) == "z[1,1,1] + z[2,1,1] + z[1,2,1] + z[2,2,1] + z[1,1,2] + z[2,1,2] + z[1,2,2] + z[2,2,2]"
+    @test affToStr(dot(z,B)) == "z[1,1,1] + z[2,1,1] + z[1,2,1] + z[2,2,1] + z[1,1,2] + z[2,1,2] + z[1,2,2] + z[2,2,2]"
 
     @setObjective(dot_m, Max, dot(x, ones(3)) - dot(y, ones(2,2)) )
     solve(dot_m)
-    @test_approx_eq_eps dot(c, getValue(x))   6.0  1e-6
-    @test_approx_eq_eps dot(A, getValue(y))  10.0  1e-6
+    @test_approx_eq_eps dot(c, getValue(x))   6  1e-6
+    @test_approx_eq_eps dot(A, getValue(y))  10  1e-6
 end
 
 let
@@ -227,7 +227,7 @@ let
     catcoef = [1,2,3]
     dogcoef = [3,4,5]
 
-    @test affToStr(dot(catcoef, x[:,:cat])) == "1.0 x[-1,cat] + 2.0 x[0,cat] + 3.0 x[1,cat]"
-    @test affToStr(dot(dogcoef, x[:,:dog])) == "3.0 x[-1,dog] + 4.0 x[0,dog] + 5.0 x[1,dog]"
+    @test affToStr(dot(catcoef, x[:,:cat])) == "x[-1,cat] + 2 x[0,cat] + 3 x[1,cat]"
+    @test affToStr(dot(dogcoef, x[:,:dog])) == "3 x[-1,dog] + 4 x[0,dog] + 5 x[1,dog]"
 end
 

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -48,44 +48,44 @@ setUpper(x, 3)
 # Test long-form bounds printing code in print.jl
 mprint = Model()
 @defVar(mprint, 0 <= a[3:6] <= 5)
-@test JuMP.dictstring(a, :REPL)   == "0.0 ≤ a[i] ≤ 5.0, for all i in {3..6}"
-@test JuMP.dictstring(a, :IJulia) == "0.0 \\leq a_{i} \\leq 5.0 \\quad \\forall i \\in \\{ 3..6 \\}"
+@test JuMP.dictstring(a, :REPL)   == "0 ≤ a[i] ≤ 5, for all i in {3..6}"
+@test JuMP.dictstring(a, :IJulia) == "0 \\leq a_{i} \\leq 5 \\quad \\forall i \\in \\{ 3..6 \\}"
 @defVar(mprint, b[-2:3] >= 2)
-@test JuMP.dictstring(b, :REPL)   == "b[i] ≥ 2.0, for all i in {-2..3}"
-@test JuMP.dictstring(b, :IJulia) == "b_{i} \\geq 2.0 \\quad \\forall i \\in \\{ -2..3 \\}"
-@defVar(mprint, c[-2:3] <= 7.0)
-@test JuMP.dictstring(c, :REPL)   == "c[i] ≤ 7.0, for all i in {-2..3}"
-@test JuMP.dictstring(c, :IJulia) == "c_{i} \\leq 7.0 \\quad \\forall i \\in \\{ -2..3 \\}"
+@test JuMP.dictstring(b, :REPL)   == "b[i] ≥ 2, for all i in {-2..3}"
+@test JuMP.dictstring(b, :IJulia) == "b_{i} \\geq 2 \\quad \\forall i \\in \\{ -2..3 \\}"
+@defVar(mprint, c[-2:3] <= 7)
+@test JuMP.dictstring(c, :REPL)   == "c[i] ≤ 7, for all i in {-2..3}"
+@test JuMP.dictstring(c, :IJulia) == "c_{i} \\leq 7 \\quad \\forall i \\in \\{ -2..3 \\}"
 @defVar(mprint, 0 <= d[-5:2] <= 5, Int)
-@test JuMP.dictstring(d, :REPL)   == "0.0 ≤ d[i] ≤ 5.0, for all i in {-5..2}, integer"
-@test JuMP.dictstring(d, :IJulia) == "0.0 \\leq d_{i} \\leq 5.0 \\quad \\forall i \\in \\{ -5..2 \\}, integer"
+@test JuMP.dictstring(d, :REPL)   == "0 ≤ d[i] ≤ 5, for all i in {-5..2}, integer"
+@test JuMP.dictstring(d, :IJulia) == "0 \\leq d_{i} \\leq 5 \\quad \\forall i \\in \\{ -5..2 \\}, integer"
 @defVar(mprint, z[-5:2], Bin)
 @test JuMP.dictstring(z, :REPL)   == "z[i], for all i in {-5..2}, binary"
 @test JuMP.dictstring(z, :IJulia) == "z_{i} \\quad \\forall i \\in \\{ -5..2 \\}, binary"
 @defVar(mprint, f[6:9] >= 3, Int)
-@test JuMP.dictstring(f, :REPL)   == "f[i] ≥ 3.0, for all i in {6..9}, integer"
-@test JuMP.dictstring(f, :IJulia) == "f_{i} \\geq 3.0 \\quad \\forall i \\in \\{ 6..9 \\}, integer"
+@test JuMP.dictstring(f, :REPL)   == "f[i] ≥ 3, for all i in {6..9}, integer"
+@test JuMP.dictstring(f, :IJulia) == "f_{i} \\geq 3 \\quad \\forall i \\in \\{ 6..9 \\}, integer"
 @defVar(mprint, g[1:5:3] >= 0)
-@test JuMP.dictstring(g, :REPL)   == "g[i] ≥ 0.0, for all i in {1}"
-@test JuMP.dictstring(g, :IJulia) == "g_{i} \\geq 0.0 \\quad \\forall i \\in \\{ 1 \\}"
+@test JuMP.dictstring(g, :REPL)   == "g[i] ≥ 0, for all i in {1}"
+@test JuMP.dictstring(g, :IJulia) == "g_{i} \\geq 0 \\quad \\forall i \\in \\{ 1 \\}"
 @defVar(mprint, h[0:2:2] >= 0)
-@test JuMP.dictstring(h, :REPL)   == "h[i] ≥ 0.0, for all i in {0,2}"
-@test JuMP.dictstring(h, :IJulia) == "h_{i} \\geq 0.0 \\quad \\forall i \\in \\{ 0,2 \\}"
+@test JuMP.dictstring(h, :REPL)   == "h[i] ≥ 0, for all i in {0,2}"
+@test JuMP.dictstring(h, :IJulia) == "h_{i} \\geq 0 \\quad \\forall i \\in \\{ 0,2 \\}"
 @defVar(mprint, i[0:2:4] >= 0)
-@test JuMP.dictstring(i, :REPL)   == "i[i] ≥ 0.0, for all i in {0,2,4}"
-@test JuMP.dictstring(i, :IJulia) == "i_{i} \\geq 0.0 \\quad \\forall i \\in \\{ 0,2,4 \\}"
+@test JuMP.dictstring(i, :REPL)   == "i[i] ≥ 0, for all i in {0,2,4}"
+@test JuMP.dictstring(i, :IJulia) == "i_{i} \\geq 0 \\quad \\forall i \\in \\{ 0,2,4 \\}"
 @defVar(mprint, j[1:2:20] >= 0)
-@test JuMP.dictstring(j, :REPL)   == "j[i] ≥ 0.0, for all i in {1,3..17,19}"
-@test JuMP.dictstring(j, :IJulia) == "j_{i} \\geq 0.0 \\quad \\forall i \\in \\{ 1,3..17,19 \\}"
+@test JuMP.dictstring(j, :REPL)   == "j[i] ≥ 0, for all i in {1,3..17,19}"
+@test JuMP.dictstring(j, :IJulia) == "j_{i} \\geq 0 \\quad \\forall i \\in \\{ 1,3..17,19 \\}"
 @defVar(mprint, k[[:a,:b,:c]] >= 0)
-@test JuMP.dictstring(k, :REPL)   == "k[i] ≥ 0.0, for all i in {a,b,c}"
-@test JuMP.dictstring(k, :IJulia) == "k_{i} \\geq 0.0 \\quad \\forall i \\in \\{ a,b,c \\}"
+@test JuMP.dictstring(k, :REPL)   == "k[i] ≥ 0, for all i in {a,b,c}"
+@test JuMP.dictstring(k, :IJulia) == "k_{i} \\geq 0 \\quad \\forall i \\in \\{ a,b,c \\}"
 @defVar(mprint, l[[:apple,:banana,:carrot,:diamonds]] >= 0)
-@test JuMP.dictstring(l, :REPL)   == "l[i] ≥ 0.0, for all i in {apple,banana..}"
-@test JuMP.dictstring(l, :IJulia) == "l_{i} \\geq 0.0 \\quad \\forall i \\in \\{ apple,banana.. \\}"
-@defVar(mprint, m[1:5,2:2:6,[:cats,:dogs,:dinosaurs],["gah",5.0,2,:symbol]] >= 0)
-@test JuMP.dictstring(m, :REPL)   == "m[i,j,k,l] ≥ 0.0, for all i in {1..5}, j in {2,4,6}, k in {cats,dogs..}, l in {gah,5.0,2..}"
-@test JuMP.dictstring(m, :IJulia) == "m_{i,j,k,l} \\geq 0.0 \\quad \\forall i \\in \\{ 1..5 \\}, j \\in \\{ 2,4,6 \\}, k \\in \\{ cats,dogs.. \\}, l \\in \\{ gah,5.0,2.. \\}"
+@test JuMP.dictstring(l, :REPL)   == "l[i] ≥ 0, for all i in {apple,banana..}"
+@test JuMP.dictstring(l, :IJulia) == "l_{i} \\geq 0 \\quad \\forall i \\in \\{ apple,banana.. \\}"
+@defVar(mprint, m[1:5,2:2:6,[:cats,:dogs,:dinosaurs],["gah",5,2,:symbol]] >= 0)
+@test JuMP.dictstring(m, :REPL)   == "m[i,j,k,l] ≥ 0, for all i in {1..5}, j in {2,4,6}, k in {cats,dogs..}, l in {gah,5,2,symbol}"
+@test JuMP.dictstring(m, :IJulia) == "m_{i,j,k,l} \\geq 0 \\quad \\forall i \\in \\{ 1..5 \\}, j \\in \\{ 2,4,6 \\}, k \\in \\{ cats,dogs.. \\}, l \\in \\{ gah,5,2,symbol \\}"
 idx1 = [[1:10]]
 idx2 = [[2:2:20]]
 idx3 = [[2:2:20],21]


### PR DESCRIPTION
A proposal, with two different stages:

``` julia
using JuMP

m = Model()

@defVar(m, 0 <= foo[i=1:3] <= i)
@defVar(m, bar >= 2.0)
@defVar(m, MILES <= 6.3)

@setObjective(m, Max, sum{2^i * foo[i], i=1:3})
@addConstraint(m, MILES + bar + foo[1] <= 3.0)
addConstraint(m, 3.0*bar*bar + 1.57*bar*foo[2] >= 2.0)

println(m)
```
## Original

```
Max 2.0 foo[1] + 4.0 foo[2] + 8.0 foo[3]
Subject to 
1.0 MILES + 1.0 bar + 1.0 foo[1] <= 3.0
3.0*bar^2 + 1.57 foo[2]*bar - 2.0 >= 0
0.0 ≤ foo[1] ≤ 1.0
0.0 ≤ foo[2] ≤ 2.0
0.0 ≤ foo[3] ≤ 3.0
bar ≥ 2.0
MILES ≤ 6.3
```
## Phase 1 - clamp to ints if possible

```
Max 2 foo[1] + 4 foo[2] + 8 foo[3]
Subject to 
1 MILES + 1 bar + 1 foo[1] <= 3
1.57 foo[2]*bar + 3 bar² - 2 >= 0
0 ≤ foo[1] ≤ 1
0 ≤ foo[2] ≤ 2
0 ≤ foo[3] ≤ 3
bar ≥ 2
MILES ≤ 6.3
```
## Phase 2 - 1 to nothing

```
Max 2 foo[1] + 4 foo[2] + 8 foo[3]
Subject to 
MILES + bar + foo[1] <= 3
1.57 foo[2]*bar + 3 bar² - 2 >= 0
0 ≤ foo[1] ≤ 1
0 ≤ foo[2] ≤ 2
0 ≤ foo[3] ≤ 3
bar ≥ 2
MILES ≤ 6.3
```
