### PR TITLE
WIP: SDP and Block structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ notifications:
     email: false
 env:
     matrix: 
-        - PKGADD="Cbc;Clp" JULIAVERSION="juliareleases" 
+        - PKGADD="Cbc;Clp" JULIAVERSION="julianightlies" 
         - PKGADD="GLPKMathProgInterface" JULIAVERSION="julianightlies" 
-        - PKGADD="GLPKMathProgInterface" JULIAVERSION="juliareleases" 
+        - PKGADD="GLPKMathProgInterface" JULIAVERSION="julianightlies" 
 before_install:
     - sudo add-apt-repository ppa:staticfloat/julia-deps -y
     - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -45,6 +45,7 @@ Contents
     refmodel.rst
     refvariable.rst
     refexpr.rst
+    sdp.rst
     probmod.rst
     callbacks.rst
     nlp.rst

--- a/doc/sdp.rst
+++ b/doc/sdp.rst
@@ -1,0 +1,93 @@
+.. _sdp:
+
+---------------------
+Semidefinite modeling
+---------------------
+
+JuMP has *experimental* support for general semidefinite optimization problems. 
+
+Currently, `Mosek <http://mosek.com/>`_
+is the only supported solver. To install Mosek, run::
+
+    Pkg.add("Mosek")
+
+Semidefinite Variables
+^^^^^^^^^^^^^^^^^^^^^^
+
+Semidefinite variables can be created with the ``@defSDPVar`` macro; the dimension of the matrix must be specified::
+    
+    @defSDPVar(m, X[3])
+
+Variables are implicitly assumed to be positive semidefinite, but other bounds (with respect to the semidefinite partial order) can be explicitly stated::
+
+    @defSDPVar(m, eye(5,5) <= Y[5,5] <= 5*ones(5,5))
+
+Matrix Variables
+^^^^^^^^^^^^^^^^
+
+Matrix variables can be created with the ``@defMatrixVar`` macro; the dimension of the matrix must be specified. Matrix variables are allowed to be either one-dimensional (vectors) or two-dimensional (matrices)::
+
+    @defMatrixVar(m, Z[2,3])
+
+Component-wise variable bounds can be explicitly added::
+
+    @defMatrixVar(m, ones(5,3) <= W[5,3] <= eye(5,3) + 2*ones(5,3))
+
+Matrix Expressions
+^^^^^^^^^^^^^^^^^^
+
+Matrix expressions are a natural extension of affine expressions for matrix variables. Matrix variables can be multiplied by or added with scalar matrices, and concatenated to create larger structures::
+
+    @defSDPVar(m, X[3])
+    @defMatrixVar(m, Y[2,3])
+    R = diagm(2ones(3)) +  diagm(ones(2),-1) + diagm(ones(2),1)
+    matexpr = [3*ones(3,3)*X Y; Y' -R*Y] + eye(5,5)
+
+SDP solvers are strongly reliant on data sparsity to solve large-scale problems; because of this, it is important to use sparse matrices whenever possible.
+
+Matrix Function Variables
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Matrix function variables are affine functions of matrix expressions. Supported operations include trace and element reference::
+
+    trace(A*X)
+    X[3,2]
+
+Matrix Function Expressions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Affine expressions can be constructed from a mixture of matrix function variables, scalar variables, and scalar constants::
+
+    trace(A*X) + y + 3
+
+Norm Expressions
+^^^^^^^^^^^^^^^^
+
+Primal Constraints
+^^^^^^^^^^^^^^^^^^
+
+Primal constraints are scalar linear constraints on both matrix and scalar variables: :math:``L \leq \sum_{i} f_i(X_i) + \sum_{j} c_jy_j \leq U``, with matrix variables :math:`X_i`, scalar variables :math:`y_i`, symmetric matrices :math:`A_i`, scalar constants :math:`c_j,L`, and :math:`U`, and matrix function variables :math:`f_i`. These constraints are the natural form for many modern SDP solvers.
+
+Dual Constraints
+^^^^^^^^^^^^^^^^
+
+Dual constraints are semidefinite constraints on scalar variables: :math:``\sum_{i} y_iB_i \succcurlyeq C`` for (symmetric) constant matrices :math:`B_i` and :math:`C` and scalar variables :math:`y_i`. 
+
+Matrix Constraints
+^^^^^^^^^^^^^^^^^^
+
+Matrix constraints are semidefinite constraints on matrix variables: :math:``\sum_{i} A_iX_iB_i \succcurlyeq C`` for matrices :math:`A_i,B_i`, and :math:`C` and matrix variables :math:`X_i`.
+
+SDP Example
+^^^^^^^^^^^
+
+    m = Model()
+    @defSDPVar(m, X[3] >= eye(3,3))
+    @defVar(m, 0 <= y <= 1)
+
+    addConstraint(m, X[1,2] + y == 5)
+    addConstraint(m, eye(2,2)*y <= 2*ones(2,2))
+    addConstraint(m, ones(3,3)*X <= 5*eye(3,3))
+    setObjective(m, :Max, trace(X) + y)
+
+    solve(m)

--- a/examples/cluster.jl
+++ b/examples/cluster.jl
@@ -1,0 +1,83 @@
+##############################################################################
+# JuMP
+# An algebraic modelling langauge for Julia
+# See http://github.com/JuliaOpt/JuMP.jl
+#############################################################################
+# cluster.jl
+#
+# From "Approximating K-means-type clustering via semidefinite programming"
+# By Jiming Peng and Yu Wei
+#
+# Given a set of points a_1, ..., a_m  in R_n, allocate them to k clusters
+#############################################################################
+
+using JuMP
+using Mosek
+
+# Data points
+n = 2
+m = 6
+a = {[2.0, 2.0], [2.5, 2.1], [7.0, 7.0],
+     [2.2, 2.3], [6.8, 7.0], [7.2, 7.5]}
+k = 2
+
+# Weight matrix
+W = zeros(m,m)
+for i = 1:m
+    for j = i+1:m
+        dist = exp(-norm(a[i] - a[j])/1.0)
+        W[i,j] = dist
+        W[j,i] = dist
+    end
+end
+
+mod = Model()
+
+# Z >= 0, PSD
+@defSDPVar(mod, Z[m,m])
+addConstraint(mod, Z .>= 0.)
+
+# min Tr(W(I-Z))
+setObjective(mod, :Min, trace(W * (eye(m,m) - Z)))
+
+# Z e = e
+addConstraint(mod, Z*ones(m) == ones(m))
+#for i = 1:m
+#    addConstraint(mod, sum([ Z[i,j] for j = 1:m]) == 1)
+#end
+
+# Tr(Z) = k
+addConstraint(mod, trace(Z) == k)
+
+solve(mod)
+
+Z_val = getValue(Z)[:,:]
+println("Raw solution")
+println(round(Z_val,4))
+
+# A simple rounding scheme
+which_cluster = zeros(Int,m)
+num_clusters = 0
+for i = 1:m
+    Z_val[i,i] <= 1e-6 && continue
+    
+    if which_cluster[i] == 0
+        num_clusters += 1
+        which_cluster[i] = num_clusters
+        for j = i+1:m
+            if norm(Z_val[i,j] - Z_val[i,i]) <= 1e-6
+                which_cluster[j] = num_clusters
+            end
+        end
+    end
+end
+
+# Print results
+for cluster = 1:k
+    println("Cluster $cluster")
+    for i = 1:m
+        if which_cluster[i] == cluster
+            println(a[i])
+        end
+    end
+end

--- a/examples/corr_sdp.jl
+++ b/examples/corr_sdp.jl
@@ -1,0 +1,48 @@
+#############################################################################
+# JuMP
+# An algebraic modelling langauge for Julia
+# See http://github.com/JuliaOpt/JuMP.jl
+#############################################################################
+# corr_sdp.jl
+#
+# Given three random variables A,B,C and given bounds on two of the three
+# correlation coefficients:
+# -0.2 <= ρ_AB <= -0.1
+#  0.4 <= ρ_BC <=  0.5
+# We can use the following property of the correlations:
+# [  1    ρ_AB  ρ_AC ]
+# [ ρ_AB   1    ρ_BC ]  ≽ 0
+# [ ρ_AC  ρ_BC   1   ]
+# To determine bounds on ρ_AC by solving a SDP
+#############################################################################
+
+using JuMP
+using Mosek
+
+
+m = Model()
+
+@defSDPVar(m, X[3])
+
+# Diagonal is 1s
+addConstraint(m, X[1,1] == 1)
+addConstraint(m, X[2,2] == 1)
+addConstraint(m, X[3,3] == 1)
+
+# Bounds on the known correlations
+addConstraint(m, X[1,2] >= -0.2)
+addConstraint(m, X[1,2] <= -0.1)
+addConstraint(m, X[2,3] >=  0.4)
+addConstraint(m, X[2,3] <=  0.5)
+
+# Find upper bound
+setObjective(m, :Max, X[1,3])
+solve(m)
+println("Maximum value is ", getValue(X)[1,3])
+@assert +0.8719 <= getValue(X)[1,3] <= +0.8720
+
+# Find lower bound
+setObjective(m, :Min, X[1,3])
+solve(m)
+println("Minimum value is ", getValue(X)[1,3])
+@assert -0.9779 >= getValue(X)[1,3] >= -0.9799

--- a/examples/maxcut_sdp.jl
+++ b/examples/maxcut_sdp.jl
@@ -1,0 +1,132 @@
+#############################################################################
+# JuMP
+# An algebraic modelling langauge for Julia
+# See http://github.com/JuliaOpt/JuMP.jl
+#############################################################################
+# maxcut_sdp.jl
+#
+# Solves the SDP relaxation of the classic MAXCUT problem:
+# max   L•X
+# s.t.  diag(X) == e
+#       X ≽ 0
+# where
+#  L = 1/4(Diag(W e) - W)
+#  W = edge-weight matrix
+#  e = vector of 1s
+#
+# then applies the Goemans-Williamson algorithm
+#############################################################################
+using JuMP
+using Mosek
+
+function solve_maxcut_sdp(n, W)
+    L = 0.25 * (diagm(W*ones(n)) - W)
+
+    # Solve the SDP relaxation
+    m = Model()
+    @defSDPVar(m, X[n])
+    setObjective(m, :Max, dot(L,X))
+    for i = 1:n
+        addConstraint(m, X[i,i] == 1)
+    end
+    solve(m)
+
+    # Cholesky the result
+    F = cholfact(getValue(X), pivot=true)    
+    V = (F[:P]*F[:L])'
+
+    # Normalize columns
+    for i = 1:n
+        V[:,i] ./= norm(V[:,i])
+    end
+
+    # Generate "random" vector
+    # - seeded on problem size for repeatability
+    # - for all the problems in this file, the 
+    #   solutions are "integral" anyway so there
+    #   isn't really a need for this
+    r = rand(n)
+    cut = ones(n)
+    for i = 1:n
+        if sum(r' * V[:,i]) <= 0
+            cut[i] = -1
+        end
+    end
+
+    return cut, sum(L.*(cut*cut'))
+end
+
+function test0()
+    #   [1] --- 5 --- [2]
+    #
+    # Solution:
+    #  S  = {1}
+    #  S' = {2}
+    n = 2
+    W = [0.0 5.0;
+         5.0 0.0]
+    cut, cutval = solve_maxcut_sdp(n, W)
+    @assert cut[1] == +1.0
+    @assert cut[2] == -1.0
+
+    println("Solution for Graph 0 = $cutval")
+    println(cut)
+end
+
+function test1()
+    #   [1] --- 5 --- [2]
+    #    |  \          | 
+    #    |    \        |
+    #    7      6      1
+    #    |        \    |
+    #    |          \  |
+    #   [3] --- 1 --- [4]
+    #
+    # Solution:
+    #  S  = {1}
+    #  S' = {2,3,4}
+    n = 4
+    W = [0.0 5.0 7.0 6.0;
+         5.0 0.0 0.0 1.0;
+         7.0 0.0 0.0 1.0;
+         6.0 1.0 1.0 0.0]
+    cut, cutval = solve_maxcut_sdp(n, W)
+    @assert cut[1] == -1.0
+    @assert cut[2] == +1.0
+    @assert cut[3] == +1.0
+    @assert cut[4] == +1.0
+
+    println("Solution for Graph 1 = $cutval")
+    println(cut)
+end
+
+function test2()
+    #   [1] --- 1 --- [2]
+    #    |             | 
+    #    |             |
+    #    9             9
+    #    |             |
+    #    |             |
+    #   [3] --- 1 --- [4]
+    #
+    # Solution:
+    #  S  = {2,3}
+    #  S' = {1,4}
+    n = 4
+    W = [0.0 1.0 9.0 0.0;
+         1.0 0.0 0.0 9.0;
+         9.0 0.0 0.0 1.0;
+         0.0 9.0 1.0 0.0]
+    cut, cutval = solve_maxcut_sdp(n, W)
+    @assert cut[1] == +1.0
+    @assert cut[2] == -1.0
+    @assert cut[3] == -1.0
+    @assert cut[4] == +1.0
+
+    println("Solution for Graph 2 = $cutval")
+    println(cut)
+end
+
+test0()
+test1()
+test2()

--- a/examples/maxellipse.jl
+++ b/examples/maxellipse.jl
@@ -1,0 +1,124 @@
+#############################################################################
+# JuMP
+# An algebraic modelling langauge for Julia
+# See http://github.com/JuliaOpt/JuMP.jl
+#############################################################################
+# maxellipse.jl
+#
+# This example is from the Mosek modelling manual. 
+# If PyPlot is installed, passing the argument `plot` will plot
+# the solution, e.g. julia maxellipse.jl plot
+#
+# Given a polytope
+# P = { x :  a_i x <= b_i   i = 1...m}
+# we seek to find the maximal inscribed ellipse 
+# E = { x :  x = Cu + d, || u || <= 1 }
+#
+# The ellipse is contained in P iff
+# max  a_i^T (Cu + d) <= b_i  for all i = 1...m
+#  u 
+# which we can rewrite (e.g. using duality, like in robust optimization) as
+# ||C a_i|| + a_i^T d <= b_i  for all i = 1...m
+#
+# The volume of this ellipse can be approximated by det(C) ^ (1/n)
+#
+# So we can solve the following problem 
+#     maximize   det(C) ^ (1/n)
+#   subject to   ||C a_i|| + a_i^T d <= b_i  for all i = 1...m
+#                C is p.s.d.
+# 
+# Alternatively, we can solve
+#     maximize   t
+#   subject to   ||C a_i|| + a_i^T d <= b_i  for all i = 1...m
+#                [ C    Z       ] 
+#                [ Z^T  Diag(Z) ] PSD
+#                t <= (Z_11 * Z_22 * ... * Z_nn) ^ 1/n
+# which is an SDP
+#############################################################################
+
+using JuMP
+using Mosek
+using PyPlot  # Comment out if not installed
+
+# 1  ^  2
+#   /+\
+#  /---\ 
+#    3
+#m = 3
+#a = {[-1.0, +1.0],   
+#     [+1.0, +1.0],
+#     [ 0.0, -1.0]}
+#b = [1.0, 1.0, 0.0]
+
+# Same as above but with top of triangle chopped off
+m = 4
+a = {[-1.0, +1.0],   
+     [+1.0, +1.0],
+     [ 0.0, -1.0],
+     [ 0.0,  1.0]}
+b = [1.0, 1.0, 0.0, 0.7]
+
+mod = Model()
+
+@defVar(mod, 0 <= t <= 100)
+@setObjective(mod, Max, t)
+
+@defVar(mod, -1 <= d[1:2] <= 1)
+
+# ||C a_i|| + a_i^T d <= b_i  for all i = 1...m
+@defSDPVar(mod, C[2,2])
+for i = 1:m
+    addConstraint(mod, norm(C*a[i]) + dot(a[i],d) <= b[i])
+end
+
+# [ C    Z       ] 
+# [ Z^T  Diag(Z) ] PSD
+@defMatrixVar(mod, Z[2,2])
+lhs = [C Z; Z' diagm(Z)]
+addConstraint(mod, lhs >= 0)
+
+# t <= (Z_11 * Z_22 * ... * Z_nn) ^ 1/n
+# t <= (Z_11 * Z_22) ^ 1/2
+# This in general requires rotated cone shenanigans
+# but for the 2D case is simple enough.
+addConstraint(mod, t^2 <= Z[1,1] * Z[2,2])
+
+solve(mod)
+
+C_val = getValue(C)[:,:]
+d_val = getValue(d)[:]
+
+println(C_val)
+
+# Plot it, if desired (e.g. julia maxellipse.jl plot)
+if length(ARGS) > 0 && Pkg.installed("PyPlot") != nothing
+    # Setup the figure
+    fig = figure()
+    ax = fig[:gca]()
+    ax[:set_xticks]([-2:+2])
+    ax[:set_yticks]([-2:+2])
+
+    # Draw polyhedron
+    for i = 1:m
+      x1 = -2
+      y1 = (b[i] - a[i][1]*x1)/a[i][2]
+      x2 = +2
+      y2 = (b[i] - a[i][1]*x2)/a[i][2]
+      plot((x1, x2), (y1, y2), "k", linewidth=2.0)
+    end
+
+    # Draw ellipse
+    # x = Cu + d, || u || <= 1
+    xs = Float64[]
+    ys = Float64[]
+    for angle in linspace(0, 2*pi, 100)
+        u = [cos(angle),sin(angle)]
+        x = C_val * u + d_val
+        push!(xs, x[1])
+        push!(ys, x[2])
+    end
+    plot(xs, ys, "b", linewidth=2.0)
+
+    fig[:canvas][:draw]()
+    readline()
+end

--- a/examples/mindistortion.jl
+++ b/examples/mindistortion.jl
@@ -1,0 +1,60 @@
+#############################################################################
+# JuMP
+# An algebraic modeling langauge for Julia
+# See http://github.com/JuliaOpt/JuMP.jl
+#############################################################################
+# mindistortion.jl
+#
+# This example arises from computational geometry, in particular the problem
+# of embedding a general finite metric space into a euclidean space.
+#
+# It is known that the 4-point metric space defined by the star graph:
+#   x
+#    \
+#     x — x
+#    /
+#   x
+# where distances are computed by length of the shortest path between 
+# vertices, cannot be exactly embedded into a euclidean space of any
+# dimension.
+#
+# Here we will formulate and solve an SDP to compute the best possible
+# embedding, that is, the embedding f() that minimizes the distortion c such
+# that (1/c)*D(a,b) ≤ ||f(a)-f(b)|| ≤ D(a,b) for all points (a,b), where
+# D(a,b) is the distance in the metric space.
+#
+# Any embedding can be characterized by its Gram matrix Q, which is PSD,
+# and ||f(a)-f(b)||^2 = Q[a,a] + Q[b,b] - 2Q[i,j]
+# We can therefore constrain
+# D[i,j]^2 ≤ Q[i,i] + Q[j,j] - 2Q[i,j] ≤ c^2*D[i,j]^2
+# and minimize c^2, which gives us the SDP formulation below.
+#
+# For more detail, see 
+# "Lectures on discrete geometry" by J. Matoušek, Springer, 2002, pp. 378-379.
+
+using JuMP
+
+
+m = Model()
+
+D = [0.0 1.0 1.0 1.0
+     1.0 0.0 2.0 2.0
+     1.0 2.0 0.0 2.0
+     1.0 2.0 2.0 0.0]
+
+@defVar(m, cSq >= 1.0)
+
+@defSDPVar(m, Q[4,4])
+
+for i in 1:4
+    for j in (i+1):4
+        addConstraint(m, D[i,j]^2 <= Q[i,i] + Q[j,j] - 2Q[i,j])
+        addConstraint(m, Q[i,i] + Q[j,j] - 2Q[i,j] <= D[i,j]^2*cSq )
+    end
+end
+
+@setObjective(m, Min, cSq)
+
+solve(m)
+
+println(getValue(cSq))

--- a/examples/minellipse.jl
+++ b/examples/minellipse.jl
@@ -1,0 +1,87 @@
+#############################################################################
+# JuMP
+# An algebraic modelling langauge for Julia
+# See http://github.com/JuliaOpt/JuMP.jl
+#############################################################################
+# minellipse.jl
+#
+# This example is from the Boyd & Vandenberghe book "Convex Optimization".
+# If PyPlot is installed, passing the argument `plot` will plot
+# the solution, e.g. julia minellipse.jl plot
+#
+# Given a set of ellipses centered on the origin
+# E(A) = { u | u^T inv(A) u <= 1 }
+# find a "minimal" ellipse that contains the provided ellipses
+#
+# We can formulate this as an SDP:
+#     minimize  trace(WX)
+#   subject to  X >= A_i,    i = 1,...,m
+#               X PSD
+# where W is a PD matrix of weights to choose between different solutions
+#############################################################################
+
+using JuMP
+using Mosek
+using PyPlot  # Comment out if not installed
+
+# We will use three ellipses
+m = 3
+# Two "simple" ones
+As = { [2.0  0.0;
+        0.0  1.0],
+       [1.0  0.0;
+        0.0  3.0]}
+# and a random one
+randA = rand(2,2)
+push!(As, (randA' * randA) * (rand()*2+1))
+
+# We change the weights to see different solutions, if they exist
+W = [1.0 0.0
+     0.0 1.0];
+
+mod = Model()
+@defSDPVar(mod, X[2,2])
+setObjective(mod, :Min, trace(W*X))
+for i = 1:m
+    addConstraint(mod, X >= As[i])
+end
+solve(mod)
+
+X_val = getValue(X)[:,:]
+println(X_val)
+
+# Plot it, if desired (e.g. julia maxellipse.jl plot)
+if length(ARGS) > 0 && Pkg.installed("PyPlot") != nothing
+    # Setup the figure
+    fig = figure()
+    ax = fig[:gca]()
+    ax[:set_xticks]([-4:+4])
+    ax[:set_yticks]([-4:+4])
+
+    # Draw provided ellipses
+    for i = 1:m
+        xs = Float64[]
+        ys = Float64[]
+        for angle in linspace(0, 2*pi, 100)
+            u = [cos(angle),sin(angle)]
+            x = As[i] * u
+            push!(xs, x[1])
+            push!(ys, x[2])
+        end
+        plot(xs, ys, "b", linewidth=2.0)
+    end
+
+    # Draw bounding ellipse
+    xs = Float64[]
+    ys = Float64[]
+    for angle in linspace(0, 2*pi, 100)
+        u = [cos(angle),sin(angle)]
+        x = X_val * u
+        push!(xs, x[1])
+        push!(ys, x[2])
+    end
+    plot(xs, ys, "r", linewidth=2.0)
+
+    fig[:canvas][:draw]()
+    readline()
+end

--- a/examples/robust_uncertainty.jl
+++ b/examples/robust_uncertainty.jl
@@ -1,0 +1,51 @@
+#############################################################################
+# JuMP
+# An algebraic modelling langauge for Julia
+# See http://github.com/JuliaOpt/JuMP.jl
+#############################################################################
+# robust_uncertainty.jl
+#
+# Computes the Value at Risk for a data-driven uncertainty set; see 
+# "Data-Driven Robust Optimization" (Bertsimas 2013), section 6.1 for 
+# details. Closed-form expressions for the optimal value are available.
+#############################################################################
+
+
+using JuMP
+
+R = 1
+d = 10
+𝛿 = 0.05
+ɛ = 0.05
+N = ceil((2+2log(2/𝛿))^2) + 1
+
+Γ1(𝛿,N) = (R/sqrt(N))*(2+sqrt(2*log(1/𝛿)))
+Γ2(𝛿,N) = (2R^2/sqrt(N))*(2+sqrt(2*log(2/𝛿)))
+
+μhat = rand(d)
+M = rand(d,d)
+Σhat = 1/(d-1)*(M-ones(d)*μhat')'*(M-ones(d)*μhat')
+
+m = Model()
+
+@defSDPVar(m, Σ[d,d])
+@defMatrixVar(m, u[d])
+@defMatrixVar(m, μ[d])
+
+addConstraint(m, norm(μ-μhat) <= Γ1(𝛿/2,N))
+addConstraint(m, vecnorm(Σ-Σhat) <= Γ2(𝛿/2,N))
+
+A = [(1-ɛ)/ɛ (u-μ)';
+     (u-μ)     Σ   ]
+addConstraint(m, A >= 0)
+
+c = randn(d)
+setObjective(m, :Max, dot(c,u))
+
+solve(m)
+
+object = getObjectiveValue(m)
+exact = dot(μhat,c) + Γ1(𝛿/2,N)*norm(c) + sqrt((1-ɛ)/ɛ)*sqrt(dot(c,(Σhat+Γ2(𝛿/2,N)*eye(d,d))*c))
+
+println("objective value:  $(object)")
+println("error from exact: $(abs(exact-object))")

--- a/examples/simple_dual.jl
+++ b/examples/simple_dual.jl
@@ -1,0 +1,11 @@
+using JuMP
+
+n = 2
+
+m = Model()
+@defVar(m, 0 <= y <= 4)
+
+addConstraint(m, y*ones(n,n) >= 2*ones(n,n))
+setObjective(m, :Max, 1.0*y)
+
+stat = solve(m)

--- a/examples/simple_matrix.jl
+++ b/examples/simple_matrix.jl
@@ -1,0 +1,9 @@
+using JuMP
+
+m = Model()
+@defSDPVar(m, X[3])
+
+addConstraint(m, X >= ones(3,3))
+setObjective(m, :Min, trace(ones(3,3)*X))
+
+stat = solve(m)

--- a/examples/simple_sdp.jl
+++ b/examples/simple_sdp.jl
@@ -1,0 +1,35 @@
+using JuMP
+
+m = Model()
+@defSDPVar(m, X[3] >= zeros(3,3))
+@defSDPVar(m, Y[2] >= zeros(2,2))
+
+C = eye(3,3)
+A1 = zeros(3,3)
+A1[1,1] = 1.0
+A2 = zeros(3,3)
+A2[2,2] = 1.0
+A3 = zeros(3,3)
+A3[3,3] = 1.0
+D = eye(2,2)
+B1 = ones(2,2)
+B2 = zeros(2,2)
+B2[1,1] = 1
+B3 = zeros(2,2)
+B3[1,2] = B3[2,1] = 2
+
+setObjective(m, :Min, trace(C*X)+1+trace(D*Y))
+addConstraint(m, trace(A1*X-eye(3,3)/3) == 0)
+addConstraint(m, 2*trace(A2*X) == 1)
+addConstraint(m, trace(A3*X) >= 2)
+addConstraint(m, trace(B1*Y) == 1)
+addConstraint(m, trace(B2*Y) == 0)
+addConstraint(m, trace(B3*Y) <= 0)
+addConstraint(m, trace(A1*X)+trace(B1*Y) >= 1)
+addConstraint(m, Y[2,2] == 1)
+
+solve(m)
+
+println("objective value = $(getObjectiveValue(m))")
+println("X = $(getValue(X))")
+println("Y = $(getValue(Y))")

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -7,7 +7,7 @@
 module JuMP
 
 import MathProgBase
-import Base: size, copy
+import Base: size, copy, zero, one, isequal, issym
 
 using ReverseDiffSparse
 if isdir(Pkg.dir("ArrayViews"))
@@ -264,7 +264,7 @@ getindex(x::AffExpr,idx::Int,idy::Int) = ((idx,idy) == (1,1) ? x : throw(BoundsE
 isequal(x::AffExpr,y::AffExpr) = isequal(x.vars,y.vars) && isequal(x.coeffs,y.coeffs) && isequal(x.constant,y.constant)
 
 Base.isempty(a::AffExpr) = (length(a.vars) == 0 && a.constant == 0.)
-Base.convert(::Type{AffExpr}, v::Variable) = AffExpr([v], [1.], 0.)
+Base.convert(::Type{AffExpr}, v::Variable) = AffExpr(Variable[v], [1.0], 0.)
 Base.convert(::Type{AffExpr}, v::Real) = AffExpr(Variable[], Float64[], v)
 Base.zero(::Type{AffExpr}) = AffExpr(Variable[],Float64[],0.)
 Base.zero(a::AffExpr) = zero(typeof(a))

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -7,6 +7,7 @@
 module JuMP
 
 import MathProgBase
+import Base: size, copy
 
 using ReverseDiffSparse
 if isdir(Pkg.dir("ArrayViews"))
@@ -108,7 +109,7 @@ function Model(;solver=nothing)
         Model(QuadExpr(),:Min,LinearConstraint[], QuadConstraint[],SOSConstraint[],
               0,String[],Float64[],Float64[],Int[],
               0,Float64[],Float64[],Float64[],nothing,UnsetSolver(),false,
-              nothing,nothing,nothing,JuMPDict[],nothing,IndexedVector(Float64,0),nothing,Dict{Symbol,Any}())
+              nothing,nothing,nothing,JuMPDict[],nothing,IndexedVector(Float64,0),nothing,nothing,Dict{Symbol,Any}())
     else
         if !isa(solver,MathProgBase.AbstractMathProgSolver)
             error("solver argument ($solver) must be an AbstractMathProgSolver")

--- a/src/sdp.jl
+++ b/src/sdp.jl
@@ -61,25 +61,25 @@ type SDPVar <: SDPMatrix
     dim::Int64
 end
 
-transpose(a::SDPVar)  = a
-ctranspose(a::SDPVar) = a
-conj(a::SDPVar) = a
+Base.transpose(a::SDPVar)  = a
+Base.ctranspose(a::SDPVar) = a
+Base.conj(a::SDPVar) = a
 
-size(d::SDPVar) = (d.dim,d.dim)
-size(d::SDPVar, slice::Int64) = (0 <= slice <= 2) ? d.dim : 1
-ndims(d::SDPVar) = 2
-eye(d::SDPVar)  = eye(d.dim)
-issym(d::SDPVar) = true
-isequal(a::SDPVar, b::SDPVar) = isequal(a.m,b.m) && isequal(a.index,b.index)
+Base.size(d::SDPVar) = (d.dim,d.dim)
+Base.size(d::SDPVar, slice::Int64) = (0 <= slice <= 2) ? d.dim : 1
+Base.ndims(d::SDPVar) = 2
+Base.eye(d::SDPVar)  = eye(d.dim)
+Base.issym(d::SDPVar) = true
+Base.isequal(a::SDPVar, b::SDPVar) = isequal(a.m,b.m) && isequal(a.index,b.index)
 
-function diagm(d::SDPVar)
+function Base.diagm(d::SDPVar)
     m,n = size(d)
     return DualExpr(MatrixFuncVar[d[it,it] for it in 1:m],
                    SparseMatrixCSC[sparse([it],[it],[1.0],m,n) for it in 1:m],
                    spzeros(m,n))
 #    return mapreduce(it->d[it,it]*sparse([it],[it],[1.0],m,n), +, 1:m)
 end
-spdiagm(d::SDPVar) = diagm(d)
+Base.spdiagm(d::SDPVar) = diagm(d)
 
 getValue(d::SDPVar) = d.m.sdpdata.sdpval[d.index] 
 
@@ -107,16 +107,16 @@ end
 getName(d::SDPVar) = d.m.sdpdata.varname[d.index]
 setName(d::SDPVar, name::String) = (d.m.sdpdata.varname[d.index] = name)
 
-trace(c::SDPVar)  = trace(convert(MatrixExpr, c))
-dot(c::SDPVar,d::AbstractArray) = trace(c*d)
-dot(c::AbstractArray,d::SDPVar) = trace(c*d)
-norm(c::SDPVar)   = norm(convert(MatrixExpr, c))
-sum(c::SDPVar)    = sum(convert(MatrixExpr, c))
+Base.trace(c::SDPVar)  = trace(convert(MatrixExpr, c))
+Base.dot(c::SDPVar,d::AbstractArray) = trace(c*d)
+Base.dot(c::AbstractArray,d::SDPVar) = trace(c*d)
+Base.norm(c::SDPVar)   = norm(convert(MatrixExpr, c))
+Base.sum(c::SDPVar)    = sum(convert(MatrixExpr, c))
 
-show(io::IO,d::SDPVar)  = print(io, "$(d.m.sdpdata.varname[d.index])")
-print(io::IO,d::SDPVar) = println(io, "$(d.m.sdpdata.varname[d.index]) ∈ 𝒮₊($(d.dim))")
+Base.show(io::IO,d::SDPVar)  = print(io, "$(d.m.sdpdata.varname[d.index])")
+Base.print(io::IO,d::SDPVar) = println(io, "$(d.m.sdpdata.varname[d.index]) ∈ 𝒮₊($(d.dim))")
 
-getindex(d::SDPVar, x::Int64, y::Int64) = 
+Base.getindex(d::SDPVar, x::Int64, y::Int64) = 
     MatrixFuncVar(MatrixExpr(concat(d),concat(sparse([x,y],[y,x],[0.5,0.5],d.dim,d.dim)),concat(𝕀),spzeros(d.dim,d.dim)),:ref)
 
 macro defSDPVar(m, x, extra...)
@@ -171,8 +171,8 @@ macro defSDPVar(m, x, extra...)
         code = quote
             issym($lb) || error("Lower bound is not symmetric")
             issym($ub) || error("Upper bound is not symmetric")
-            (isa($lb,AbstractArray) && !($sz == size($lb,1))) && error("Lower bound is not of same size as variable")
-            (isa($ub,AbstractArray) && !($sz == size($ub,1))) && error("Upper bound is not of same size as variable")
+            (isa($lb,AbstractArray) && !($sz == Base.size($lb,1))) && error("Lower bound is not of same size as variable")
+            (isa($ub,AbstractArray) && !($sz == Base.size($ub,1))) && error("Upper bound is not of same size as variable")
             isa($lb,Number) && !($lb == 0.0 || $lb == -Inf) && error("Bounds must be of same size as variable")
             isa($ub,Number) && !($ub == 0.0 || $ub ==  Inf) && error("Bounds must be of same size as variable")
             $lb == -Inf && $ub == Inf && error("Replace unrestricted SDP variable with regular, scalar variables")
@@ -219,27 +219,27 @@ function MatrixVar(m::Model, sz::(Int,Int), lb, ub, varname::String)
     return MatrixVar(m, length(sdp.sdpvar)+1, sz)
 end
 
-transpose(a::MatrixVar)  = MatrixVar(a.m,a.index,reverse(a.dim))
-ctranspose(a::MatrixVar) = MatrixVar(a.m,a.index,reverse(a.dim))
-conj(a::MatrixVar) = a
+Base.transpose(a::MatrixVar)  = MatrixVar(a.m,a.index,reverse(a.dim))
+Base.ctranspose(a::MatrixVar) = MatrixVar(a.m,a.index,reverse(a.dim))
+Base.conj(a::MatrixVar) = a
 
-size(a::MatrixVar) = a.dim
-size(d::MatrixVar, slice::Int64) = (0 <= slice <= 2) ? d.dim[slice] : 1
-ndims(d::MatrixVar) = 2
-eye(d::MatrixVar)  = eye(d.dim[1],d.dim[2])
-issym(d::MatrixVar) = (d.dim == (1,1))
-isequal(a::MatrixVar, b::MatrixVar) = (a.m == b.m) && isequal(a.index,b.index) && isequal(a.dim,b.dim)
+Base.size(a::MatrixVar) = a.dim
+Base.size(d::MatrixVar, slice::Int64) = (0 <= slice <= 2) ? d.dim[slice] : 1
+Base.ndims(d::MatrixVar) = 2
+Base.eye(d::MatrixVar)  = eye(d.dim[1],d.dim[2])
+Base.issym(d::MatrixVar) = (d.dim == (1,1))
+Base.isequal(a::MatrixVar, b::MatrixVar) = (a.m == b.m) && isequal(a.index,b.index) && isequal(a.dim,b.dim)
 
-function dot{T<:Number}(a::Array{T},b::MatrixVar)
+function Base.dot{T<:Number}(a::Array{T},b::MatrixVar)
     (size(a,1) == size(b,1) && size(a,2) == size(b,2)) || error("Incompatible dimensions")
     return AffExpr(Variable[b[it] for it in 1:length(a)],
                    Float64[a[it] for it in 1:length(a)],
                    0.0)
     # return mapreduce(it->a[it]*b[it], +, 1:length(a))
 end
-dot{T<:Number}(a::MatrixVar,b::Array{T}) = dot(b,a)
+Base.dot{T<:Number}(a::MatrixVar,b::Array{T}) = dot(b,a)
 
-function diagm(d::MatrixVar)
+function Base.diagm(d::MatrixVar)
     m,n = size(d)
     m == n || error("Cannot construct diagonal of nonsquare matrix")
     return DualExpr(Variable[d[it,it] for it in 1:m],
@@ -247,7 +247,7 @@ function diagm(d::MatrixVar)
                spzeros(m,n))
     # return mapreduce(it->d[it,it]*sparse([it],[it],[1.0],m,n), +, 1:m)
 end
-spdiagm(d::MatrixVar) = diagm(d)
+Base.spdiagm(d::MatrixVar) = diagm(d)
 
 getValue(d::MatrixVar) = reshape(d.m.sdpdata.sdpval[d.index], size(d))
 
@@ -281,22 +281,22 @@ end
 getName(d::MatrixVar) = d.m.sdpdata.varname[d.index]
 setName(d::MatrixVar, name::String) = (d.m.sdpdata.varname[d.index] = name)
 
-show(io::IO,d::MatrixVar)  = print(io, "$(d.m.sdpdata.varname[d.index])")
-print(io::IO,d::MatrixVar) = println(io, "$(d.m.sdpdata.varname[d.index]) ∈ ℝ($(d.dim[1])×$(d.dim[2]))")
+Base.show(io::IO,d::MatrixVar)  = print(io, "$(d.m.sdpdata.varname[d.index])")
+Base.print(io::IO,d::MatrixVar) = println(io, "$(d.m.sdpdata.varname[d.index]) ∈ ℝ($(d.dim[1])×$(d.dim[2]))")
 
-function getindex(d::MatrixVar, x::Int)
+function Base.getindex(d::MatrixVar, x::Int)
     rng = d.m.sdpdata.solverinfo[d.index].id
     Variable(d.m, rng[x])
 end
 
-function getindex(d::MatrixVar, x::Int, y::Int)
+function Base.getindex(d::MatrixVar, x::Int, y::Int)
     sx,sy = d.dim
     rng   = d.m.sdpdata.solverinfo[d.index].id
     off = (y-1)*sx + x
     return Variable(d.m, rng[off])
 end
 
-function getindex(d::MatrixVar, x::Int, y::Range{Int})
+function Base.getindex(d::MatrixVar, x::Int, y::Range{Int})
     sx,sy = d.dim
     rng   = d.m.sdpdata.solverinfo[d.index].id
     arr = Array(Variable, 1, length(y))
@@ -307,7 +307,7 @@ function getindex(d::MatrixVar, x::Int, y::Range{Int})
     return arr
 end
 
-function getindex(d::MatrixVar, x::Range{Int}, y::Int)
+function Base.getindex(d::MatrixVar, x::Range{Int}, y::Int)
     sx,sy = d.dim
     rng   = d.m.sdpdata.solverinfo[d.index].id
     arr = Array(Variable, length(x))
@@ -374,8 +374,8 @@ macro defMatrixVar(m, x, extra...)
     else
         varname = esc(var.args[1])
         code = quote
-            (isa($lb,AbstractArray) && !($sx == size($lb,1) && $sy == size($lb,2))) && error("Lower bound is not of same size as variable")
-            (isa($ub,AbstractArray) && !($sx == size($ub,1) && $sy == size($ub,2))) && error("Upper bound is not of same size as variable")
+            (isa($lb,AbstractArray) && !($sx == Base.size($lb,1) && $sy == Base.size($lb,2))) && error("Lower bound is not of same size as variable")
+            (isa($ub,AbstractArray) && !($sx == Base.size($ub,1) && $sy == Base.size($ub,2))) && error("Upper bound is not of same size as variable")
             isa($lb,Number) && !($lb == 0.0 || $lb == -Inf) && error("Bounds must be of same size as variable")
             isa($ub,Number) && !($ub == 0.0 || $ub ==  Inf) && error("Bounds must be of same size as variable")
             $lb == $ub && error("Replace with constant matrix")
@@ -443,15 +443,15 @@ function blocksize(array::Array)
     return sum(sy[:,1]), sum(sx[1,:])
 end
 
-size(b::BlockMatrix) = b.sz
+Base.size(b::BlockMatrix) = b.sz
 blocksize(b::BlockMatrix) = size(b.elem)
 
-transpose(b::BlockMatrix)  = BlockMatrix(transpose(map(transpose,b.elem)))
-ctranspose(b::BlockMatrix) = BlockMatrix(transpose(map(transpose,b.elem)))
+Base.transpose(b::BlockMatrix)  = BlockMatrix(transpose(map(transpose,b.elem)))
+Base.ctranspose(b::BlockMatrix) = BlockMatrix(transpose(map(transpose,b.elem)))
 
-isequal(a::BlockMatrix, b::BlockMatrix) = isequal(a.elem,b.elem)
+Base.isequal(a::BlockMatrix, b::BlockMatrix) = isequal(a.elem,b.elem)
 
-function issym(d::BlockMatrix)
+function Base.issym(d::BlockMatrix)
     m,n = size(d.elem)
     m == n || return false
     for i in 1:n # check that diagonal is symmetric
@@ -467,14 +467,14 @@ function issym(d::BlockMatrix)
     return true
 end
 
-size(::Variable) = (1,)
-size(::Variable,::Int) = 1
-size(::AffExpr) = (1,1)
-size(::AffExpr,::Int) = 1
-size(::QuadExpr) = (1,)
-size(::QuadExpr,::Int) = 1
+Base.size(::Variable) = (1,)
+Base.size(::Variable,::Int) = 1
+Base.size(::AffExpr) = (1,1)
+Base.size(::AffExpr,::Int) = 1
+Base.size(::QuadExpr) = (1,)
+Base.size(::QuadExpr,::Int) = 1
 
-function getindex(d::BlockMatrix, x::Int64, y::Int64)
+function Base.getindex(d::BlockMatrix, x::Int64, y::Int64)
     m,n = size(d)
     curr = 0
     it = 1
@@ -535,32 +535,34 @@ end
 MatrixExpr{T<:Number}(elem::Vector,pre::Array,post::Array,constant::AbstractArray{T}) = 
     MatrixExpr(elem,pre,post,transpose(transpose(constant)))
 
-size(d::MatrixExpr) = (size(d.constant,1),size(d.constant,2))
-size(d::MatrixExpr, slice::Int64) = (0 <= slice <= 2) ? size(d)[slice] : 1
-ndims(d::MatrixExpr) = 2
-eye(d::MatrixExpr)  = eye(size(d)...)
+Base.size(d::MatrixExpr) = (size(d.constant,1),size(d.constant,2))
+Base.size(d::MatrixExpr, slice::Int64) = (0 <= slice <= 2) ? size(d)[slice] : 1
+Base.ndims(d::MatrixExpr) = 2
+Base.eye(d::MatrixExpr)  = eye(size(d)...)
 
-convert(::Type{MatrixExpr}, v::SDPVar)    = MatrixExpr(concat(v), concat(𝕀), concat(𝕀), spzeros(v.dim,v.dim))
-convert(::Type{MatrixExpr}, v::MatrixVar) = MatrixExpr(concat(v), concat(𝕀), concat(𝕀), spzeros(v.dim...))
+Base.convert(::Type{MatrixExpr}, v::SDPVar)    = MatrixExpr(concat(v), concat(𝕀), concat(𝕀), spzeros(v.dim,v.dim))
+Base.convert(::Type{MatrixExpr}, v::MatrixVar) = MatrixExpr(concat(v), concat(𝕀), concat(𝕀), spzeros(v.dim...))
 
-transpose(d::MatrixExpr)  = MatrixExpr(map(transpose, d.elem), map(transpose, d.post), map(transpose, d.pre), transpose(d.constant))
-ctranspose(d::MatrixExpr) = MatrixExpr(map(transpose, d.elem), map(transpose, d.post), map(transpose, d.pre), transpose(d.constant))
+Base.transpose(d::MatrixExpr)  = MatrixExpr(map(transpose, d.elem), map(transpose, d.post), map(transpose, d.pre), transpose(d.constant))
+Base.ctranspose(d::MatrixExpr) = MatrixExpr(map(transpose, d.elem), map(transpose, d.post), map(transpose, d.pre), transpose(d.constant))
 
-isequal(a::MatrixExpr, b::MatrixExpr) = isequal(a.elem,b.elem) && isequal(a.pre,b.pre) && isequal(a.post,b.post) && isequal(a.constant,b.constant)
+Base.isequal(a::MatrixExpr, b::MatrixExpr) = isequal(a.elem,b.elem) && isequal(a.pre,b.pre) && isequal(a.post,b.post) && isequal(a.constant,b.constant)
 
-trace(c::MatrixExpr) = MatrixFuncVar(c, :trace)
-norm(c::MatrixExpr)  = MatrixFuncVar(c, :norm)
-sum(c::MatrixExpr)   = MatrixFuncVar(c, :sum)
+Base.trace(c::MatrixExpr) = MatrixFuncVar(c, :trace)
+Base.norm(c::MatrixExpr)  = MatrixFuncVar(c, :norm)
+Base.sum(c::MatrixExpr)   = MatrixFuncVar(c, :sum)
 
-issym(d::MatrixExpr) = issym(d.constant) && all(issym, d.elem)
+Base.issym(d::MatrixExpr) = issym(d.constant) && all(issym, d.elem)
 
-function getindex(d::MatrixExpr, x::Int64)
+Base.copy(d::MatrixExpr) = MatrixExpr(copy(d.elem), copy(d.pre), copy(d.post), copy(d.constant))
+
+function Base.getindex(d::MatrixExpr, x::Int64)
     m = size(d,1)
     idx,idy = rem(x-1,m)+1, div(x-1,m)+1
     return getindex(d, idx, idy)
 end
 
-function getindex(d::MatrixExpr, x::Int64, y::Int64)
+function Base.getindex(d::MatrixExpr, x::Int64, y::Int64)
     m,n = size(d)
     refer = ScalarExpr(d.constant[x,y])
     for it in 1:length(d.elem)
@@ -582,7 +584,7 @@ function getindex(d::MatrixExpr, x::Int64, y::Int64)
     return refer
 end
 
-function getindex(d::MatrixExpr, x::Int, y::Range{Int})
+function Base.getindex(d::MatrixExpr, x::Int, y::Range{Int})
     sx,sy = size(d)
     arr = Array(AffExpr, 1, length(y))
     for (it,val) in enumerate(y)
@@ -591,7 +593,7 @@ function getindex(d::MatrixExpr, x::Int, y::Range{Int})
     return arr
 end
 
-function getindex(d::MatrixExpr, x::Range{Int}, y::Int)
+function Base.getindex(d::MatrixExpr, x::Range{Int}, y::Int)
     sx,sy = size(d)
     arr = Array(AffExpr, length(x))
     for (it,val) in enumerate(x)
@@ -617,8 +619,8 @@ function getnames(c::MatrixExpr,d::Set)
     return d
 end
 
-show(io::IO,d::MatrixExpr)  = print(io, "Matrix expression")
-function print(io::IO,d::MatrixExpr)
+Base.show(io::IO,d::MatrixExpr)  = print(io, "Matrix expression")
+function Base.print(io::IO,d::MatrixExpr)
     n = getnames(d,Set())
     str = join([chomp(string(v)) for v in n], ", ")
     println(io, string("Matrix expression in ", str))
@@ -633,10 +635,10 @@ type MatrixFuncVar
     func::Symbol
 end
 
-isequal(x::MatrixFuncVar,y::MatrixFuncVar) = isequal(x.expr,y.expr) && isequal(x.func,y.func)
+Base.isequal(x::MatrixFuncVar,y::MatrixFuncVar) = isequal(x.expr,y.expr) && isequal(x.func,y.func)
 
-size(::MatrixFuncVar) = 1
-size(::MatrixFuncVar,::Int) = 1
+Base.size(::MatrixFuncVar) = 1
+Base.size(::MatrixFuncVar,::Int) = 1
 
 function getValue(v::MatrixFuncVar)
     if v.func == :trace
@@ -668,21 +670,21 @@ type NormExpr
     form::Vector{Symbol}
 end
 
-isequal(x::NormExpr,y::NormExpr) = isequal(x.vars,y.vars) && isequal(x.coeffs,y.coeffs) && isequal(x.form,y.form)
+Base.isequal(x::NormExpr,y::NormExpr) = isequal(x.vars,y.vars) && isequal(x.coeffs,y.coeffs) && isequal(x.form,y.form)
 
 NormExpr() = NormExpr(Union(AffExpr,MatrixExpr)[], Float64[], Symbol[])
 NormExpr(form::Symbol) = NormExpr(Union(AffExpr,MatrixExpr)[], [form])
 
-abs(d::Variable) = NormExpr(concat(convert(AffExpr,d)), [1.0], [:abs])
-abs(d::AffExpr)  = NormExpr(concat(d), [1.0], [:abs], AffExpr())
+Base.abs(d::Variable) = NormExpr(concat(convert(AffExpr,d)), [1.0], [:abs])
+Base.abs(d::AffExpr)  = NormExpr(concat(d), [1.0], [:abs], AffExpr())
 
-norm(d::MatrixVar)  = NormExpr(concat(convert(MatrixExpr,d)), [1.0], [:norm2])
-norm(d::MatrixExpr) = NormExpr(concat(d), [1.0], [:norm2])
+Base.norm(d::MatrixVar)  = NormExpr(concat(convert(MatrixExpr,d)), [1.0], [:norm2])
+Base.norm(d::MatrixExpr) = NormExpr(concat(d), [1.0], [:norm2])
 
-vecnorm(d::MatrixVar)  = NormExpr(concat(convert(MatrixExpr,d)), [1.0], [:normfrob])
-vecnorm(d::MatrixExpr) = NormExpr(concat(d), [1.0], [:normfrob])
+Base.vecnorm(d::MatrixVar)  = NormExpr(concat(convert(MatrixExpr,d)), [1.0], [:normfrob])
+Base.vecnorm(d::MatrixExpr) = NormExpr(concat(d), [1.0], [:normfrob])
 
-copy(d::NormExpr) = NormExpr(copy(d.vars), copy(d.coeffs), copy(d.form))
+Base.copy(d::NormExpr) = NormExpr(copy(d.vars), copy(d.coeffs), copy(d.form))
 
 function getValue(d::NormExpr)
     ret = 0.0
@@ -711,8 +713,8 @@ function exprToStr(c::NormExpr)
     return string("Norm expression in ", str)
 end
 
-show(io::IO, d::NormExpr)  = print(io, "Norm expression")
-print(io::IO, d::NormExpr) = print(io, exprToStr(d))
+Base.show(io::IO, d::NormExpr)  = print(io, "Norm expression")
+Base.print(io::IO, d::NormExpr) = print(io, exprToStr(d))
 
 ###############################################################################
 # Scalar Expression class
@@ -723,22 +725,22 @@ type ScalarExpr
     normexpr::NormExpr
 end
 
-isequal(x::ScalarExpr,y::ScalarExpr) = isequal(x.matvars,y.matvars) && isequal(x.aff,y.aff) && isequal(x.normexpr,y.normexpr)
+Base.isequal(x::ScalarExpr,y::ScalarExpr) = isequal(x.matvars,y.matvars) && isequal(x.aff,y.aff) && isequal(x.normexpr,y.normexpr)
 
 ScalarExpr() = ScalarExpr(MatrixFuncVar[], AffExpr(), NormExpr())
 ScalarExpr(v::Number) = ScalarExpr(MatrixFuncVar[], AffExpr(v), NormExpr())
 
-convert(::Type{ScalarExpr}, v::MatrixFuncVar) = ScalarExpr(concat(v), AffExpr(), NormExpr())
-convert(::Type{ScalarExpr}, v::AffExpr) = ScalarExpr(MatrixFuncVar[], v, NormExpr())
-convert(::Type{ScalarExpr}, v::NormExpr) = ScalarExpr(MatrixFuncVar[], AffExpr(), v)
+Base.convert(::Type{ScalarExpr}, v::MatrixFuncVar) = ScalarExpr(concat(v), AffExpr(), NormExpr())
+Base.convert(::Type{ScalarExpr}, v::AffExpr) = ScalarExpr(MatrixFuncVar[], v, NormExpr())
+Base.convert(::Type{ScalarExpr}, v::NormExpr) = ScalarExpr(MatrixFuncVar[], AffExpr(), v)
 
-function convert(::Type{ScalarExpr}, v::MatrixExpr)
+function Base.convert(::Type{ScalarExpr}, v::MatrixExpr)
     size(v) == (1,1) || error("Cannot coerce matrix expression to scalar expression")
     return v[1]
 end
 
-size(::ScalarExpr) = 1
-size(::ScalarExpr,::Int) = 1
+Base.size(::ScalarExpr) = 1
+Base.size(::ScalarExpr,::Int) = 1
 
 getValue(v::ScalarExpr) = getValue(v.aff) + mapreduce(getValue, +, v.matvars) + getValue(v.normexpr)
 
@@ -778,8 +780,8 @@ function exprToStr(a::ScalarExpr)
     return string("Scalar expression in ", str)
 end
 
-show(io::IO, c::ScalarExpr)  = print(io, "Scalar expression")
-print(io::IO, c::ScalarExpr) = print(io, exprToStr(c))
+Base.show(io::IO, c::ScalarExpr)  = print(io, "Scalar expression")
+Base.print(io::IO, c::ScalarExpr) = print(io, exprToStr(c))
 
 ###############################################################################
 # Dual Expression class
@@ -787,16 +789,16 @@ print(io::IO, c::ScalarExpr) = print(io, exprToStr(c))
 # and yᵢ are scalar variables. Used in dual SDP constraints.
 typealias DualExpr JuMP.GenericAffExpr{AbstractArray{Float64,2},Union(Variable,MatrixFuncVar)}
 
-isequal(x::DualExpr,y::DualExpr) = isequal(x.vars,y.vars) && isequal(x.coeffs,y.coeffs) && (x.constant == y.constant)
+Base.isequal(x::DualExpr,y::DualExpr) = isequal(x.vars,y.vars) && isequal(x.coeffs,y.coeffs) && (x.constant == y.constant)
 
 DualExpr(n::Integer) = DualExpr({},AbstractArray[],spzeros(n,n))
 
-size(d::DualExpr) = size(d.constant)
-size(d::DualExpr, slice::Int64) = size(d.constant,slice)
+Base.size(d::DualExpr) = size(d.constant)
+Base.size(d::DualExpr, slice::Int64) = size(d.constant,slice)
 
-issym(d::DualExpr) =  issym(d.constant) && all(issym, d.coeffs)
+Base.issym(d::DualExpr) =  issym(d.constant) && all(issym, d.coeffs)
 
-function getindex(d::DualExpr, x::Int, y::Int)
+function Base.getindex(d::DualExpr, x::Int, y::Int)
     m,n = size(d)
     ret = ScalarExpr(d.constant[x,y])
     for it in 1:m
@@ -820,8 +822,8 @@ function getnames(c::DualExpr)
     return d
 end
 
-show(io::IO, c::DualExpr)  = print(io, "Dual expression in ", join(getnames(c),", "))
-print(io::IO, c::DualExpr) = println(io, "Dual expression in ", join(getnames(c),", "))
+Base.show(io::IO, c::DualExpr)  = print(io, "Dual expression in ", join(getnames(c),", "))
+Base.print(io::IO, c::DualExpr) = println(io, "Dual expression in ", join(getnames(c),", "))
 
 ###############################################################################
 # Primal Constraint class
@@ -843,8 +845,8 @@ function conToStr(c::PrimalConstraint)
     return string("Primal constraint in ", str) 
 end
 
-show(io::IO, c::ConstraintRef{PrimalConstraint})  = print(io, conToStr(c.m.sdpdata.primalconstr[c.idx]))
-print(io::IO, c::ConstraintRef{PrimalConstraint}) = print(io, conToStr(c.m.sdpdata.primalconstr[c.idx]))
+Base.show(io::IO, c::ConstraintRef{PrimalConstraint})  = print(io, conToStr(c.m.sdpdata.primalconstr[c.idx]))
+Base.print(io::IO, c::ConstraintRef{PrimalConstraint}) = print(io, conToStr(c.m.sdpdata.primalconstr[c.idx]))
 
 ###############################################################################
 # Dual Constraint class
@@ -863,8 +865,8 @@ end
 
 conToStr(c::DualConstraint) = string("Dual constraint in ", join(getnames(c.terms),", ")) 
 
-show(io::IO, c::ConstraintRef{DualConstraint})  = print(io, conToStr(c.m.sdpdata.dualconstr[c.idx]))
-print(io::IO, c::ConstraintRef{DualConstraint}) = print(io, conToStr(c.m.sdpdata.dualconstr[c.idx]))
+Base.show(io::IO, c::ConstraintRef{DualConstraint})  = print(io, conToStr(c.m.sdpdata.dualconstr[c.idx]))
+Base.print(io::IO, c::ConstraintRef{DualConstraint}) = print(io, conToStr(c.m.sdpdata.dualconstr[c.idx]))
 
 ###############################################################################
 # Matrix Constraint class
@@ -889,5 +891,5 @@ function conToStr(c::MatrixConstraint)
     return string("SDP matrix constraint in ", str) 
 end
 
-show(io::IO, c::ConstraintRef{MatrixConstraint})  = print(io, conToStr(c.m.sdpdata.matrixconstr[c.idx]))
-print(io::IO, c::ConstraintRef{MatrixConstraint}) = print(io, conToStr(c.m.sdpdata.matrixconstr[c.idx]))
+Base.show(io::IO, c::ConstraintRef{MatrixConstraint})  = print(io, conToStr(c.m.sdpdata.matrixconstr[c.idx]))
+Base.print(io::IO, c::ConstraintRef{MatrixConstraint}) = print(io, conToStr(c.m.sdpdata.matrixconstr[c.idx]))

--- a/src/sdp.jl
+++ b/src/sdp.jl
@@ -1,0 +1,893 @@
+export SDPData, 
+       SDPModel, 
+       SDPVar, 
+       MatrixVar,
+       BlockMatrix,
+       MatrixExpr, 
+       MatrixFuncVar,
+       NormExpr,
+       ScalarExpr,
+       DualExpr,
+       PrimalConstraint,
+       DualConstraint,
+       MatrixConstraint,
+       addConstraints,
+       @defSDPVar,
+       @defMatrixVar
+
+type SolverInfo
+    id # internal solver IDs for SDPVar
+       # column indices for MatrixVar (Range)
+    psd::Bool # psd==true, nsd==false
+    offset # constant C in X≽C
+end
+
+SolverInfo() = SolverInfo(0,true,0.0)
+
+type SDPData
+    sdpvar#::Vector{SDPVar}
+    varname::Vector{String}
+    lb
+    ub
+    solverinfo::Vector{SolverInfo}
+    matrixconstr#::Vector{MatrixConstraint}
+    primalconstr#::Vector{PrimalConstraint}
+    dualconstr#::Vector{DualConstraint}
+    sdpobj
+    sdpval
+end
+
+SDPData() = SDPData({}, String[], {}, {}, SolverInfo[], MatrixConstraint[], PrimalConstraint[], DualConstraint[], ScalarExpr(), {})
+
+initSDP(m::Model) = (m.sdpdata == nothing) && (m.sdpdata = SDPData())
+
+const snsmap = [:(>=) => "≽", :(==) => "=", :(<=) => "≼", :(.>=) => "≥", :(.<=) => "≤"]
+
+if Pkg.installed("Mosek") != nothing
+    eval(Expr(:using,:Mosek))
+end
+
+const 𝕀 = UniformScaling(1)
+
+# Useful type hierarchy for vcat, hcat, etc.
+abstract SDPMatrix 
+
+###############################################################################
+# Semidefinite Variable class
+# Pointer to model, with solver index and dimension
+type SDPVar <: SDPMatrix
+    m::Model
+    index::Int64
+    dim::Int64
+end
+
+transpose(a::SDPVar)  = a
+ctranspose(a::SDPVar) = a
+conj(a::SDPVar) = a
+
+size(d::SDPVar) = (d.dim,d.dim)
+size(d::SDPVar, slice::Int64) = (0 <= slice <= 2) ? d.dim : 1
+ndims(d::SDPVar) = 2
+eye(d::SDPVar)  = eye(d.dim)
+issym(d::SDPVar) = true
+isequal(a::SDPVar, b::SDPVar) = isequal(a.m,b.m) && isequal(a.index,b.index)
+
+function diagm(d::SDPVar)
+    m,n = size(d)
+    return DualExpr(MatrixFuncVar[d[it,it] for it in 1:m],
+                   SparseMatrixCSC[sparse([it],[it],[1.0],m,n) for it in 1:m],
+                   spzeros(m,n))
+#    return mapreduce(it->d[it,it]*sparse([it],[it],[1.0],m,n), +, 1:m)
+end
+spdiagm(d::SDPVar) = diagm(d)
+
+getValue(d::SDPVar) = d.m.sdpdata.sdpval[d.index] 
+
+getLower(d::SDPVar) = d.m.sdpdata.lb[d.index]
+getUpper(d::SDPVar) = d.m.sdpdata.ub[d.index]
+function setLower(d::SDPVar,lb::Real)
+    (lb == 0.0 || isinf(lb)) && error("Only zero or infinite scalar bound is allowed")
+    d.m.sdpdata.lb[d.index] = lb
+end
+function setLower{T<:Number}(d::SDPVar,lb::AbstractArray{T,2})
+    size(d) == size(lb) || error("Bound must be same size as matrix variable")
+    issym(lb) || error("Bound must be symmetric")
+    d.m.sdpdata.lb[d.index] = lb
+end
+function setUpper(d::SDPVar,ub::Real)
+    (ub == 0.0 || isinf(ub)) && error("Only zero or infinite scalar bound is allowed")
+    d.m.sdpdata.ub[d.index] = ub
+end
+function setUpper{T<:Number}(d::SDPVar,ub::AbstractArray{T,2})
+    size(d) == size(ub) || error("Bound must be same size as matrix variable")
+    issym(ub) || error("Bound must be symmetric")
+    d.m.sdpdata.ub[d.index] = ub
+end
+
+getName(d::SDPVar) = d.m.sdpdata.varname[d.index]
+setName(d::SDPVar, name::String) = (d.m.sdpdata.varname[d.index] = name)
+
+trace(c::SDPVar)  = trace(convert(MatrixExpr, c))
+dot(c::SDPVar,d::AbstractArray) = trace(c*d)
+dot(c::AbstractArray,d::SDPVar) = trace(c*d)
+norm(c::SDPVar)   = norm(convert(MatrixExpr, c))
+sum(c::SDPVar)    = sum(convert(MatrixExpr, c))
+
+show(io::IO,d::SDPVar)  = print(io, "$(d.m.sdpdata.varname[d.index])")
+print(io::IO,d::SDPVar) = println(io, "$(d.m.sdpdata.varname[d.index]) ∈ 𝒮₊($(d.dim))")
+
+getindex(d::SDPVar, x::Int64, y::Int64) = 
+    MatrixFuncVar(MatrixExpr(concat(d),concat(sparse([x,y],[y,x],[0.5,0.5],d.dim,d.dim)),concat(𝕀),spzeros(d.dim,d.dim)),:ref)
+
+macro defSDPVar(m, x, extra...)
+    m = esc(m)
+    if isexpr(x,:comparison)
+        # we have some bounds
+        if x.args[2] == :>=
+            if length(x.args) == 5
+                error("Use the form lb <= var <= ub instead of ub >= var >= lb")
+            end
+            @assert length(x.args) == 3
+            # lower bounds, no upper
+            lb = esc(x.args[3])
+            ub = Inf
+            var = x.args[1]
+        elseif x.args[2] == :<=
+            if length(x.args) == 5
+                # lb <= x <= u
+                lb = esc(x.args[1])
+                if (x.args[4] != :<=)
+                    error("Expected <= operator")
+                end
+                ub = esc(x.args[5])
+                var = x.args[3]
+            else
+                # x <= u
+                ub = esc(x.args[3])
+                lb = -Inf
+                var = x.args[1]
+            end
+        end
+    else
+        var = x
+        lb = 0.0
+        ub = Inf
+    end
+    if length(extra) > 0
+        # TODO: allow user to specify matrix properties here (diagonal, etc.)
+    end
+
+    if length(var.args) == 3
+        var.args[2] == var.args[3] || error("SDP variable must be square")
+    elseif length(var.args) > 3
+        error("SDPVar must be specificed by one or two (equal) dimensions")
+    end
+
+    if !isexpr(var,:ref) # TODO: infer size via syntax like @defSDPVar(m, X >= ones(3,3))
+        error("Syntax error: Need to specify matrix size (e.g. $var[5])")
+    else
+        varname = esc(var.args[1])
+        sz = esc(var.args[2])
+        code = quote
+            issym($lb) || error("Lower bound is not symmetric")
+            issym($ub) || error("Upper bound is not symmetric")
+            (isa($lb,AbstractArray) && !($sz == size($lb,1))) && error("Lower bound is not of same size as variable")
+            (isa($ub,AbstractArray) && !($sz == size($ub,1))) && error("Upper bound is not of same size as variable")
+            isa($lb,Number) && !($lb == 0.0 || $lb == -Inf) && error("Bounds must be of same size as variable")
+            isa($ub,Number) && !($ub == 0.0 || $ub ==  Inf) && error("Bounds must be of same size as variable")
+            $lb == -Inf && $ub == Inf && error("Replace unrestricted SDP variable with regular, scalar variables")
+            $lb == $ub && error("Replace with constant matrix")
+            initSDP($m)
+            sdp = $(m).sdpdata
+            $(varname) = SDPVar($m, length(sdp.sdpvar)+1, $(esc(var.args[2])))
+            push!(sdp.sdpvar, $(varname))
+            push!(sdp.lb, $lb)
+            push!(sdp.ub, $ub)
+            push!(sdp.varname, $(string(var.args[1])))
+            push!(sdp.solverinfo, SolverInfo())
+            nothing
+        end
+        return code
+    end
+end
+
+###############################################################################
+# Matrix Variable class
+# Pointer to model, with solver index and dimension
+type MatrixVar <: SDPMatrix
+    m::Model
+    index::Int64
+    dim::(Int64,Int64)
+end
+
+function MatrixVar(m::Model, sz::(Int,Int), lb, ub, varname::String)
+    sdp = m.sdpdata
+    push!(sdp.lb, lb)
+    push!(sdp.ub, ub)
+    push!(sdp.varname, varname)
+    rng = (m.numCols+1):(m.numCols+prod(sz))
+    patt = (sz[2] == 1) ? :col : 
+           (sz[1] == 1) ? :row : :mat
+    for j in 1:sz[2], i in 1:sz[1]
+        lower = (lb == -Inf || lb == 0.0) ? lb : lb[i,j]
+        upper = (ub ==  Inf || ub == 0.0) ? ub : ub[i,j]
+        vname = (patt == :col) ? "$varname[$i]" : 
+                (patt == :row) ? "$varname[1,$j]" : "$varname[$i,$j]"
+        Variable(m, lower, upper, JuMP.CONTINUOUS, vname) # TODO: make this more efficient
+    end
+    push!(sdp.solverinfo, SolverInfo(rng,true,0.0))
+    return MatrixVar(m, length(sdp.sdpvar)+1, sz)
+end
+
+transpose(a::MatrixVar)  = MatrixVar(a.m,a.index,reverse(a.dim))
+ctranspose(a::MatrixVar) = MatrixVar(a.m,a.index,reverse(a.dim))
+conj(a::MatrixVar) = a
+
+size(a::MatrixVar) = a.dim
+size(d::MatrixVar, slice::Int64) = (0 <= slice <= 2) ? d.dim[slice] : 1
+ndims(d::MatrixVar) = 2
+eye(d::MatrixVar)  = eye(d.dim[1],d.dim[2])
+issym(d::MatrixVar) = (d.dim == (1,1))
+isequal(a::MatrixVar, b::MatrixVar) = (a.m == b.m) && isequal(a.index,b.index) && isequal(a.dim,b.dim)
+
+function dot{T<:Number}(a::Array{T},b::MatrixVar)
+    (size(a,1) == size(b,1) && size(a,2) == size(b,2)) || error("Incompatible dimensions")
+    return AffExpr(Variable[b[it] for it in 1:length(a)],
+                   Float64[a[it] for it in 1:length(a)],
+                   0.0)
+    # return mapreduce(it->a[it]*b[it], +, 1:length(a))
+end
+dot{T<:Number}(a::MatrixVar,b::Array{T}) = dot(b,a)
+
+function diagm(d::MatrixVar)
+    m,n = size(d)
+    m == n || error("Cannot construct diagonal of nonsquare matrix")
+    return DualExpr(Variable[d[it,it] for it in 1:m],
+               SparseMatrixCSC[sparse([it],[it],[1.0],m,n) for it in 1:m],
+               spzeros(m,n))
+    # return mapreduce(it->d[it,it]*sparse([it],[it],[1.0],m,n), +, 1:m)
+end
+spdiagm(d::MatrixVar) = diagm(d)
+
+getValue(d::MatrixVar) = reshape(d.m.sdpdata.sdpval[d.index], size(d))
+
+getLower(d::MatrixVar) = d.m.sdpdata.lb[d.index]
+getUpper(d::MatrixVar) = d.m.sdpdata.ub[d.index]
+function setLower(d::MatrixVar,lb::Real)
+    (lb == 0.0 || isinf(lb)) && error("Only zero or infinite scalar bound is allowed")
+    d.m.sdpdata.lb[d.index] = lb
+    rng = d.m.sdpdata.solverinfo[d.id].id
+    d.m.colLower[rng] = lb
+end
+function setLower{T<:Number}(d::MatrixVar,lb::AbstractArray{T,2})
+    size(d) == size(lb) || error("Bound must be same size as matrix variable")
+    d.m.sdpdata.lb[d.index] = lb
+    rng = d.m.sdpdata.solverinfo[d.id].id
+    d.m.colLower[rng] = lb
+end
+function setUpper(d::MatrixVar,ub::Real)
+    (ub == 0.0 || isinf(ub)) && error("Only zero or infinite scalar bound is allowed")
+    d.m.sdpdata.ub[d.index] = ub
+    rng = d.m.sdpdata.solverinfo[d.id].id
+    d.m.colUpper[rng] = ub
+end
+function setUpper{T<:Number}(d::MatrixVar,ub::AbstractArray{T,2})
+    size(d) == size(ub) || error("Bound must be same size as matrix variable")
+    d.m.sdpdata.ub[d.index] = ub
+    rng = d.m.sdpdata.solverinfo[d.id].id
+    d.m.colUpper[rng] = ub
+end
+
+getName(d::MatrixVar) = d.m.sdpdata.varname[d.index]
+setName(d::MatrixVar, name::String) = (d.m.sdpdata.varname[d.index] = name)
+
+show(io::IO,d::MatrixVar)  = print(io, "$(d.m.sdpdata.varname[d.index])")
+print(io::IO,d::MatrixVar) = println(io, "$(d.m.sdpdata.varname[d.index]) ∈ ℝ($(d.dim[1])×$(d.dim[2]))")
+
+function getindex(d::MatrixVar, x::Int)
+    rng = d.m.sdpdata.solverinfo[d.index].id
+    Variable(d.m, rng[x])
+end
+
+function getindex(d::MatrixVar, x::Int, y::Int)
+    sx,sy = d.dim
+    rng   = d.m.sdpdata.solverinfo[d.index].id
+    off = (y-1)*sx + x
+    return Variable(d.m, rng[off])
+end
+
+function getindex(d::MatrixVar, x::Int, y::Range{Int})
+    sx,sy = d.dim
+    rng   = d.m.sdpdata.solverinfo[d.index].id
+    arr = Array(Variable, 1, length(y))
+    for (it,val) in enumerate(y)
+        off = (val-1)*sx + x
+        arr[it] = Variable(d.m, rng[off])
+    end
+    return arr
+end
+
+function getindex(d::MatrixVar, x::Range{Int}, y::Int)
+    sx,sy = d.dim
+    rng   = d.m.sdpdata.solverinfo[d.index].id
+    arr = Array(Variable, length(x))
+    for (it,val) in enumerate(x)
+        off = (y-1)*sx + val
+        arr[it] = Variable(d.m, rng[off])
+    end
+    return arr
+end
+
+macro defMatrixVar(m, x, extra...)
+    m = esc(m)
+    if isexpr(x,:comparison)
+        # we have some bounds
+        if x.args[2] == :>=
+            if length(x.args) == 5
+                error("Use the form lb <= var <= ub instead of ub >= var >= lb")
+            end
+            @assert length(x.args) == 3
+            # lower bounds, no upper
+            lb = esc(x.args[3])
+            ub = Inf
+            var = x.args[1]
+        elseif x.args[2] == :<=
+            if length(x.args) == 5
+                # lb <= x <= u
+                lb = esc(x.args[1])
+                if (x.args[4] != :<=)
+                    error("Expected <= operator")
+                end
+                ub = esc(x.args[5])
+                var = x.args[3]
+            else
+                # x <= u
+                ub = esc(x.args[3])
+                lb = -Inf
+                var = x.args[1]
+            end
+        end
+    else
+        var = x
+        lb = -Inf
+        ub =  Inf
+    end
+    if length(extra) > 0
+        # TODO: allow user to specify matrix properties here (diagonal, etc.)
+    end
+
+    if isa(var,Symbol)
+        error("Consider using defVar for scalar variables")
+    elseif length(var.args) == 2
+        Base.warn_once("Single dimension defaults to column vector")
+        sx = esc(var.args[2])
+        sy = 1
+    elseif length(var.args) == 3
+        sx = esc(var.args[2])
+        sy = esc(var.args[3])
+    else
+        error("MatrixVar must be specificed by less than two dimensions")
+    end
+
+    if !isexpr(var,:ref)
+        error("Syntax error: Need to specify matrix size (e.g. $var[5])")
+    else
+        varname = esc(var.args[1])
+        code = quote
+            (isa($lb,AbstractArray) && !($sx == size($lb,1) && $sy == size($lb,2))) && error("Lower bound is not of same size as variable")
+            (isa($ub,AbstractArray) && !($sx == size($ub,1) && $sy == size($ub,2))) && error("Upper bound is not of same size as variable")
+            isa($lb,Number) && !($lb == 0.0 || $lb == -Inf) && error("Bounds must be of same size as variable")
+            isa($ub,Number) && !($ub == 0.0 || $ub ==  Inf) && error("Bounds must be of same size as variable")
+            $lb == $ub && error("Replace with constant matrix")
+            initSDP($m)
+            sdp = $(m).sdpdata
+            $(varname) = MatrixVar($m, ($sx,$sy), $lb, $ub, $(string(var.args[1])))
+            # $(varname) = MatrixVar($m, length(sdp.sdpvar)+1, ($sx,$sy))
+            push!(sdp.sdpvar, $(varname))
+            # push!(sdp.lb, $lb)
+            # push!(sdp.ub, $ub)
+            # push!(sdp.varname, $(string(var.args[1])))
+            # push!(sdp.solverinfo, SolverInfo())
+            nothing
+        end
+        return code
+    end
+end
+
+###############################################################################
+# Block Matrix Class
+# Dense container for matrix objects. Elements can be a matrix expression, 
+# matrix variable, SDP variable, Variable, array, or number. 
+type BlockMatrix <: SDPMatrix
+    elem::Array
+    sz::(Int,Int)
+end
+
+function BlockMatrix(array::Array)
+    bm, bn = blocksize(array) # do this to assert dimensions are consistent
+    return BlockMatrix(array,(bm,bn))
+end
+
+function blocksize(array::Array)
+    m, n = size(array)
+    sx = Array(Int64, m, n)
+    sy = Array(Int64, m, n)
+    for i in 1:m
+        for j in 1:n
+            elem = array[i,j]
+            if isa(elem, UniformScaling)
+                error("Not yet support for UniformScaling")
+            elseif isa(elem, Number) || isa(elem, Variable) || isa(elem, AffExpr) || isa(elem, QuadExpr)
+                sx[i,j] = 1
+                sy[i,j] = 1
+            else
+                sx[i,j] = size(elem,2)
+                sy[i,j] = size(elem,1)
+            end
+        end
+    end
+    for i in 1:m
+        for j in 2:n
+            if sy[i,j] != sy[i,j-1]
+                error("Incompatible number of rows")
+            end
+        end
+    end
+    for j in 1:n
+        for i in 2:m
+            if sx[i,j] != sx[i-1,j]
+                error("Incompatible number of columns")
+            end
+        end
+    end
+    return sum(sy[:,1]), sum(sx[1,:])
+end
+
+size(b::BlockMatrix) = b.sz
+blocksize(b::BlockMatrix) = size(b.elem)
+
+transpose(b::BlockMatrix)  = BlockMatrix(transpose(map(transpose,b.elem)))
+ctranspose(b::BlockMatrix) = BlockMatrix(transpose(map(transpose,b.elem)))
+
+isequal(a::BlockMatrix, b::BlockMatrix) = isequal(a.elem,b.elem)
+
+function issym(d::BlockMatrix)
+    m,n = size(d.elem)
+    m == n || return false
+    for i in 1:n # check that diagonal is symmetric
+        if !issym(d.elem[i,i])
+            return false
+        end
+    end
+    for i = 1:(n-1), j = (i+1):n # check off-diagonal blocks are transposes of each other
+        if !isequal(d.elem[i,j], transpose(d.elem[j,i]))
+            return false
+        end
+    end
+    return true
+end
+
+size(::Variable) = (1,)
+size(::Variable,::Int) = 1
+size(::AffExpr) = (1,1)
+size(::AffExpr,::Int) = 1
+size(::QuadExpr) = (1,)
+size(::QuadExpr,::Int) = 1
+
+function getindex(d::BlockMatrix, x::Int64, y::Int64)
+    m,n = size(d)
+    curr = 0
+    it = 1
+    while x > (curr+size(d.elem[it,1],1))
+        curr += size(d.elem[it,1],1)
+        it += 1
+    end
+    idx = it
+    offx = x - curr
+    curr = 0
+    it = 1
+    while y > (curr+size(d.elem[1,it],2))
+        curr += size(d.elem[1,it],2)
+        it += 1
+    end
+    idy = it
+    offy = y - curr
+    if isa(d.elem[idx,idy],Number) || isa(d.elem[idx,idy],Variable) || isa(d.elem[idx,idy],AffExpr) || isa(d.elem[idx,idy],QuadExpr)
+        return d.elem[idx,idy]
+    else
+        return getindex(d.elem[idx,idy],offx,offy)
+    end
+end
+
+getValue(b::BlockMatrix) = hvcat(size(b.elem), map(getValue, b.elem)'...)
+
+function getnames(c::BlockMatrix,d::Set)
+    for el in c.elem
+        if isa(el,SDPVar) || isa(el,MatrixVar)
+            push!(d,el.m.sdpdata.varname[el.index])
+        elseif isa(el, BlockMatrix) || isa(el, MatrixExpr)
+            getnames(el,d)
+        end
+    end
+    return d
+end
+
+###############################################################################
+# Matrix Expression class
+# Expressions of the form ΣᵢAᵢ*Xᵢ*Bᵢ+C for matrices A, B, C, and where
+# X may be a block matrix or a matrix variable. 
+type MatrixExpr{T<:Number} <: SDPMatrix
+    elem::Vector
+    pre::Array
+    post::Array
+    constant::AbstractArray{T,2}
+end
+
+MatrixExpr(n::Int) = MatrixExpr({},{},{},spzeros(n,n))
+
+MatrixExpr(arr::BlockMatrix) = MatrixExpr(concat(arr), concat(𝕀), concat(𝕀), spzeros(size(arr)...))
+function MatrixExpr(arr::Array)
+    bl = BlockMatrix(arr)
+    MatrixExpr(concat(bl), concat(𝕀), concat(𝕀), spzeros(size(bl)...))
+end
+
+# really ugly hack to coerce vectors to matrix...
+MatrixExpr{T<:Number}(elem::Vector,pre::Array,post::Array,constant::AbstractArray{T}) = 
+    MatrixExpr(elem,pre,post,transpose(transpose(constant)))
+
+size(d::MatrixExpr) = (size(d.constant,1),size(d.constant,2))
+size(d::MatrixExpr, slice::Int64) = (0 <= slice <= 2) ? size(d)[slice] : 1
+ndims(d::MatrixExpr) = 2
+eye(d::MatrixExpr)  = eye(size(d)...)
+
+convert(::Type{MatrixExpr}, v::SDPVar)    = MatrixExpr(concat(v), concat(𝕀), concat(𝕀), spzeros(v.dim,v.dim))
+convert(::Type{MatrixExpr}, v::MatrixVar) = MatrixExpr(concat(v), concat(𝕀), concat(𝕀), spzeros(v.dim...))
+
+transpose(d::MatrixExpr)  = MatrixExpr(map(transpose, d.elem), map(transpose, d.post), map(transpose, d.pre), transpose(d.constant))
+ctranspose(d::MatrixExpr) = MatrixExpr(map(transpose, d.elem), map(transpose, d.post), map(transpose, d.pre), transpose(d.constant))
+
+isequal(a::MatrixExpr, b::MatrixExpr) = isequal(a.elem,b.elem) && isequal(a.pre,b.pre) && isequal(a.post,b.post) && isequal(a.constant,b.constant)
+
+trace(c::MatrixExpr) = MatrixFuncVar(c, :trace)
+norm(c::MatrixExpr)  = MatrixFuncVar(c, :norm)
+sum(c::MatrixExpr)   = MatrixFuncVar(c, :sum)
+
+issym(d::MatrixExpr) = issym(d.constant) && all(issym, d.elem)
+
+function getindex(d::MatrixExpr, x::Int64)
+    m = size(d,1)
+    idx,idy = rem(x-1,m)+1, div(x-1,m)+1
+    return getindex(d, idx, idy)
+end
+
+function getindex(d::MatrixExpr, x::Int64, y::Int64)
+    m,n = size(d)
+    refer = ScalarExpr(d.constant[x,y])
+    for it in 1:length(d.elem)
+        !isa(d.pre[it],UniformScaling) && !isa(d.post[it],UniformScaling) && error("Expression not linear in matrix variables")
+        if !isa(d.post[it],UniformScaling)
+            for k in 1:size(d.elem[it],2)
+                refer += d.pre[it].λ*d.elem[it][x,k]*d.post[it][k,y]
+            end
+            # refer += mapreduce(k->d.pre[it].λ*d.elem[it][x,k]*d.post[it][k,y], +, 1:size(d.elem[it],2))
+        elseif !isa(d.pre[it],UniformScaling)
+            for k in 1:size(d.elem[it],1)
+                refer += d.pre[it][x,k]*d.elem[it][k,y]*d.post[it].λ
+            end
+            # refer += mapreduce(k->d.pre[it][x,k]*d.elem[it][k,y]*d.post[it].λ, +, 1:size(d.elem[it],1))
+        else
+            refer += d.pre[it].λ * d.elem[it][x,y] * d.post[it].λ
+        end
+    end
+    return refer
+end
+
+function getindex(d::MatrixExpr, x::Int, y::Range{Int})
+    sx,sy = size(d)
+    arr = Array(AffExpr, 1, length(y))
+    for (it,val) in enumerate(y)
+        arr[it] = d[x,val]
+    end
+    return arr
+end
+
+function getindex(d::MatrixExpr, x::Range{Int}, y::Int)
+    sx,sy = size(d)
+    arr = Array(AffExpr, length(x))
+    for (it,val) in enumerate(x)
+        arr[it] = d[val,y]
+    end
+    return arr
+end
+
+# helper for getValue(c::MatrixExpr)
+getValue{T<:Number}(c::AbstractArray{T,2}) = c
+
+getValue(c::MatrixExpr) =
+    mapreduce(it->c.pre[it]*getValue(c.elem[it])*c.post[it], +, 1:length(c.elem)) + c.constant
+
+function getnames(c::MatrixExpr,d::Set)
+    for el in c.elem
+        if isa(el,SDPVar) || isa(el,MatrixVar)
+            push!(d,el.m.sdpdata.varname[el.index])
+        elseif isa(el, BlockMatrix)
+            getnames(el,d)
+        end
+    end
+    return d
+end
+
+show(io::IO,d::MatrixExpr)  = print(io, "Matrix expression")
+function print(io::IO,d::MatrixExpr)
+    n = getnames(d,Set())
+    str = join([chomp(string(v)) for v in n], ", ")
+    println(io, string("Matrix expression in ", str))
+end
+
+###############################################################################
+# (Linear function) of a matrix expression
+# Represents a linear function acting on a matrix expression of the form
+# 𝒮₊ⁿ→ℝ. Current types include a trace operator or element reference.
+type MatrixFuncVar
+    expr::MatrixExpr
+    func::Symbol
+end
+
+isequal(x::MatrixFuncVar,y::MatrixFuncVar) = isequal(x.expr,y.expr) && isequal(x.func,y.func)
+
+size(::MatrixFuncVar) = 1
+size(::MatrixFuncVar,::Int) = 1
+
+function getValue(v::MatrixFuncVar)
+    if v.func == :trace
+        return trace(getValue(v.expr))
+    elseif v.func == :ref
+        (i,j,val) = findnz(v.expr.pre[1])
+        if length(i) == 2
+            return getValue(MatrixExpr(v.expr.elem,concat(𝕀),concat(𝕀),spzeros(size(v.expr)...)))[i[1],j[1]] * 2val[1]
+        elseif length(i) == 1
+            return getValue(MatrixExpr(v.expr.elem,concat(𝕀),concat(𝕀),spzeros(size(v.expr)...)))[i[1],j[1]] * val[1]
+        else
+            error("Shouldn't reach here")
+        end
+        # return getValue(MatrixExpr(v.expr.elem,concat(𝕀),concat(𝕀),spzeros(size(v.expr)...)))[findn(v.expr.pre[1])...][1] # this is real hacky and ugly
+    end
+end
+
+setObjective(m::Model, sense::Symbol, c::MatrixFuncVar) = setObjective(m, sense, convert(ScalarExpr,c))
+
+getnames(c::MatrixFuncVar,d::Set)  = getnames(c.expr,d)
+
+###############################################################################
+# Norm Expression class
+# Stores a normed expression of the form ‖X‖ for some norm ‖·‖, matrix
+# expression X. 
+type NormExpr
+    vars::Vector{Union(AffExpr,MatrixExpr)}
+    coeffs::Vector{Float64}
+    form::Vector{Symbol}
+end
+
+isequal(x::NormExpr,y::NormExpr) = isequal(x.vars,y.vars) && isequal(x.coeffs,y.coeffs) && isequal(x.form,y.form)
+
+NormExpr() = NormExpr(Union(AffExpr,MatrixExpr)[], Float64[], Symbol[])
+NormExpr(form::Symbol) = NormExpr(Union(AffExpr,MatrixExpr)[], [form])
+
+abs(d::Variable) = NormExpr(concat(convert(AffExpr,d)), [1.0], [:abs])
+abs(d::AffExpr)  = NormExpr(concat(d), [1.0], [:abs], AffExpr())
+
+norm(d::MatrixVar)  = NormExpr(concat(convert(MatrixExpr,d)), [1.0], [:norm2])
+norm(d::MatrixExpr) = NormExpr(concat(d), [1.0], [:norm2])
+
+vecnorm(d::MatrixVar)  = NormExpr(concat(convert(MatrixExpr,d)), [1.0], [:normfrob])
+vecnorm(d::MatrixExpr) = NormExpr(concat(d), [1.0], [:normfrob])
+
+copy(d::NormExpr) = NormExpr(copy(d.vars), copy(d.coeffs), copy(d.form))
+
+function getValue(d::NormExpr)
+    ret = 0.0
+    for it in 1:length(d.vars)
+        if d.form[it] == :abs
+            ret += coeffs[it] * abs(getValue(d.vars[it]))
+        elseif d.form[it] == :norm2
+            ret += coeffs[it] * norm(getValue(d.vars[it]))
+        elseif d.form[it] == :normfrob
+            ret += coeffs[it] * vecnorm(getValue(d.vars[it]))
+        end
+    end
+    return ret
+end
+
+setObjective(m::Model, sense::Symbol, c::NormExpr) = setObjective(m, sense, convert(ScalarExpr,c))
+
+getnames(c::NormExpr,d::Set) = map(x->getnames(x,d), c.vars)
+
+function exprToStr(c::NormExpr)
+    d = Set()
+    for var in c.vars
+        getnames(var,d)
+    end
+    str = join([chomp(string(v)) for v in d], ", ")
+    return string("Norm expression in ", str)
+end
+
+show(io::IO, d::NormExpr)  = print(io, "Norm expression")
+print(io::IO, d::NormExpr) = print(io, exprToStr(d))
+
+###############################################################################
+# Scalar Expression class
+# Combination of AffExpr, MatrixFuncExpr, and NormExpr.
+type ScalarExpr
+    matvars::Vector{MatrixFuncVar}
+    aff::AffExpr
+    normexpr::NormExpr
+end
+
+isequal(x::ScalarExpr,y::ScalarExpr) = isequal(x.matvars,y.matvars) && isequal(x.aff,y.aff) && isequal(x.normexpr,y.normexpr)
+
+ScalarExpr() = ScalarExpr(MatrixFuncVar[], AffExpr(), NormExpr())
+ScalarExpr(v::Number) = ScalarExpr(MatrixFuncVar[], AffExpr(v), NormExpr())
+
+convert(::Type{ScalarExpr}, v::MatrixFuncVar) = ScalarExpr(concat(v), AffExpr(), NormExpr())
+convert(::Type{ScalarExpr}, v::AffExpr) = ScalarExpr(MatrixFuncVar[], v, NormExpr())
+convert(::Type{ScalarExpr}, v::NormExpr) = ScalarExpr(MatrixFuncVar[], AffExpr(), v)
+
+function convert(::Type{ScalarExpr}, v::MatrixExpr)
+    size(v) == (1,1) || error("Cannot coerce matrix expression to scalar expression")
+    return v[1]
+end
+
+size(::ScalarExpr) = 1
+size(::ScalarExpr,::Int) = 1
+
+getValue(v::ScalarExpr) = getValue(v.aff) + mapreduce(getValue, +, v.matvars) + getValue(v.normexpr)
+
+setObjective(m::Model, sense::Symbol, c::MatrixExpr) = setObjective(m, sense, convert(ScalarExpr,c))
+function setObjective(m::Model, sense::Symbol, c::ScalarExpr)
+    initSDP(m)
+    setObjectiveSense(m, sense)
+    m.sdpdata.sdpobj = c
+end
+
+function getnames(c::ScalarExpr,d::Set)
+    map(x->getnames(x,d), c.matvars)
+    getnames(c.aff,d)
+    getnames(c.normexpr,d)
+    return d
+end
+getnames(c::ScalarExpr) = getnames(c,Set())
+getnames(c::Variable,d::Set) = (push!(d,c.m.colNames[c.col]))
+function getnames(c::Variable)
+    d = Set()
+    push!(d, c.m.colNames[c.col])
+end
+getnames(a::AffExpr,d::Set) = map(x->getnames(x,d), a.vars)
+function getnames(a::AffExpr)
+    d = Set()
+    getnames(a,d)
+    return d
+end
+
+function exprToStr(a::ScalarExpr)
+    d = Set()
+    for it in a.matvars
+        getnames(it,d)
+    end
+    getnames(a.aff,d)
+    str = join([chomp(string(v)) for v in d], ", ")
+    return string("Scalar expression in ", str)
+end
+
+show(io::IO, c::ScalarExpr)  = print(io, "Scalar expression")
+print(io::IO, c::ScalarExpr) = print(io, exprToStr(c))
+
+###############################################################################
+# Dual Expression class
+# Expressions of the form ΣᵢyᵢAᵢ + C, where Aᵢ and C are (symmetric) matrices
+# and yᵢ are scalar variables. Used in dual SDP constraints.
+typealias DualExpr JuMP.GenericAffExpr{AbstractArray{Float64,2},Union(Variable,MatrixFuncVar)}
+
+isequal(x::DualExpr,y::DualExpr) = isequal(x.vars,y.vars) && isequal(x.coeffs,y.coeffs) && (x.constant == y.constant)
+
+DualExpr(n::Integer) = DualExpr({},AbstractArray[],spzeros(n,n))
+
+size(d::DualExpr) = size(d.constant)
+size(d::DualExpr, slice::Int64) = size(d.constant,slice)
+
+issym(d::DualExpr) =  issym(d.constant) && all(issym, d.coeffs)
+
+function getindex(d::DualExpr, x::Int, y::Int)
+    m,n = size(d)
+    ret = ScalarExpr(d.constant[x,y])
+    for it in 1:m
+        ret += d.vars[it]*d.coeffs[it][x,y]
+    end
+    return ret
+    #return mapreduce(it->d.vars[it]*d.coeffs[it][x,y], +, 1:m) + d.constant[x,y]
+end
+
+getValue(d::DualExpr) = mapreduce(it->d.coeffs[it]*getValue(d.vars[it]), +, 1:length(d.vars)) + d.constant
+
+function getnames(c::DualExpr)
+    d = Set()
+    for v in c.vars
+        if isa(v,Variable)
+            push!(d, v.m.colNames[v.col])
+        elseif isa(v,MatrixFuncVar)
+            getnames(v.expr,d)
+        end
+    end
+    return d
+end
+
+show(io::IO, c::DualExpr)  = print(io, "Dual expression in ", join(getnames(c),", "))
+print(io::IO, c::DualExpr) = println(io, "Dual expression in ", join(getnames(c),", "))
+
+###############################################################################
+# Primal Constraint class
+# Stores a constraint of the type ub ≤ X ≤ lb, where X is a matrix function
+# expression.
+
+typealias PrimalConstraint JuMP.GenericRangeConstraint{ScalarExpr}
+
+function addConstraint(m::Model, c::PrimalConstraint)
+    initSDP(m)
+    push!(m.sdpdata.primalconstr,c)
+    return ConstraintRef{PrimalConstraint}(m,length(m.sdpdata.primalconstr))
+end
+
+function conToStr(c::PrimalConstraint)
+    d = Set()
+    getnames(c.terms,d)
+    str = join([chomp(string(v)) for v in d], ", ")
+    return string("Primal constraint in ", str) 
+end
+
+show(io::IO, c::ConstraintRef{PrimalConstraint})  = print(io, conToStr(c.m.sdpdata.primalconstr[c.idx]))
+print(io::IO, c::ConstraintRef{PrimalConstraint}) = print(io, conToStr(c.m.sdpdata.primalconstr[c.idx]))
+
+###############################################################################
+# Dual Constraint class
+# Stores a constraint of the type X ? 0, where X is a dual expression and ? is
+# inequality or equality.
+type DualConstraint <: JuMPConstraint
+    terms::DualExpr
+    sense::Symbol
+end
+
+function addConstraint(m::Model, c::DualConstraint)
+    initSDP(m)
+    push!(m.sdpdata.dualconstr,c)
+    return ConstraintRef{DualConstraint}(m,length(m.sdpdata.dualconstr))
+end
+
+conToStr(c::DualConstraint) = string("Dual constraint in ", join(getnames(c.terms),", ")) 
+
+show(io::IO, c::ConstraintRef{DualConstraint})  = print(io, conToStr(c.m.sdpdata.dualconstr[c.idx]))
+print(io::IO, c::ConstraintRef{DualConstraint}) = print(io, conToStr(c.m.sdpdata.dualconstr[c.idx]))
+
+###############################################################################
+# Matrix Constraint class
+# Stores a constraint of the type X ? 0, where X is a matrix expression and ? 
+# is a a semidefinite inequality (>=, <=, or ==) or an entrywise inequality
+# (.>= or .<=).
+type MatrixConstraint <: JuMPConstraint
+    terms::MatrixExpr
+    sense::Symbol
+end
+
+function addConstraint(m::Model, c::MatrixConstraint)
+    initSDP(m)
+    push!(m.sdpdata.matrixconstr,c)
+    return ConstraintRef{MatrixConstraint}(m,length(m.sdpdata.matrixconstr))
+end
+
+function conToStr(c::MatrixConstraint)
+    d = Set()
+    getnames(c.terms,d)
+    str = join([chomp(string(v)) for v in d], ", ")
+    return string("SDP matrix constraint in ", str) 
+end
+
+show(io::IO, c::ConstraintRef{MatrixConstraint})  = print(io, conToStr(c.m.sdpdata.matrixconstr[c.idx]))
+print(io::IO, c::ConstraintRef{MatrixConstraint}) = print(io, conToStr(c.m.sdpdata.matrixconstr[c.idx]))

--- a/src/sdp.jl
+++ b/src/sdp.jl
@@ -85,24 +85,6 @@ getValue(d::SDPVar) = d.m.sdpdata.sdpval[d.index]
 
 getLower(d::SDPVar) = d.m.sdpdata.lb[d.index]
 getUpper(d::SDPVar) = d.m.sdpdata.ub[d.index]
-function setLower(d::SDPVar,lb::Real)
-    (lb == 0.0 || isinf(lb)) && error("Only zero or infinite scalar bound is allowed")
-    d.m.sdpdata.lb[d.index] = lb
-end
-function setLower{T<:Number}(d::SDPVar,lb::AbstractArray{T,2})
-    size(d) == size(lb) || error("Bound must be same size as matrix variable")
-    issym(lb) || error("Bound must be symmetric")
-    d.m.sdpdata.lb[d.index] = lb
-end
-function setUpper(d::SDPVar,ub::Real)
-    (ub == 0.0 || isinf(ub)) && error("Only zero or infinite scalar bound is allowed")
-    d.m.sdpdata.ub[d.index] = ub
-end
-function setUpper{T<:Number}(d::SDPVar,ub::AbstractArray{T,2})
-    size(d) == size(ub) || error("Bound must be same size as matrix variable")
-    issym(ub) || error("Bound must be symmetric")
-    d.m.sdpdata.ub[d.index] = ub
-end
 
 getName(d::SDPVar) = d.m.sdpdata.varname[d.index]
 setName(d::SDPVar, name::String) = (d.m.sdpdata.varname[d.index] = name)
@@ -253,30 +235,6 @@ getValue(d::MatrixVar) = reshape(d.m.sdpdata.sdpval[d.index], size(d))
 
 getLower(d::MatrixVar) = d.m.sdpdata.lb[d.index]
 getUpper(d::MatrixVar) = d.m.sdpdata.ub[d.index]
-function setLower(d::MatrixVar,lb::Real)
-    (lb == 0.0 || isinf(lb)) && error("Only zero or infinite scalar bound is allowed")
-    d.m.sdpdata.lb[d.index] = lb
-    rng = d.m.sdpdata.solverinfo[d.id].id
-    d.m.colLower[rng] = lb
-end
-function setLower{T<:Number}(d::MatrixVar,lb::AbstractArray{T,2})
-    size(d) == size(lb) || error("Bound must be same size as matrix variable")
-    d.m.sdpdata.lb[d.index] = lb
-    rng = d.m.sdpdata.solverinfo[d.id].id
-    d.m.colLower[rng] = lb
-end
-function setUpper(d::MatrixVar,ub::Real)
-    (ub == 0.0 || isinf(ub)) && error("Only zero or infinite scalar bound is allowed")
-    d.m.sdpdata.ub[d.index] = ub
-    rng = d.m.sdpdata.solverinfo[d.id].id
-    d.m.colUpper[rng] = ub
-end
-function setUpper{T<:Number}(d::MatrixVar,ub::AbstractArray{T,2})
-    size(d) == size(ub) || error("Bound must be same size as matrix variable")
-    d.m.sdpdata.ub[d.index] = ub
-    rng = d.m.sdpdata.solverinfo[d.id].id
-    d.m.colUpper[rng] = ub
-end
 
 getName(d::MatrixVar) = d.m.sdpdata.varname[d.index]
 setName(d::MatrixVar, name::String) = (d.m.sdpdata.varname[d.index] = name)

--- a/src/sdp_operators.jl
+++ b/src/sdp_operators.jl
@@ -660,7 +660,7 @@ for ltype in (:AbstractArray, :Variable, :AffExpr, :MatrixVar, :MatrixExpr, :Mat
     end
 end
 
-function dot(x::AbstractArray, y::MatrixExpr)
+function Base.dot(x::AbstractArray, y::MatrixExpr)
     (size(x,1) == size(y,1) && size(x,2) == size(y,2)) || error("Incompatible sizes")
     ret = ScalarExpr()
     for i in 1:size(x,1), j in 1:size(x,2)
@@ -668,6 +668,6 @@ function dot(x::AbstractArray, y::MatrixExpr)
     end
     return ret
 end
-dot(x::MatrixExpr, y::AbstractArray) = dot(y,x)
-dot(x::MatrixVar,y::AbstractArray) = dot(convert(MatrixExpr,x),y)
-dot(x::AbstractArray, y::MatrixVar) = dot(y,x)
+Base.dot(x::MatrixExpr, y::AbstractArray) = dot(y,x)
+Base.dot(x::MatrixVar,y::AbstractArray) = dot(convert(MatrixExpr,x),y)
+Base.dot(x::AbstractArray, y::MatrixVar) = dot(y,x)

--- a/src/sdp_operators.jl
+++ b/src/sdp_operators.jl
@@ -523,6 +523,8 @@ for sgn in (:<=, :(==), :>=, :(.<=), :(.>=))
         end
         # MatrixVar--AbstractArray{T}
         $(sgn){T<:Number}(lhs::MatrixVar, rhs::AbstractArray{T}) = MatrixConstraint(lhs-rhs, $(quot(sgn)))
+        # MatrixVar--MatrixVar
+        $(sgn)(lhs::MatrixVar, rhs::MatrixVar) = MatrixConstraint(lhs-rhs, $(quot(sgn)))
         # MatrixVar--SDPVar
         $(sgn)(lhs::MatrixVar, rhs::SDPVar) = MatrixConstraint(lhs-rhs, $(quot(sgn)))
         # MatrixVar--MatrixExpr

--- a/src/sdp_operators.jl
+++ b/src/sdp_operators.jl
@@ -1,0 +1,673 @@
+# DualExpr
+(-)(x::DualExpr) = DualExpr(copy(x.vars), map(-,x.coeffs), -x.constant)
+# Number--DualExpr
+(*)(lhs::Number, rhs::DualExpr) = DualExpr(copy(rhs.vars), lhs*rhs.coeffs, lhs*rhs.constant)
+# Number--MatrixVar
+(*)(lhs::Number,rhs::MatrixVar) = MatrixExpr(concat(rhs), concat(lhs*𝕀), concat(𝕀), spzeros(size(rhs)...))
+# Number--SDPVar
+(*)(lhs::Number, rhs::SDPVar) = MatrixExpr(concat(rhs), concat(lhs*𝕀), concat(𝕀), spzeros(size(rhs)...))
+# Number--MatrixExpr
+# function (+)(lhs::Number, rhs::MatrixExpr)
+#     size(rhs) == (1,1) || error("Cannot add scalar to matrix expression")
+#     return lhs + rhs[1]
+# end
+# function (-)(lhs::Number, rhs::MatrixExpr)
+#     size(rhs) == (1,1) || error("Cannot add scalar to matrix expression")
+#     return lhs - rhs[1]
+# end
+(*)(lhs::Number, rhs::MatrixExpr)  = MatrixExpr(copy(rhs.elem), lhs*rhs.pre, copy(rhs.post), lhs*rhs.constant)
+# Number--MatrixFuncVar
+(+)(lhs::Number, rhs::MatrixFuncVar) = ScalarExpr(concat( rhs),AffExpr(lhs),NormExpr())
+(-)(lhs::Number, rhs::MatrixFuncVar) = ScalarExpr(concat(-rhs),AffExpr(lhs),NormExpr())
+(*)(lhs::Number, rhs::MatrixFuncVar) = MatrixFuncVar(lhs*rhs.expr,rhs.func)
+# Number--NormExpr
+(+)(lhs::Number,rhs::NormExpr)  = ScalarExpr(MatrixFuncVar[], AffExpr(lhs),  rhs)
+(-)(lhs::Number,rhs::NormExpr)  = ScalarExpr(MatrixFuncVar[], AffExpr(lhs), -rhs)
+(*)(lhs::Number,rhs::NormExpr)  =
+    ( lhs == 0 ? NormExpr() : NormExpr(copy(rhs.vars), rhs.coeffs*lhs, rhs.form) )
+# Number--ScalarExpr
+(+)(lhs::Number, rhs::ScalarExpr) = ScalarExpr(        copy(rhs.matvars), lhs+rhs.aff, copy(rhs.normexpr))
+(-)(lhs::Number, rhs::ScalarExpr) = ScalarExpr(       map(-,rhs.matvars), lhs-rhs.aff,     -rhs.normexpr )
+(*)(lhs::Number, rhs::ScalarExpr) = ScalarExpr(map(x->lhs*x,rhs.matvars), lhs*rhs.aff,  lhs*rhs.normexpr )
+
+# Variable--AbstractArray{T,2}
+function (*){T<:Number}(lhs::Variable, rhs::AbstractArray{T,2})
+    issym(rhs) || error("Matrix coefficient must be symmetric")
+    DualExpr(concat(lhs), concat(rhs), spzeros(size(rhs)...))
+end
+# Variable--MatrixExpr
+function (+)(lhs::Variable, rhs::MatrixExpr)
+    size(rhs) == (1,1) || error("Cannot add scalar to matrix expression")
+    return lhs + rhs[1]
+end
+function (-)(lhs::Variable, rhs::MatrixExpr)
+    size(rhs) == (1,1) || error("Cannot add scalar to matrix expression")
+    return lhs - rhs[1]
+end
+# Variable--MatrixFuncVar
+(+)(lhs::Variable, rhs::MatrixFuncVar) = ScalarExpr(concat( rhs), convert(AffExpr,lhs), NormExpr())
+(-)(lhs::Variable, rhs::MatrixFuncVar) = ScalarExpr(concat(-rhs), convert(AffExpr,lhs), NormExpr())
+# Variable--NormExpr
+(+)(lhs::Variable,rhs::NormExpr)  = ScalarExpr(MatrixFuncVar[], convert(AffExpr,lhs),  rhs)
+(-)(lhs::Variable,rhs::NormExpr)  = ScalarExpr(MatrixFuncVar[], convert(AffExpr,lhs), -rhs)
+# Variable--ScalarExpr
+(+)(lhs::Variable, rhs::ScalarExpr) = ScalarExpr(copy(rhs.matvars), lhs+rhs.aff, copy(rhs.normexpr))
+(-)(lhs::Variable, rhs::ScalarExpr) = ScalarExpr(    -rhs.matvars , lhs-rhs.aff,     -rhs.normexpr )
+
+# AffExpr--AbstractArray{T,2}
+function (*){T<:Number}(lhs::AffExpr, rhs::AbstractArray{T,2})
+    issym(rhs) || error("Matrix coefficient must be symmetric")
+    DualExpr(copy(lhs.vars), map(x->x*rhs,lhs.coeffs), lhs.constant*rhs)
+end
+# AffExpr--MatrixExpr
+function (+)(lhs::AffExpr, rhs::MatrixExpr)
+    size(rhs) == (1,1) || error("Cannot add scalar to matrix expression")
+    return lhs + rhs[1]
+end
+function (-)(lhs::AffExpr, rhs::MatrixExpr)
+    size(rhs) == (1,1) || error("Cannot add scalar to matrix expression")
+    return lhs - rhs[1]
+end
+# AffExpr--MatrixFuncVar
+(+)(lhs::AffExpr, rhs::MatrixFuncVar) = ScalarExpr(concat( rhs), copy(lhs), NormExpr())
+(-)(lhs::AffExpr, rhs::MatrixFuncVar) = ScalarExpr(concat(-rhs), copy(lhs), NormExpr())
+# AffExpr--NormExpr
+(+)(lhs::AffExpr,rhs::NormExpr) = ScalarExpr(MatrixFuncVar[], lhs,  rhs)
+(-)(lhs::AffExpr,rhs::NormExpr) = ScalarExpr(MatrixFuncVar[], lhs, -rhs)
+# AffExpr--ScalarExpr
+(+)(lhs::AffExpr, rhs::ScalarExpr) = ScalarExpr(copy(rhs.matvars), lhs+rhs.aff, copy(rhs.normexpr))
+(-)(lhs::AffExpr, rhs::ScalarExpr) = ScalarExpr(    -rhs.matvars , lhs-rhs.aff,     -rhs.normexpr )
+
+# QuadExpr--SDPVar
+# QuadExpr--MatrixExpr
+
+# DualExpr
+# DualExpr--Number
+(*)(lhs::DualExpr, rhs::Number) = DualExpr(copy(lhs.vars), lhs.coeffs*rhs, lhs.constant*rhs)
+(/)(lhs::DualExpr, rhs::Number) = DualExpr(copy(lhs.vars), lhs.coeffs/rhs, lhs.constant/rhs)
+# DualExpr--AbstractArray{T,2}
+function (+){T<:Number}(lhs::DualExpr, rhs::AbstractArray{T,2})
+    issym(rhs) || error("Matrix must be symmetric")
+    DualExpr(copy(lhs.vars), copy(lhs.coeffs), lhs.constant+rhs)
+end
+function (-){T<:Number}(lhs::DualExpr, rhs::AbstractArray{T,2})
+    issym(rhs) || error("Matrix must be symmetric")
+    DualExpr(copy(lhs.vars), copy(lhs.coeffs), lhs.constant-rhs)
+end
+function (*){T<:Number}(lhs::DualExpr, rhs::AbstractArray{T,2})
+    issym(rhs) || error("Matrix coefficient must be symmetric")
+    coeffs = copy(lhs.coeffs)
+    for it in 1:length(coeffs)
+        coeffs[it] *= rhs
+    end
+    DualExpr(copy(lhs.vars), coeffs, lhs.constant*rhs)
+end
+# DualExpr--DualExpr
+(+)(lhs::DualExpr, rhs::DualExpr) = DualExpr(concat(lhs.vars,rhs.vars), concat(lhs.coeffs, rhs.coeffs), lhs.constant+rhs.constant)
+(-)(lhs::DualExpr, rhs::DualExpr) = DualExpr(concat(lhs.vars,rhs.vars), concat(lhs.coeffs,-rhs.coeffs), lhs.constant-rhs.constant)
+# AbstractArray{T,2}
+# AbstractArray{T,2}--Variable
+function (*){T<:Number}(lhs::AbstractArray{T,2}, rhs::Variable)
+    issym(lhs) || error("Matrix coefficient must be symmetric")
+    DualExpr(concat(rhs), concat(lhs), spzeros(size(lhs)...))
+end
+# AbstractArray{T,2}--AffExpr
+function (*){T<:Number}(lhs::AbstractArray{T,2}, rhs::AffExpr)
+    issym(lhs) || error("Matrix coefficient must be symmetric")
+    DualExpr(copy(rhs.vars), map(x->lhs*x,rhs.coeffs), lhs*rhs.constant)
+end
+# AbstractArray{T,2}--DualExpr
+function (+){T<:Number}(lhs::AbstractArray{T,2}, rhs::DualExpr)
+    issym(rhs) || error("Matrix must be symmetric")
+    DualExpr(copy(rhs.vars), copy(rhs.coeffs), lhs+rhs.constant)
+end
+function (-){T<:Number}(lhs::AbstractArray{T,2}, rhs::DualExpr)
+    issym(rhs) || error("Matrix must be symmetric")
+    DualExpr(copy(rhs.vars), -rhs.coeffs, lhs-rhs.constant)
+end
+function (*){T<:Number}(lhs::AbstractArray{T,2}, rhs::DualExpr)
+    issym(rhs) || error("Matrix coefficient must be symmetric")
+    coeffs = copy(rhs.coeffs)
+    for it in 1:length(coeffs)
+        coeffs[it] = lhs * coeffs[it]
+    end
+    DualExpr(copy(rhs.vars), coeffs, lhs*rhs.constant)
+end
+# AbstractArray{T}--MatrixVar
+function (+){T<:Number}(lhs::AbstractArray{T},rhs::MatrixVar)
+    ( (size(lhs,1) == size(rhs,1)) && (size(lhs,2) == size(rhs,2)) ) || error("Cannot add matrices of unequal size")
+    MatrixExpr(concat(rhs), concat(𝕀), concat(𝕀), lhs)
+end
+function (-){T<:Number}(lhs::AbstractArray{T},rhs::MatrixVar)
+    ( (size(lhs,1) == size(rhs,1)) && (size(lhs,2) == size(rhs,2)) ) || error("Cannot subtract matrices of unequal size")
+    MatrixExpr(concat(rhs), concat(-𝕀), concat(I), lhs)
+end
+function (*){T<:Number}(lhs::AbstractArray{T},rhs::MatrixVar)
+    (size(lhs,2) == size(rhs,1)) || error("Matrix multiplication with incompatible sizes")
+    MatrixExpr(concat(rhs), concat(lhs), concat(𝕀), spzeros(size(lhs,1),size(rhs,2)))
+end
+# AbstractArray{T,2}--SDPVar
+function (+){T<:Number}(lhs::AbstractArray{T,2}, rhs::SDPVar)
+    (size(lhs) == size(rhs)) || error("Cannot add matrices of unequal size")
+    MatrixExpr(concat(rhs), concat(𝕀), concat(𝕀), lhs)
+end
+function (-){T<:Number}(lhs::AbstractArray{T,2}, rhs::SDPVar)
+    (size(lhs) == size(rhs)) || error("Cannot subtract matrices of unequal size")
+    MatrixExpr(concat(rhs), concat(-𝕀), concat(𝕀), lhs)
+end
+function (*){T<:Number}(lhs::AbstractArray{T}, rhs::SDPVar)
+    size(lhs,2) == size(rhs,1) || error("Incompatible dimensions")
+    MatrixExpr(concat(rhs), concat(lhs), concat(𝕀), spzeros(size(lhs,1),size(rhs,2)))
+end
+# AbstractArray{T}--MatrixExpr
+function (+){T<:Number}(lhs::AbstractArray{T}, rhs::MatrixExpr)
+    (size(lhs,1) == size(rhs,1) && size(lhs,2) == size(rhs,2)) || error("Cannot add matrices of unequal size")
+    MatrixExpr(copy(rhs.elem), copy(rhs.pre), copy(rhs.post), lhs+rhs.constant)
+end
+function (-){T<:Number}(lhs::AbstractArray{T}, rhs::MatrixExpr)
+    (size(lhs,1) == size(rhs,1) && size(lhs,2) == size(rhs,2)) || error("Cannot subtract matrices of unequal size")
+    MatrixExpr(copy(rhs.elem), -rhs.pre, copy(rhs.post), lhs-rhs.constant)
+end
+function (*){T<:Number}(lhs::AbstractArray{T}, rhs::MatrixExpr)
+    size(lhs,2) == size(rhs,1) || error("Incompatible dimensions")
+    MatrixExpr(copy(rhs.elem), map(x->lhs*x, rhs.pre), copy(rhs.post), lhs*rhs.constant)
+end
+# AbstractArray{T,2}--MatrixFuncVar
+function (*){T<:Number}(lhs::AbstractArray{T,2},rhs::MatrixFuncVar)
+    issym(lhs) || error("Matrix must be symmetric")
+    DualExpr(concat(rhs), concat(lhs), spzeros(size(lhs)...))
+end
+# AbstractArray{T,2}--ScalarExpr
+function (*){T<:Number}(lhs::AbstractArray{T,2},rhs::ScalarExpr)
+    isequal(rhs.normexpr,NormExpr()) || error("Cannot multiply norm expression with a matrix")
+    issym(lhs) || error("Matrix must by symmetric")
+    DualExpr(concat(rhs.matvars,rhs.aff.vars), concat([lhs for c in rhs.matvars],[lhs*c for c in rhs.aff.coeffs]), lhs*rhs.aff.constant)
+end
+# # UniformScaling
+# # UniformScaling--SDPVar
+# (+)(lhs::UniformScaling,rhs::SDPVar) = MatrixExpr(concat(rhs),concat( 𝕀) ,concat(𝕀),lhs)
+# (-)(lhs::UniformScaling,rhs::SDPVar) = MatrixExpr(concat(rhs),concat(-𝕀) ,concat(𝕀),lhs)
+# (*)(lhs::UniformScaling,rhs::SDPVar) = MatrixExpr(concat(rhs),concat(lhs),concat(𝕀),spzeros(size(rhs)...))
+# # UniformScaling--MatrixExpr
+# (+)(lhs::UniformScaling,rhs::MatrixExpr) = MatrixExpr(copy(rhs.elem),copy(rhs.pre),copy(rhs.post),rhs.constant+lhs)
+# (-)(lhs::UniformScaling,rhs::MatrixExpr) = MatrixExpr(copy(rhs.elem),-rhs.pre,copy(rhs.post),lhs-rhs.constant)
+# (*)(lhs::UniformScaling,rhs::MatrixExpr) = MatrixExpr(copy(rhs.elem),lhs.λ*rhs.pre,copy(rhs.post),lhs.λ*rhs.constant)
+
+# MatrixVar
+(-)(var::MatrixVar) = MatrixExpr(concat(var),concat(-𝕀),concat(𝕀),spzeros(size(var)...))
+# MatrixVar--Number
+(*)(lhs::MatrixVar, rhs::Number) = (*)(rhs,lhs)
+(/)(lhs::MatrixVar, rhs::Number) = (*)(1/rhs,lhs)
+# MatrixVar--AbstractArray{T}
+function (+){T<:Number}(lhs::MatrixVar, rhs::AbstractArray{T})
+    ( (size(lhs,1) == size(rhs,1)) && (size(lhs,2) == size(rhs,2)) ) || error("Cannot add matrices of unequal size")
+    MatrixExpr(concat(lhs), concat(𝕀), concat(𝕀), rhs)
+end
+function (-){T<:Number}(lhs::MatrixVar, rhs::AbstractArray{T})
+    ( (size(lhs,1) == size(rhs,1)) && (size(lhs,2) == size(rhs,2)) ) || error("Cannot subtract matrices of unequal size")
+    MatrixExpr(concat(lhs), concat(𝕀), concat(𝕀), -rhs)
+end
+function (*){T<:Number}(lhs::MatrixVar, rhs::AbstractArray{T})
+    (size(lhs,2) == size(rhs,1)) || error("Matrix multiplication with incompatible sizes")
+    MatrixExpr(concat(lhs), concat(𝕀), concat(rhs), spzeros(size(lhs,1),size(rhs,2)))
+end
+# MatrixVar--MatrixVar
+function (+)(lhs::MatrixVar,rhs::MatrixVar)
+    size(lhs) == size(rhs) || error("Cannot add matrices of unequal size")
+    MatrixExpr(concat(lhs,rhs), concat(𝕀,𝕀), concat(𝕀,𝕀), spzeros(size(lhs)...))
+end
+function (-)(lhs::MatrixVar,rhs::MatrixVar)
+    size(lhs) == size(rhs) || error("Cannot subtract matrices of unequal size")
+    MatrixExpr(concat(lhs,rhs), concat(𝕀,-𝕀), concat(𝕀,𝕀), spzeros(size(lhs)...))
+end
+function (*)(lhs::MatrixVar,rhs::MatrixVar)
+    (m,p),(q,n) = size(lhs), size(rhs)
+    p == q || error("Imcompatible dimensions for matrix multiplication")
+    arr = Array(QuadExpr, m, n)
+    for i in 1:m, j in 1:n
+        arr[i,j] = QuadExpr(vec(lhs[i,:]),rhs[:,j],ones(p), AffExpr())
+    end
+    bl = BlockMatrix(arr)
+    MatrixExpr(concat(bl), concat(𝕀), concat(𝕀), spzeros(size(lhs,1),size(rhs,2)))
+end
+# MatrixVar--SDPVar
+function (+)(lhs::MatrixVar,rhs::SDPVar)
+    size(lhs) == size(rhs) || error("Cannot add matrices of unequal size")
+    MatrixExpr(concat(lhs,rhs), concat(𝕀,𝕀), concat(𝕀,𝕀), spzeros(size(lhs)...))
+end
+function (-)(lhs::MatrixVar,rhs::SDPVar)
+    size(lhs) == size(rhs) || error("Cannot subtract matrices of unequal size")
+    MatrixExpr(concat(lhs,rhs), concat(𝕀,-𝕀), concat(𝕀,𝕀), spzeros(size(lhs)...))
+end
+# MatrixVar--MatrixExpr
+function (+)(lhs::MatrixVar,rhs::MatrixExpr)
+    size(lhs) == size(rhs) || error("Cannot add matrices of unequal size")
+    MatrixExpr(concat(lhs,rhs.elem), concat(𝕀,rhs.pre), concat(𝕀,rhs.post), copy(rhs.constant))
+end
+function (-)(lhs::MatrixVar,rhs::MatrixExpr)
+    size(lhs) == size(rhs) || error("Cannot subtract matrices of unequal size")
+    MatrixExpr(concat(lhs,rhs.elem), concat(𝕀,-rhs.pre), concat(𝕀,rhs.post), -rhs.constant)
+end
+function (*)(lhs::MatrixVar,rhs::MatrixExpr)
+    (m,p),(q,n) = size(lhs), size(rhs)
+    p == q || error("Imcompatible dimensions for matrix multiplication")
+    m == n == 1 || error("Only quadratic forms are allowed")
+    ret = QuadExpr()
+    for k in 1:p
+        ret += lhs[k]*rhs[k]
+    end
+    return ret
+end
+
+# SDPVar
+(-)(var::SDPVar) = MatrixExpr(concat(var),concat(-𝕀),concat(𝕀),spzeros(size(var)...))
+# SDPVar--Number
+(*)(lhs::SDPVar, rhs::Number) = (*)(rhs,lhs)
+(/)(lhs::SDPVar, rhs::Number) = (*)(1/rhs,lhs)
+# SDPVar--AbstractArray{T}
+function (+){T<:Number}(lhs::SDPVar, rhs::AbstractArray{T})
+    (size(lhs,1) == size(rhs,1) && size(lhs,2) == size(lhs,2)) || error("Cannot add matrices of unequal size")
+    MatrixExpr(concat(lhs), concat(𝕀), concat(𝕀), rhs)
+end
+function (-){T<:Number}(lhs::SDPVar, rhs::AbstractArray{T})
+    (size(lhs,1) == size(rhs,1) && size(lhs,2) == size(lhs,2)) || error("Cannot subtract matrices of unequal size")
+    MatrixExpr(concat(lhs), concat(𝕀), concat(I), -rhs)
+end
+function (*){T<:Number}(lhs::SDPVar, rhs::AbstractArray{T})
+    (size(lhs,2) == size(rhs,1)) || error("Cannot subtract matrices of unequal size")
+    MatrixExpr(concat(lhs), concat(𝕀), concat(rhs), spzeros(size(lhs,1),size(rhs,2)))
+end
+# # SDPVar--UniformScaling
+# (+)(lhs::SDPVar,rhs::UniformScaling) = MatrixExpr(concat(lhs),concat(𝕀),concat(𝕀), rhs)
+# (-)(lhs::SDPVar,rhs::UniformScaling) = MatrixExpr(concat(lhs),concat(𝕀),concat(𝕀),-rhs)
+# (*)(lhs::SDPVar,rhs::UniformScaling) = MatrixExpr(concat(lhs),concat(𝕀),concat(rhs),spzeros(size(lhs)...))
+# SDPVar--Variable
+# SDPVar--AffExpr
+# SDPVar--QuadExpr
+# SDPVar--MatrixVar
+function (+)(lhs::SDPVar,rhs::MatrixVar)
+    size(lhs) == size(rhs) || error("Cannot add matrices of unequal size")
+    MatrixExpr(concat(lhs,rhs), concat(𝕀,𝕀), concat(𝕀,𝕀), spzeros(size(lhs)...))
+end
+function (-)(lhs::SDPVar,rhs::MatrixVar)
+    size(lhs) == size(rhs) || error("Cannot subtract matrices of unequal size")
+    MatrixExpr(concat(lhs,rhs), concat(𝕀,-𝕀), concat(𝕀,𝕀), spzeros(size(lhs)...))
+end
+# SDPVar--SDPVar
+function (+)(lhs::SDPVar, rhs::SDPVar)
+    (size(lhs) == size(rhs)) || error("Cannot add matrix variables of unequal size")
+    MatrixExpr(concat(lhs,rhs), concat(𝕀,𝕀), concat(𝕀,𝕀), spzeros(size(lhs)...))
+end
+function (-)(lhs::SDPVar, rhs::SDPVar)
+    (size(lhs) == size(rhs)) || error("Cannot subtract matrix variables of unequal size")
+    MatrixExpr(concat(lhs,rhs),concat(𝕀,-𝕀), concat(𝕀,𝕀), spzeros(size(lhs)...))
+end
+# SDPVar--MatrixExpr
+(+)(lhs::SDPVar, rhs::MatrixExpr) = MatrixExpr(concat(lhs,rhs.elem),concat(𝕀, rhs.pre),concat(𝕀,rhs.post), rhs.constant)
+(-)(lhs::SDPVar, rhs::MatrixExpr) = MatrixExpr(concat(lhs,rhs.elem),concat(𝕀,-rhs.pre),concat(𝕀,rhs.post),-rhs.constant)
+function (*)(lhs::SDPVar, rhs::MatrixExpr) 
+    (length(rhs.elem) == 0) || error("Cannot multiply matrix variables")
+    (size(lhs) == size(rhs.constant)) || error("Cannot multiply matrixes of incompatible sizes")
+    MatrixExpr(copy(lhs), copy(rhs.constant), concat(𝕀), spzeros(size(lhs)...))
+end
+
+# MatrixExpr
+(-)(v::MatrixExpr) = MatrixExpr(copy(v.elem), -v.pre, copy(v.post), copy(v.constant))
+# MatrixExpr--Number
+# function (+)(lhs::MatrixExpr, rhs::Number)
+#     size(lhs) == (1,1) || error("Cannot add scalar to matrix expression")
+#     return lhs[1] + rhs
+# end
+# function (-)(lhs::MatrixExpr, rhs::Number)
+#     size(lhs) == (1,1) || error("Cannot add scalar to matrix expression")
+#     return lhs[1] - rhs
+# end
+(*)(lhs::MatrixExpr, rhs::Number) = (*)(rhs,lhs)
+(/)(lhs::MatrixExpr, rhs::Number) = (*)(1/rhs,lhs)
+# MatrixExpr--AbstractArray{T,2}
+function (+){T<:Number}(lhs::MatrixExpr, rhs::AbstractArray{T})
+    (size(lhs,1) == size(rhs,1) && size(lhs,2) == size(rhs,2)) || error("Cannot add matrices of unequal size")
+    MatrixExpr(copy(lhs.elem), copy(lhs.pre), copy(lhs.post), lhs.constant+rhs)
+end
+function (-){T<:Number}(lhs::MatrixExpr, rhs::AbstractArray{T})
+    (size(lhs,1) == size(rhs,1) && size(lhs,2) == size(rhs,2)) || error("Cannot subtract matrices of unequal size")
+    MatrixExpr(copy(lhs.elem), copy(lhs.pre), copy(lhs.post), lhs.constant-rhs)
+end
+function (*){T<:Number}(lhs::MatrixExpr, rhs::AbstractArray{T})
+    size(lhs,2) == size(rhs,1) || error("Incompatible dimensions") 
+    MatrixExpr(copy(lhs.elem), copy(lhs.pre), map(x->x*rhs, lhs.post), lhs.constant*rhs)
+end
+# # MatrixExpr--UniformScaling
+# (+)(lhs::MatrixExpr,rhs::UniformScaling) = MatrixExpr(copy(lhs.elem),copy(lhs.pre),copy(lhs.post),lhs.constant+rhs)
+# (-)(lhs::MatrixExpr,rhs::UniformScaling) = MatrixExpr(copy(lhs.elem),copy(lhs.pre),copy(lhs.post),lhs.constant-rhs)
+# (*)(lhs::MatrixExpr,rhs::UniformScaling) = MatrixExpr(copy(lhs.elem),copy(lhs.pre),lhs.post*rhs.λ,lhs.constant*rhs.λ)
+# MatrixExpr--Variable
+function (+)(lhs::MatrixExpr, rhs::Variable)
+    size(lhs) == (1,1) || error("Cannot add scalar to matrix expression")
+    return lhs[1] + rhs
+end
+function (-)(lhs::MatrixExpr, rhs::Variable)
+    size(lhs) == (1,1) || error("Cannot add scalar to matrix expression")
+    return lhs[1] - rhs
+end
+# MatrixExpr--AffExpr
+function (+)(lhs::MatrixExpr, rhs::AffExpr)
+    size(lhs) == (1,1) || error("Cannot add scalar to matrix expression")
+    return lhs[1] + rhs
+end
+function (-)(lhs::MatrixExpr, rhs::AffExpr)
+    size(lhs) == (1,1) || error("Cannot add scalar to matrix expression")
+    return lhs[1] - rhs
+end
+# MatrixExpr--QuadExpr
+# MatrixExpr--MatrixVar
+function (+)(lhs::MatrixExpr,rhs::MatrixVar)
+    size(lhs) == size(rhs) || error("Cannot add matrices of unequal size")
+    MatrixExpr(concat(lhs.elem,rhs), concat(lhs.pre,𝕀), concat(lhs.post,𝕀), copy(lhs.constant))
+end
+function (-)(lhs::MatrixExpr,rhs::MatrixVar)
+    size(lhs) == size(rhs) || error("Cannot subtract matrices of unequal size")
+    MatrixExpr(concat(lhs.elem,rhs), concat(lhs.pre,-𝕀), concat(lhs.post,𝕀), lhs.constant)
+end
+function (*)(lhs::MatrixExpr,rhs::MatrixVar)
+    (m,p),(q,n) = size(lhs), size(rhs)
+    p == q || error("Imcompatible dimensions for matrix multiplication")
+    m == n == 1 || error("Only quadratic forms are allowed")
+    ret = QuadExpr()
+    for k in 1:p
+        ret += lhs[k]*rhs[k]
+    end
+    return ret
+end
+# MatrixExpr--SDPVar
+function (+)(lhs::MatrixExpr, rhs::SDPVar)
+    (size(lhs.constant) == size(rhs)) || error("Cannot add matrix variables of unequal size")
+    MatrixExpr(concat(lhs.elem,rhs), concat(lhs.pre,𝕀), concat(lhs.post,𝕀), lhs.constant)
+end
+function (-)(lhs::MatrixExpr, rhs::SDPVar)
+    (size(lhs.constant) == size(rhs)) || error("Cannot subtract matrix variables of unequal size")
+    MatrixExpr(concat(lhs.elem,rhs), concat(lhs.pre,-𝕀), concat(lhs.post,𝕀), lhs.constant)
+end
+# MatrixExpr--MatrixExpr
+(+)(lhs::MatrixExpr, rhs::MatrixExpr) = MatrixExpr(concat(lhs.elem,rhs.elem),concat(lhs.pre, rhs.pre),concat(lhs.post,rhs.post),lhs.constant+rhs.constant)
+(-)(lhs::MatrixExpr, rhs::MatrixExpr) = MatrixExpr(concat(lhs.elem,rhs.elem),concat(lhs.pre,-rhs.pre),concat(lhs.post,rhs.post),lhs.constant-rhs.constant)
+function (*)(lhs::MatrixExpr,rhs::MatrixExpr)
+    (m,p),(q,n) = size(lhs), size(rhs)
+    p == q || error("Imcompatible dimensions for matrix multiplication")
+    m == n == 1 || error("Only quadratic forms are allowed")
+    ret = QuadExpr()
+    for k in 1:p
+        ret += lhs[k]*rhs[k]
+    end
+    return ret
+end
+# MatrixFuncVar
+(-)(lhs::MatrixFuncVar) = MatrixFuncVar(-lhs.expr, lhs.func)
+# MatrixFuncVar--Number
+(+)(lhs::MatrixFuncVar,rhs::Number) = ScalarExpr(concat(lhs), AffExpr( rhs), NormExpr())
+(-)(lhs::MatrixFuncVar,rhs::Number) = ScalarExpr(concat(lhs), AffExpr(-rhs), NormExpr())
+(*)(lhs::MatrixFuncVar,rhs::Number) = MatrixFuncVar(lhs.expr*rhs,lhs.func)
+(/)(lhs::MatrixFuncVar,rhs::Number) = MatrixFuncVar(lhs.expr/rhs,lhs.func)
+# MatrixFuncVar--Variable
+(+)(lhs::MatrixFuncVar,rhs::Variable) = ScalarExpr(concat(lhs),convert(AffExpr,rhs), NormExpr())
+(-)(lhs::MatrixFuncVar,rhs::Variable) = ScalarExpr(concat(lhs),               -rhs , NormExpr())
+# MatrixFuncVar--AffExpr
+(+)(lhs::MatrixFuncVar,rhs::AffExpr) = ScalarExpr(concat(lhs), copy(rhs), NormExpr())
+(-)(lhs::MatrixFuncVar,rhs::AffExpr) = ScalarExpr(concat(lhs),     -rhs , NormExpr())
+# MatrixFuncVar--AbstractArray{T,2}
+function (*){T<:Number}(lhs::MatrixFuncVar,rhs::AbstractArray{T,2})
+    issym(rhs) || error("Matrix must be symmetric")
+    DualExpr(concat(lhs), concat(rhs), spzeros(size(rhs)...))
+end
+# MatrixFuncVar--MatrixFuncVar
+(+)(lhs::MatrixFuncVar,rhs::MatrixFuncVar) = ScalarExpr(concat(lhs, rhs), AffExpr(), NormExpr())
+(-)(lhs::MatrixFuncVar,rhs::MatrixFuncVar) = ScalarExpr(concat(lhs,-rhs), AffExpr(), NormExpr())
+# MatrixFuncVar--NormExpr
+(+)(lhs::MatrixFuncVar,rhs::NormExpr) = ScalarExpr(concat(lhs), AffExpr(), copy(rhs))
+(-)(lhs::MatrixFuncVar,rhs::NormExpr) = ScalarExpr(concat(lhs), AffExpr(),     -rhs )
+# MatrixFuncVar--ScalarExpr
+(+)(lhs::MatrixFuncVar,rhs::ScalarExpr) = ScalarExpr(concat(lhs,      rhs.matvars ), copy(rhs.aff), copy(rhs.normexpr))
+(-)(lhs::MatrixFuncVar,rhs::ScalarExpr) = ScalarExpr(concat(lhs,map(-,rhs.matvars)),     -rhs.aff ,     -rhs.normexpr )
+
+# NormExpr
+(-)(v::NormExpr) = NormExpr(copy(v.vars), -v.coeffs, copy(v.form))
+# NormExpr--Number
+(+)(lhs::NormExpr,rhs::Number)  = ScalarExpr(MatrixFuncVar[], AffExpr( rhs), lhs)
+(-)(lhs::NormExpr,rhs::Number)  = ScalarExpr(MatrixFuncVar[], AffExpr(-rhs), lhs)
+(*)(lhs::NormExpr,rhs::Number)  = 
+    ( rhs == 0 ? NormExpr(lhs.form) : NormExpr(copy(lhs.vars), lhs.coeffs*rhs, lhs.form) )
+(/)(lhs::NormExpr,rhs::Number)  = NormExpr(lhs.vars, lhs.coeffs/rhs, lhs.form)
+# NormExpr--Variable
+(+)(lhs::NormExpr,rhs::Variable) = ScalarExpr(MatrixFuncVar[], convert(AffExpr, rhs), lhs)
+(-)(lhs::NormExpr,rhs::Variable) = ScalarExpr(MatrixFuncVar[],                 -rhs,  lhs)
+# NormExpr--AffExpr
+(+)(lhs::NormExpr,rhs::AffExpr) = ScalarExpr(MatrixFuncVar[],  rhs, lhs)
+(-)(lhs::NormExpr,rhs::AffExpr) = ScalarExpr(MatrixFuncVar[], -rhs, lhs)
+# NormExpr--NormExpr
+(+)(lhs::NormExpr,rhs::NormExpr) = NormExpr(concat(lhs.vars,rhs.vars), vcat(lhs.coeffs, rhs.coeffs), vcat(lhs.form,rhs.form))
+(-)(lhs::NormExpr,rhs::NormExpr) = NormExpr(concat(lhs.vars,rhs.vars), vcat(lhs.coeffs,-rhs.coeffs), vcat(lhs.form,rhs.form))
+# NormExpr--MatrixFuncVar
+(+)(lhs::NormExpr,rhs::MatrixFuncVar) = ScalarExpr(concat(+rhs), AffExpr(), copy(lhs))
+(-)(lhs::NormExpr,rhs::MatrixFuncVar) = ScalarExpr(concat(-rhs), AffExpr(), copy(lhs))
+# NormExpr-ScalarExpr
+(+)(lhs::NormExpr,rhs::ScalarExpr) = ScalarExpr( copy(rhs.matvars), copy(rhs.aff), lhs+rhs.normexpr)
+(-)(lhs::NormExpr,rhs::ScalarExpr) = ScalarExpr(map(-,rhs.matvars),     -rhs.aff , lhs-rhs.normexpr)
+
+# ScalarExpr
+(-)(lhs::ScalarExpr) = ScalarExpr(map(-,lhs.matvars), -lhs.aff, -lhs.normexpr)
+# ScalarExpr--Number
+(+)(lhs::ScalarExpr,rhs::Number) = ScalarExpr(        copy(lhs.matvars), lhs.aff+rhs, copy(lhs.normexpr))
+(-)(lhs::ScalarExpr,rhs::Number) = ScalarExpr(        copy(lhs.matvars), lhs.aff-rhs, copy(lhs.normexpr))
+(*)(lhs::ScalarExpr,rhs::Number) = ScalarExpr(map(x->x*rhs,lhs.matvars), lhs.aff*rhs, lhs.normexpr*rhs)
+(/)(lhs::ScalarExpr,rhs::Number) = ScalarExpr(map(x->x/rhs,lhs.matvars), lhs.aff/rhs, lhs.normexpr/rhs)
+# ScalarExpr--Variable
+(+)(lhs::ScalarExpr,rhs::Variable) = ScalarExpr(copy(lhs.matvars), lhs.aff+rhs, copy(lhs.normexpr))
+(-)(lhs::ScalarExpr,rhs::Variable) = ScalarExpr(copy(lhs.matvars), lhs.aff-rhs, copy(lhs.normexpr))
+# ScalarExpr--AffExpr
+(+)(lhs::ScalarExpr,rhs::AffExpr) = ScalarExpr(copy(lhs.matvars), lhs.aff+rhs, copy(lhs.normexpr))
+(-)(lhs::ScalarExpr,rhs::AffExpr) = ScalarExpr(copy(lhs.matvars), lhs.aff-rhs, copy(lhs.normexpr))
+# ScalarExpr--AbstractArray{T,2}
+function (*){T<:Number}(lhs::ScalarExpr,rhs::AbstractArray{T,2})
+    isequal(lhs.normexpr,NormExpr()) || error("Cannot multiply norm expression by a matrix")
+    issym(rhs) || error("Matrix must by symmetric")
+    DualExpr(concat(lhs.matvars,lhs.aff.vars), concat([rhs for c in lhs.matvars],[c*rhs for c in lhs.aff.coeffs]), lhs.aff.constant*rhs)
+end
+# ScalarExpr--MatrixFuncVar
+(+)(lhs::ScalarExpr,rhs::MatrixFuncVar) = ScalarExpr(concat(lhs.matvars, rhs), copy(lhs.aff), copy(lhs.normexpr))
+(-)(lhs::ScalarExpr,rhs::MatrixFuncVar) = ScalarExpr(concat(lhs.matvars,-rhs), copy(lhs.aff), copy(lhs.normexpr))
+# ScalarExpr-NormExpr
+(+)(lhs::ScalarExpr,rhs::NormExpr) = ScalarExpr(copy(lhs.matvars), copy(lhs.aff), lhs.normexpr+rhs)
+(-)(lhs::ScalarExpr,rhs::NormExpr) = ScalarExpr(copy(lhs.matvars), copy(lhs.aff), lhs.normexpr-rhs)
+
+# ScalarExpr--ScalarExpr
+(+)(lhs::ScalarExpr,rhs::ScalarExpr) = ScalarExpr(concat(lhs.matvars, rhs.matvars), lhs.aff+rhs.aff, lhs.normexpr+rhs.normexpr)
+(-)(lhs::ScalarExpr,rhs::ScalarExpr) = ScalarExpr(concat(lhs.matvars,-rhs.matvars), lhs.aff-rhs.aff, lhs.normexpr-rhs.normexpr)
+
+for sgn in (:<=, :(==), :>=, :(.<=), :(.>=))
+    @eval begin 
+        # Number
+        # Number--MatrixVar
+        function $(sgn)(lhs::Number, rhs::MatrixVar)
+            lhs == 0.0 || error("Cannot use scalar bound unless it is zero")
+            MatrixConstraint(-rhs, $(quot(sgn)))
+        end
+        # Number--SDPVar
+        function $(sgn)(lhs::Number, rhs::SDPVar)
+            lhs == 0.0 || error("Cannot use scalar bound unless it is zero")
+            MatrixConstraint(-rhs, $(quot(sgn)))
+        end    
+        # Number--MatrixExpr
+        function $(sgn)(lhs::Number, rhs::MatrixExpr)
+            lhs == 0.0 || error("Cannot use scalar bound unless it is zero")
+            MatrixConstraint(-rhs, $(quot(sgn)))
+        end
+    # Number--DualExpr
+        function $(sgn)(lhs::Number,rhs::DualExpr)
+            lhs == 0.0 || error("Cannot use scalar bound unless it is zero")
+            DualConstraint(-rhs, $(quot(sgn)))
+        end
+        # AbstractArray{T,2}
+        # AbstractArray{T,2}--DualExpr
+        $(sgn){T<:Number}(lhs::AbstractArray{T,2}, rhs::DualExpr) = DualConstraint(lhs-rhs, $(quot(sgn)))
+        # AbstractArray{T,2}--MatrixVar
+        $(sgn){T<:Number}(lhs::AbstractArray{T,2}, rhs::MatrixVar) = MatrixConstraint(lhs-rhs, $(quot(sgn)))
+        # AbstractArray{T,2}--SDPVar
+        $(sgn){T<:Number}(lhs::AbstractArray{T,2}, rhs::SDPVar) = MatrixConstraint(lhs-rhs, $(quot(sgn)))
+        # AbstractArray{T,2}--MatrixExpr
+        $(sgn){T<:Number}(lhs::AbstractArray{T,2}, rhs::MatrixExpr) = MatrixConstraint(lhs-rhs, $(quot(sgn)))
+        # MatrixVar
+        # MatrixVar--Number
+        function $(sgn)(lhs::MatrixVar, rhs::Number)
+            rhs == 0.0 || error("Incompatible dimensions")
+            MatrixConstraint(lhs, $(quot(sgn)))
+        end
+        # MatrixVar--AbstractArray{T}
+        $(sgn){T<:Number}(lhs::MatrixVar, rhs::AbstractArray{T}) = MatrixConstraint(lhs-rhs, $(quot(sgn)))
+        # MatrixVar--SDPVar
+        $(sgn)(lhs::MatrixVar, rhs::SDPVar) = MatrixConstraint(lhs-rhs, $(quot(sgn)))
+        # MatrixVar--MatrixExpr
+        # $(sgn)(lhs::MatrixVar, rhs::MatrixExpr) = MatrixConstraint(lhs-rhs, $(quot(sgn)))
+        # SDPVar
+        # SDPVar--Number
+        function $(sgn)(lhs::SDPVar, rhs::Number)
+            rhs == 0.0 || error("Incompatible dimensions")
+            MatrixConstraint(lhs, $(quot(sgn)))
+        end
+        function $(sgn)(lhs::MatrixVar, rhs::Number)
+            rhs == 0.0 || error("Cannot use scalar bound unless it is zero")
+            MatrixConstraint(lhs, $(quot(sgn)))
+        end
+        # SDPVar--AbstractArray{T,2}
+        $(sgn){T<:Number}(lhs::SDPVar, rhs::AbstractArray{T,2}) = MatrixConstraint(lhs-rhs, $(quot(sgn)))
+        # SDPVar--UniformScaling
+         $(sgn)(lhs::SDPVar, rhs::UniformScaling) = MatrixConstraint(lhs-rhs, $(quot(sgn)))
+        # SDPVar--SDPVar
+        $(sgn)(lhs::SDPVar, rhs::SDPVar) = MatrixConstraint(lhs-rhs, $(quot(sgn)))
+        # SDPVar--MatrixExpr
+        $(sgn)(lhs::SDPVar, rhs::MatrixExpr) = MatrixConstraint(lhs-rhs, $(quot(sgn)))
+        # MatrixExpr
+        # MatrixExpr--Number
+        # function $(sgn)(lhs::MatrixExpr,rhs::Number)
+            # rhs == 0.0 || error("Cannot use scalar bound unless it is zero")
+            # MatrixConstraint(lhs, $(quot(sgn)))
+        # end
+        # MatrixExpr--AbstractArray{T,2}
+        # $(sgn){T<:Number}(lhs::MatrixExpr, rhs::AbstractArray{T,2}) = 
+            # MatrixConstraint(lhs-rhs, $(quot(sgn)))
+        # MatrixExpr--UniformScaling
+        $(sgn)(lhs::MatrixExpr, rhs::UniformScaling) =
+            MatrixConstraint(lhs-rhs, $(quot(sgn)))
+        # MatrixExpr--SDPVar
+        $(sgn)(lhs::MatrixExpr, rhs::SDPVar) = MatrixConstraint(lhs-rhs, $(quot(sgn)))
+        # MatrixExpr--MatrixExpr
+        # $(sgn)(lhs::MatrixExpr, rhs::MatrixExpr) = MatrixConstraint(lhs-rhs, $(quot(sgn)))
+        # DualExpr--Number
+        function $(sgn)(lhs::DualExpr,rhs::Number)
+            rhs == 0.0 || error("Cannot use scalar bound unless it is zero")
+            DualConstraint(lhs, $(quot(sgn)))
+        end
+        # DualExpr--AbstractArray{T,2}
+        $(sgn){T<:Number}(lhs::DualExpr, rhs::AbstractArray{T,2}) = DualConstraint(lhs-rhs, $(quot(sgn)))
+        # DualExpr--DualExpr
+        $(sgn)(lhs::DualExpr, rhs::DualExpr) = DualConstraint(lhs-rhs, $(quot(sgn)))
+    end
+end
+
+for ltype in (:Number, :Variable, :AffExpr, :MatrixFuncVar, :NormExpr, :ScalarExpr)
+    for rtype in (:Number, :Variable, :AffExpr, :MatrixFuncVar, :NormExpr, :ScalarExpr)
+        if !(ltype in [:Number, :Variable, :AffExpr]) ||
+           !(rtype in [:Number, :Variable, :AffExpr]) # don't overwrite existing ones
+            @eval begin
+                (<=)(lhs::$(ltype), rhs::$(rtype)) = PrimalConstraint(lhs-rhs, -Inf, 0.0)
+                (==)(lhs::$(ltype), rhs::$(rtype)) = PrimalConstraint(lhs-rhs,  0.0, 0.0)
+                (>=)(lhs::$(ltype), rhs::$(rtype)) = PrimalConstraint(lhs-rhs,  0.0, Inf)
+
+            end
+        end
+    end
+end
+
+function (<=)(lhs::Number, rhs::MatrixExpr)
+    !(lhs == 0) && !(issym(rhs)) && error("Incompatible dimensions")
+    return MatrixConstraint(rhs, :>=)
+end
+function (<=)(lhs::MatrixExpr, rhs::Number)
+    !(rhs == 0) && !(issym(lhs)) && error("Incompatible dimensions")
+    return MatrixConstraint(-lhs, :>=)
+end
+function (==)(lhs::Number, rhs::MatrixExpr)
+    !(lhs == 0) && !(issym(rhs)) && error("Incompatible dimensions")
+    return MatrixConstraint(rhs, :(==))
+end
+function (==)(lhs::MatrixExpr, rhs::Number)
+    rhs == 0 || error("Incompatible dimensions")
+    return MatrixConstraint(lhs, :(==))
+end
+function (>=)(lhs::Number, rhs::MatrixExpr)
+    !(lhs == 0) && !(issym(rhs)) && error("Incompatible dimensions")
+    return MatrixConstraint(-rhs, :>=)
+end
+function (>=)(lhs::MatrixExpr, rhs::Number)
+    !(rhs == 0) && !(issym(lhs)) && error("Incompatible dimensions")
+    return MatrixConstraint(lhs, :>=)
+end
+function (.<=)(lhs::Number, rhs::MatrixExpr)
+    lhs == 0 || error("Incompatible dimensions")
+    return MatrixConstraint(rhs, :.>=)
+end
+function (.<=)(lhs::MatrixExpr, rhs::Number)
+    rhs == 0 || error("Incompatible dimensions")
+    return MatrixConstraint(lhs, :.<=)
+end
+function (.>=)(lhs::Number, rhs::MatrixExpr)
+    lhs == 0 || error("Incompatible dimensions")
+    return MatrixConstraint(rhs, :.<=)
+end
+function (.>=)(lhs::MatrixExpr, rhs::Number)
+    rhs == 0 || error("Incompatible dimensions")
+    return MatrixConstraint(lhs, :.>=)
+end
+
+# >= and <= reserved for SDP constraints, .>= and .<= for componentwise
+for ltype in (:AbstractArray, :Variable, :AffExpr, :MatrixVar, :MatrixExpr, :MatrixFuncVar, :NormExpr, :ScalarExpr)
+    @eval begin
+        function (<=)(lhs::$(ltype), rhs::MatrixExpr)
+            terms = rhs - lhs
+            issym(terms) || error("Semidefinite constraint must be symmetric")
+            return MatrixConstraint(terms, :>=)
+        end
+        function (<=)(lhs::MatrixExpr, rhs::$(ltype))
+            terms = rhs - lhs
+            issym(terms) || error("Semidefinite constraint must be symmetric")
+            return MatrixConstraint(terms, :>=)
+        end
+        function (>=)(lhs::$(ltype), rhs::MatrixExpr)
+            terms = lhs - rhs
+            issym(terms) || error("Semidefinite constraint must be symmetric")
+            return MatrixConstraint(terms, :>=)
+        end
+        function (>=)(lhs::MatrixExpr, rhs::$(ltype))
+            terms = lhs - rhs
+            issym(terms) || error("Semidefinite constraint must be symmetric")
+            return MatrixConstraint(terms, :>=)
+        end
+        (==)(lhs::$(ltype), rhs::MatrixExpr) = MatrixConstraint(rhs-lhs, :(==))
+        (==)(lhs::MatrixExpr, rhs::$(ltype)) = MatrixConstraint(rhs-lhs, :(==))
+        (.<=)(lhs::$(ltype), rhs::MatrixExpr) = MatrixConstraint(rhs-lhs, :.>=)
+        (.<=)(lhs::MatrixExpr, rhs::$(ltype)) = MatrixConstraint(lhs-rhs, :.<=)
+        (.>=)(lhs::$(ltype), rhs::MatrixExpr) = MatrixConstraint(rhs-lhs, :.<=)
+        (.>=)(lhs::MatrixExpr, rhs::$(ltype)) = MatrixConstraint(lhs-rhs, :.>=)
+    end
+end
+
+function dot(x::AbstractArray, y::MatrixExpr)
+    (size(x,1) == size(y,1) && size(x,2) == size(y,2)) || error("Incompatible sizes")
+    ret = ScalarExpr()
+    for i in 1:size(x,1), j in 1:size(x,2)
+        ret += x[i,j] * y[i,j]
+    end
+    return ret
+end
+dot(x::MatrixExpr, y::AbstractArray) = dot(y,x)
+dot(x::MatrixVar,y::AbstractArray) = dot(convert(MatrixExpr,x),y)
+dot(x::AbstractArray, y::MatrixVar) = dot(y,x)

--- a/src/sdp_operators.jl
+++ b/src/sdp_operators.jl
@@ -486,22 +486,16 @@ end
 for sgn in (:<=, :(==), :>=, :(.<=), :(.>=))
     @eval begin 
         # Number
-        # Number--MatrixVar
-        function $(sgn)(lhs::Number, rhs::MatrixVar)
-            lhs == 0.0 || error("Cannot use scalar bound unless it is zero")
-            MatrixConstraint(-rhs, $(quot(sgn)))
+        for rtype in [:MatrixVar, :SDPVar, :MatrixExpr]
+            @eval begin
+                function $(sgn)(lhs::Number, rhs::MatrixVar)
+                    lhs == 0.0 || error("Cannot use scalar bound unless it is zero")
+                    MatrixConstraint(-rhs, $(quot(sgn)))
+                end
+            end
         end
-        # Number--SDPVar
-        function $(sgn)(lhs::Number, rhs::SDPVar)
-            lhs == 0.0 || error("Cannot use scalar bound unless it is zero")
-            MatrixConstraint(-rhs, $(quot(sgn)))
-        end    
-        # Number--MatrixExpr
-        function $(sgn)(lhs::Number, rhs::MatrixExpr)
-            lhs == 0.0 || error("Cannot use scalar bound unless it is zero")
-            MatrixConstraint(-rhs, $(quot(sgn)))
-        end
-    # Number--DualExpr
+
+        # Number--DualExpr
         function $(sgn)(lhs::Number,rhs::DualExpr)
             lhs == 0.0 || error("Cannot use scalar bound unless it is zero")
             DualConstraint(-rhs, $(quot(sgn)))

--- a/src/sdp_solve.jl
+++ b/src/sdp_solve.jl
@@ -39,7 +39,7 @@ function parseScalarExpr(m::Model, d::ScalarExpr; debug=false)
     return scalvaridx, scalcoefidx, matvaridx, matcoefidx, bnd_offset
 end
 
-function addPrimalConstraint(m::Model,c::PrimalConstraint; debug=true)
+function addPrimalConstraint(m::Model,c::PrimalConstraint; debug=false)
     scalvaridx, scalcoefidx, matvaridx, matcoefidx, bnd_offset = 
         parseScalarExpr(m, c.terms;debug=debug)
 

--- a/src/sdp_solve.jl
+++ b/src/sdp_solve.jl
@@ -1,0 +1,443 @@
+parseScalarExpr(m::Model,d::MatrixFuncVar;debug=false) = parseScalarExpr(m,convert(ScalarExpr,d);debug=debug)
+function parseScalarExpr(m::Model, d::ScalarExpr; debug=false)
+    scalvaridx  = Int[x.col for x in d.aff.vars]
+    scalcoefidx = d.aff.coeffs
+    matdict = Dict{Int64,AbstractArray}()
+    bnd_offset = d.aff.constant
+    for (it,el) in enumerate(d.matvars)
+        expr = el.expr
+        sinfo = m.sdpdata.solverinfo[expr.elem[1].index]
+        sgn = (sinfo.psd ? +1.0 : -1.0)
+        if el.func == :trace
+            all(x->isa(x,SDPVar),expr.elem) || error("Cannot have nested structure inside trace operator")
+            mat = sgn*expr.post[1] * expr.pre[1] # exploit cyclic property of trace
+            (!isa(mat,UniformScaling) && countnz(mat) == 0) && continue
+            isa(mat,UniformScaling) && (mat *= speye(size(el.expr)...))
+            debug && println("trace matrix: $mat")
+        elseif el.func == :ref # post matrix and constant will be empty
+            @assert expr.post[1] == 𝕀
+            mat = sgn*expr.pre[1]
+            countnz(mat) == 0 && continue
+            debug && println("ref matrix: $mat")
+        else
+            error("Only trace operator or reference is currently supported")
+        end
+        if haskey(matdict, sinfo.id)
+            matdict[sinfo.id] += mat
+        else
+            matdict[sinfo.id]  = mat
+        end
+        bnd_offset += sgn*trace(mat*sinfo.offset) + trace(el.expr.constant)
+    end
+    matvaridx  = Array(Int, length(keys(matdict)))
+    matcoefidx = Array(Int, length(keys(matdict)))
+    for (it,key) in enumerate(keys(matdict))
+        matvaridx[it] = key
+        idx = addsdpmatrix!(m.internalModel,matdict[key])
+        matcoefidx[it] = idx
+    end
+    return scalvaridx, scalcoefidx, matvaridx, matcoefidx, bnd_offset
+end
+
+function addPrimalConstraint(m::Model,c::PrimalConstraint; debug=true)
+    scalvaridx, scalcoefidx, matvaridx, matcoefidx, bnd_offset = 
+        parseScalarExpr(m, c.terms;debug=debug)
+
+    nexpr = c.terms.normexpr
+    if length(nexpr.vars) > 0
+        if c.lb == -Inf
+            all(x->(x>=0), nexpr.coeffs) || error("No support for constraints of the form ||x|| >= rhs")
+        elseif c.ub ==  Inf
+            all(x->(x<=0), nexpr.coeffs) || error("No support for constraints of the form ||x|| >= rhs")
+        else
+            error("Cannot have equality or range constraints with normed terms")
+        end
+        for it in 1:length(nexpr.vars)
+            if nexpr.form[it] == :norm2
+                idx = addnorm2(m, nexpr.vars[it])
+                push!(scalvaridx, idx)
+                push!(scalcoefidx, nexpr.coeffs[it])
+            elseif nexpr.form[it] == :normfrob
+                idx = addnormfrob(m, nexpr.vars[it])
+                push!(scalvaridx, idx)
+                push!(scalcoefidx, nexpr.coeffs[it])
+            elseif nexpr.form[it] == :abs
+                idx = addabs(m, nexpr.vars[it])
+                push!(scalvaridx, idx)
+                push!(scalcoefidx, nexpr.coeffs[it])
+            end   
+        end
+    end
+
+    if debug
+        println("matvaridx = $matvaridx")
+        println("scalvaridx = $scalvaridx")
+        println("scalcoefidx = $scalcoefidx")
+        println("lb = $(c.lb-bnd_offset)")
+        println("ub = $(c.ub-bnd_offset)")
+    end
+    addsdpconstr!(m.internalModel,
+                 matvaridx,
+                 matcoefidx,
+                 scalvaridx,
+                 scalcoefidx,
+                 c.lb-bnd_offset,
+                 c.ub-bnd_offset)
+    return nothing
+end
+
+function addInternalVar(m::Model, dim::Int64)
+    idx = addsdpvar!(m.internalModel, dim)
+    var = SDPVar(m,length(m.sdpdata.sdpvar)+1,dim)
+    push!(m.sdpdata.sdpvar, var)
+    push!(m.sdpdata.lb, 0.0)
+    push!(m.sdpdata.ub, Inf)
+    push!(m.sdpdata.varname, "_internalvar")
+    push!(m.sdpdata.solverinfo, SolverInfo(idx,true,spzeros(dim,dim)))
+    return var
+end
+
+function addMatrixConstraint(model::Model,d::MatrixConstraint)
+    # issym(d.terms) || error("Matrix expression must be symmetric")
+    m, n = size(d.terms,1), size(d.terms,2)
+    if d.sense == :(==)
+        for i in 1:m, j in 1:n
+            addPrimalConstraint(model, d.terms[i,j] == 0.0)
+        end
+    elseif d.sense == :(>=)
+        _internalvar = addInternalVar(model,n)
+        for i in 1:m, j in i:n
+            addPrimalConstraint(model, d.terms[i,j] == _internalvar[i,j])
+        end
+    elseif d.sense == :(<=)
+        _internalvar = addInternalVar(model,n)
+        for i in 1:m, j in i:n
+            addPrimalConstraint(model, -d.terms[i,j] == _internalvar[i,j])
+        end
+    elseif d.sense == :(.>=)
+        for i in 1:m, j in 1:n
+            addPrimalConstraint(model, d.terms[i,j] >= 0.0)
+        end    
+    elseif d.sense == :(.<=)
+        for i in 1:m, j in 1:n
+            addPrimalConstraint(model, d.terms[i,j] <= 0.0)
+        end
+    end
+end
+
+function addDualConstraint(m::Model, d::DualConstraint)
+    issym(d.terms.constant) || error("Dual constant matrix must be symmetric")
+    n  = size(d.terms.constant, 1)
+    for c in d.terms.coeffs
+        issym(c) || error("Dual constraint must be symmetric")
+        size(c,1) == n || error("Coefficient matrices must be of compatible sizes")
+    end
+    if d.sense == :(==)  
+        for i in 1:n, j in i:n
+            con = d.terms.constant[i,j]
+            coef = map(x->x[i,j], d.terms.coeffs)
+            addconstr!(m.internalModel,[v.col for v in d.terms.vars],coef,-con,-con)
+        end
+    elseif d.sense == :(>=)
+        _internalvar = addInternalVar(m,n)
+        for i in 1:n, j in i:n
+            terms = ScalarExpr(d.terms.constant[i,j])
+            for it in 1:length(d.terms.vars)
+                terms += d.terms.vars[it] * d.terms.coeffs[it][i,j]
+            end
+            addPrimalConstraint(m, terms ==   _internalvar[i,j] )
+        end
+    elseif d.sense == :(<=)
+        _internalvar = addInternalVar(m,n)
+        for i in 1:n, j in i:n
+            for it in 1:length(d.terms.vars)
+                terms += d.terms.vars[it] * d.terms.coeffs[it][i,j]
+            end
+            addPrimalConstraint(m, terms == -(_internalvar[i,j]))
+        end
+    elseif d.sense == :(.>=)
+        _internalvar = addInternalVar(m,n)  
+        for i in 1:n, j in i:n
+            con = d.terms.constant[i,j]
+            coef = map(x->x[i,j], d.terms.coeffs)
+            addconstr!(m.internalModel,[v.col for v in d.terms.vars],coef,-con,Inf)
+        end
+    elseif d.sense == :(.<=)
+        _internalvar = addInternalVar(m,n)  
+        for i in 1:n, j in i:n
+            con = d.terms.constant[i,j]
+            coef = map(x->x[i,j], d.terms.coeffs)
+            addconstr!(m.internalModel,[v.col for v in d.terms.vars],coef,-Inf,-con)
+        end
+    end
+end
+
+function addInternalScalarVar(m::Model, lb::Float64, ub::Float64)
+    addvar!(m.internalModel, lb, ub, 0.0)
+    # return numvar(m.internalModel) #Mosek.getnumvar(m.internalModel.task)
+    return Mosek.getnumvar(m.internalModel.task)
+end
+
+addabs(m::Model, v::Variable) = addabs(m, convert(AffExpr,v))
+function addabs(m::Model, aff::AffExpr)
+    idx = addInternalScalarVar(m, 0.0, Inf)
+    addconstr!(m.internalModel, vcat([x.col for x in aff.vars], idx),
+                                vcat(aff.coeffs, -1.0),
+                                -Inf,
+                                0.0)
+    addconstr!(m.internalModel, vcat([x.col for x in aff.vars], idx),
+                                vcat(aff.coeffs, 1.0),
+                                0.0,
+                                Inf)
+    return idx
+end
+
+function addnorm2(m::Model, ex::MatrixExpr)
+    sx,sy = size(ex)
+    (sx == 1 || sy == 1) || error("2-norm does not work on matrices")
+    varlist = Int[]
+    for i in 1:max(sx,sy)
+        elem = ex[i]
+        if isa(elem, Variable)
+            push!(varlist, elem.col)
+        elseif isa(elem, AffExpr)
+            if length(elem.vars) == 1 && elem.coeffs[1] == 1.0 && elem.constant == 0.0
+                # a Variable disguised as AffExpr
+                push!(varlist, elem.vars[1].col)
+                continue
+            end
+            _internalvar = addInternalScalarVar(m, -Inf, Inf)
+            push!(varlist, _internalvar)
+            addconstr!(m.internalModel,
+                       vcat(Int[x.col for x in elem.vars], _internalvar), 
+                       vcat(elem.coeffs, -1.0), 
+                       -elem.constant, 
+                       -elem.constant)
+        elseif isa(elem, MatrixFuncVar) || isa(elem, ScalarExpr)
+            _internalvar = addInternalScalarVar(m, -Inf, Inf)
+            push!(varlist, _internalvar)
+            scalvaridx, scalcoefidx, matvaridx, matcoefidx, bnd_offset = 
+                parseScalarExpr(m,elem)
+            addsdpconstr!(m.internalModel,
+                         matvaridx,
+                         matcoefidx,
+                         vcat(scalvaridx, _internalvar),
+                         vcat(scalcoefidx, -1.0),
+                         -bnd_offset,
+                         -bnd_offset)
+
+        else 
+            error("Unrecognized element of type $(typeof(elem))")
+        end
+    end
+    _internalvar = addInternalScalarVar(m, 0.0, Inf)
+    addquadconstr!(m.internalModel, Int[],
+                                    Float64[],
+                                    vcat(varlist, _internalvar),
+                                    vcat(varlist, _internalvar),
+                                    vcat(fill(1.0, length(varlist)), -1.0),
+                                    '<',
+                                    0.0)
+    return _internalvar
+end
+
+function addnormfrob(m::Model, ex::MatrixExpr)
+    sx,sy = size(ex)
+    varlist = Int[]
+    for i in 1:sx, j in 1:sy
+        elem = ex[i,j]
+        if isa(elem, Variable)
+            push!(varlist, elem.col)
+        elseif isa(elem, AffExpr)
+            if length(elem.vars) == 1 && elem.coeffs[1] == 1.0 && elem.constant == 0.0
+                # a Variable disguised as AffExpr
+                push!(varlist, elem.vars[1].col)
+                continue
+            end
+            _internalvar = addInternalScalarVar(m, -Inf, Inf)
+            push!(varlist, _internalvar)
+            addconstr!(m.internalModel,
+                       vcat(Int[x.col for x in elem.vars], _internalvar), 
+                       vcat(elem.coeffs, -1.0), 
+                       -elem.constant, 
+                       -elem.constant)
+        elseif isa(elem, MatrixFuncVar) || isa(elem, ScalarExpr)
+            _internalvar = addInternalScalarVar(m, -Inf, Inf)
+            push!(varlist, _internalvar)
+            scalvaridx, scalcoefidx, matvaridx, matcoefidx, bnd_offset = 
+                parseScalarExpr(m,elem)
+            addsdpconstr!(m.internalModel,
+                         matvaridx,
+                         matcoefidx,
+                         vcat(scalvaridx, _internalvar),
+                         vcat(scalcoefidx, -1.0),
+                         -bnd_offset,
+                         -bnd_offset)
+
+        else 
+            error("Unrecognized element of type $(typeof(elem))")
+        end
+    end
+    _internalvar = addInternalScalarVar(m, 0.0, Inf)
+    addquadconstr!(m.internalModel, Int[],
+                                    Float64[],
+                                    vcat(varlist, _internalvar),
+                                    vcat(varlist, _internalvar),
+                                    vcat(fill(1.0, length(varlist)), -1.0),
+                                    '<',
+                                    0.0)
+    return _internalvar
+end
+
+function setupSDPVar(m::Model, it::Int64)
+    var   = m.sdpdata.sdpvar[it]
+    if isa(var, SDPVar)
+        lb    = m.sdpdata.lb[it]
+        ub    = m.sdpdata.ub[it]
+        sinfo = m.sdpdata.solverinfo[it]
+        sinfo.id = addsdpvar!(m.internalModel, var.dim)
+        if lb == 0.0 || all(x->(x==0),lb)
+            sinfo.psd = true
+            sinfo.offset = spzeros(size(var)...)
+            if ub == Inf || all(x->(x==Inf),ub) # X >= 0
+                # do nothing
+            else
+                if ub == 0.0 || all(x->(x==0),ub) # X == 0
+                    addMatrixConstraint(m, var == spzeros(size(var)...))
+                else # 0 <= X <= C
+                    addMatrixConstraint(m, var <= ub)
+                end
+            end
+        elseif ub == 0.0 || all(x->(x==0),ub)
+            sinfo.psd = false
+            sinfo.offset = spzeros(size(var)...)
+            if lb == -Inf || all(x->(x==-Inf),lb) # X <= 0
+                # do nothing (here, at least)
+            else # C <= X <= 0
+                addMatrixConstraint(m, var >= lb)
+            end
+        else
+            if lb == -Inf || all(x->(x==-Inf),lb) # X <= D
+                sinfo.psd    = false
+                sinfo.offset = ub
+            elseif ub == Inf || all(x->(x==Inf),ub) # X >= C
+                sinfo.psd    = true
+                sinfo.offset = lb
+            else # C <= X <= D
+                sinfo.psd    = true
+                sinfo.offset = lb
+                addMatrixConstraint(m, var <= ub)
+            end
+        end
+    end
+end
+
+function solveSDP(m::Model)
+    for j = 1:m.numCols
+        m.colCat[j] == INTEGER && error("Integer variables present in SDP problem")
+    end
+
+    sdp = m.sdpdata
+    # make this solver-independent when CSDP is working
+    m.solver = Mosek.MosekSolver()
+    m.internalModel = model(m.solver)
+
+    # add linear (scalar) constraints
+    f, rowlb, rowub = prepProblemBounds(m)
+    A = prepConstrMatrix(m)
+    loadproblem!(m.internalModel, A, m.colLower, m.colUpper, f, rowlb, rowub, m.objSense)
+
+    for it in 1:length(sdp.sdpvar)
+        setupSDPVar(m, it)
+    end
+
+    # TODO: make this work for nested structure
+    # TODO: deal with bounds changing in objective
+    scalcost = zeros(Float64, m.numCols)
+    for (it,vari) in enumerate(sdp.sdpobj.aff.vars)
+        scalcost[vari.col] = sdp.sdpobj.aff.coeffs[it]
+    end
+    nexpr = sdp.sdpobj.normexpr
+    auxcoef = Float64[]
+    if length(nexpr.vars) > 0
+        if m.objSense == :Min
+            mapreduce(x->(x>=0), &, nexpr.coeffs) || error("Cannot minimize -||x||")
+        elseif m.objSense == :Max
+            mapreduce(x->(x<=0), &, nexpr.coeffs) || error("Cannot maximize ||x||")
+        else
+            error("Cannot have equality or range constraints with normed terms")
+        end
+        for it in 1:length(nexpr.vars)
+            if nexpr.form[it] == :norm2
+                idx = addnorm2(m, nexpr.vars[it])
+                push!(auxcoef, nexpr.coeffs[it])
+            elseif nexpr.form[it] == :normfrob
+                idx = addnormfrob(m, nexpr.vars[it])
+                push!(auxcoef, nexpr.coeffs[it])
+            elseif nexpr.form[it] == :abs
+                idx = addabs(m, nexpr.vars[it])
+                push!(auxcoef, nexpr.coeffs[it])
+            end   
+        end
+    end
+    matvaridx  = Int[]
+    matcoefidx = Int[]
+    for (it,var) in enumerate(sdp.sdpobj.matvars)
+        @assert length(var.expr.elem) == 1 # TODO: deal with nested structure
+        sgn = sdp.solverinfo[it].psd ? +1.0 : -1.0
+        mat = var.expr.pre[1]
+        if isa(var.expr.pre[1], UniformScaling)
+            idx = addsdpmatrix!(m.internalModel, sgn*mat.λ*speye(size(var.expr.elem[1])...))
+        else
+            idx = addsdpmatrix!(m.internalModel, sgn*mat) # TODO: deal with post case as well
+        end
+        push!(matcoefidx, idx)
+        push!(matvaridx, sdp.solverinfo[it].id)
+    end
+    setsdpobj!(m.internalModel, matvaridx, matcoefidx)
+
+    setobj!(m.internalModel, vcat(scalcost+f, auxcoef))
+    setsense!(m.internalModel,m.objSense)
+
+    # add quadratic terms
+    addQuadratics(m)
+
+    # add primal constraints
+    for c in sdp.primalconstr
+        addPrimalConstraint(m,c)
+    end
+
+    # add matrix constraints
+    for d in sdp.matrixconstr
+        addMatrixConstraint(m,d)
+    end
+
+    # add dual constraints
+    for d in sdp.dualconstr
+        addDualConstraint(m,d)
+    end
+
+    optimize!(m.internalModel)
+    stat = status(m.internalModel)
+
+    if stat == :NotSolved
+        # do nothing
+    elseif stat != :Optimal
+        warn("SDP not solved to optimality, status: $stat")
+    else
+        m.colVal = MathProgBase.getsolution(m.internalModel)
+        sdp.sdpval = Array(AbstractArray, length(sdp.sdpvar))
+        for it in 1:length(sdp.sdpvar)
+            if isa(sdp.sdpvar[it],SDPVar)
+                idx    = sdp.solverinfo[it].id
+                sgn    = sdp.solverinfo[it].psd ? +1.0 : -1.0
+                offset = sdp.solverinfo[it].offset
+                sdp.sdpval[it] = sgn*MathProgBase.getsdpsolution(m.internalModel, idx) + offset
+            elseif isa(sdp.sdpvar[it],MatrixVar)
+                sdp.sdpval[it] = m.colVal[sdp.solverinfo[it].id]
+            end
+        end
+        m.objVal = MathProgBase.getobjval(m.internalModel) + m.obj.aff.constant + sdp.sdpobj.aff.constant
+    end
+    return stat
+end

--- a/src/sdp_utils.jl
+++ b/src/sdp_utils.jl
@@ -1,0 +1,90 @@
+typealias Matrices Union(SDPMatrix, Variable, AffExpr, MatrixFuncVar, ScalarExpr, DualExpr, AbstractArray, Number)
+# typealias Matrices Union(SDPMatrix, AbstractArray, Number)
+
+# add these to deal with cases like [1 ones(1,3)]
+# They are copied from generic version in Base
+vcat(args::Union(AbstractArray,Number)...) = cat(1, args...)
+hcat(args::Union(AbstractArray,Number)...) = cat(2, args...)
+function hvcat(rows::(Int...), as::Union(AbstractArray,Number)...)
+    nbr = length(rows)  # number of block rows
+    rs = cell(nbr)
+    a = 1
+    for i = 1:nbr
+        rs[i] = hcat(as[a:a-1+rows[i]]...)
+        a += rows[i]
+    end
+    vcat(rs...)
+end
+
+function hcat(args::Matrices...)
+    n = length(args)
+    tmp = Array(Matrices, 1, n)
+    for i in 1:n
+        tmp[1,i] = args[i]
+    end
+    return MatrixExpr(tmp)
+end
+
+function vcat(args::Matrices...)
+    m = length(args)
+    tmp = Array(Matrices, m, 1)
+    for i in 1:m
+        tmp[i,1] = args[i]
+    end
+    return MatrixExpr(tmp)
+end
+
+function hvcat(dims::(Int64...,), args::Matrices...)
+    m, n = dims
+    tmp = Array(Matrices, m, n)
+    cnt = 1
+    for i in 1:m
+        for j in 1:n
+            tmp[i,j] = args[cnt]
+            cnt += 1
+        end
+    end
+    return MatrixExpr(tmp)
+end
+
+# internal concatenation function so that vcat/hcat/hvcat can remain user-facing
+function concat(X...)
+    nargs = length(X)
+    isList = map(a->isa(a,Vector) & !issubtype(eltype(a),Number), X)
+    dimsX = map((a->isList[a] ? size(X[a],1) : 1), 1:nargs)
+    dimC = sum(dimsX)
+
+    types = Set{DataType}()
+    for (k,x) in enumerate(X)
+        if isList[k]
+            elt = eltype(x)
+            if isa(elt, UnionType)
+                for it in elt.types
+                    push!(types, it)
+                end
+            else
+                push!(types, elt)
+            end
+        else
+            push!(types, typeof(x))
+        end
+    end
+
+    # I'm not sure what the best approach is here, but I think that since this
+    # is all internal code, I think this will work fine with ScalarExpr etc.
+    # typeC = promote_type(types...)
+    typeC = Union(types...)
+    C = Array(typeC, dimC)
+
+    range = 1
+    for k=1:nargs
+        nextrange = range + dimsX[k]
+        if dimsX[k] == 1 && !isList[k]
+            C[range] = X[k]
+        else
+            C[range:(nextrange-1)] = X[k]
+        end
+        range = nextrange
+    end
+    return C
+end

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -3,6 +3,9 @@ function solve(m::Model;IpoptOptions::Dict=Dict(),load_model_only=false, suppres
     if m.nlpdata != nothing
         return solveIpopt(m, options=IpoptOptions, suppress_warnings=suppress_warnings)
     end
+    if m.sdpdata != nothing
+        return solveSDP(m)
+    end
     # Analyze model to see if any integers
     anyInts = false
     for j = 1:m.numCols

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -33,4 +33,3 @@ function Base.empty!{T}(v::IndexedVector{T})
     end
     v.nnz = 0
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,5 +35,10 @@ if Pkg.installed("Ipopt") != nothing
     include("nonlinear.jl")
 end
 
+if Pkg.installed("Mosek") != nothing
+    println(" Test: sdp.jl")
+    include("sdp.jl")
+end
+
 # hygiene.jl should be run separately
 # hockschittkowski/runhs.jl has additional nonlinear tests

--- a/test/sdp.jl
+++ b/test/sdp.jl
@@ -1,0 +1,1871 @@
+#############
+# Expressions
+#############
+
+# Test: * SDP bounds
+#       * Changing objective sense
+#       * getObjectiveValue
+#       * getValue(d::MatrixFuncVar)
+m = Model()
+@defSDPVar(m, 0 <= X[3] <= 1/2*eye(3,3))
+@defSDPVar(m, -ones(5,5) <= Y[5] <= 2*ones(5,5))
+@defSDPVar(m, Z[4] <= ones(4,4))
+
+addConstraint(m, trace(X) == 1)
+addConstraint(m, trace(Y) == 3)
+addConstraint(m, trace(Z) == -1)
+setObjective(m, :Max, X[1,2] + Y[1,2] + Z[1,2])
+solve(m)
+
+@test_approx_eq_eps getValue(X[1,2]) 0.25 1e-3
+@test_approx_eq_eps getValue(Y[1,2]) 0.6 1e-3
+@test_approx_eq_eps getValue(Z[1,2]) 3.5 1e-3
+@test_approx_eq_eps getObjectiveValue(m) 4.35 1e-3
+
+setObjective(m, :Min, X[1,2] + Y[1,2] + Z[1,2])
+solve(m)
+
+@test_approx_eq_eps getValue(X[1,2]) -0.25 1e-3
+@test_approx_eq_eps getValue(Y[1,2]) 0.6 1e-3
+@test_approx_eq_eps getValue(Z[1,2]) -1.5 1e-3
+@test_approx_eq_eps getObjectiveValue(m) -1.15 1e-3
+
+# Test: * getValue(d::MatrixFuncExpr)
+#       * getValue(d::MatrixExpr)
+#       * getValue(d::SDPVar)
+A = [0.25 -0.25 0.0; -0.25 0.25 0.0; 0.0 0.0 0.5]
+@test_approx_eq_eps norm(getValue(X)-A) 0.0 1e-3
+@test_approx_eq_eps norm(getValue(Y)-0.6*ones(5,5)) 0.0 1e-3
+B = ones(4,4)
+B[1:2,1:2] = -1.5*ones(2,2)
+@test_approx_eq_eps norm(getValue(Z) - B) 0.0 1e-3
+@test_approx_eq_eps norm(getValue([2X eye(3,4); eye(4,3) -3Z+ones(4,4)] + eye(7,7)) -
+        ([2A eye(3,4); eye(4,3) -3B+ones(4,4)] + eye(7,7))) 0.0 1e-3
+
+@test_approx_eq_eps getValue(2X[1,1]+3.5) (2A[1,1]+3.5) 1e-3
+@test_approx_eq_eps getValue(-X[1,3]+2Z[2,4]-1.0) (-A[1,3]+2B[2,4]-1.0) 1e-3
+
+# Test: * getLower(x::SDPVar), getUpper
+@test getLower(X) == 0.0
+@test getUpper(X) == 1/2*eye(3,3)
+@test getLower(Y) == -ones(5,5)
+@test getUpper(Y) == 2*ones(5,5)
+@test getLower(Z) == -Inf
+@test getUpper(Z) == ones(4,4)
+
+# Test: * setLower(x::SDPVar), setUpper
+@test setLower(X) == eye(3,3)
+@test setLower(X) == Inf
+@test getLower(X) == eye(3,3)
+@test getLower(X) == Inf
+@test setLower(Y) == -Inf
+@test setUpper(Y) == 2*ones(5,5)
+@test getLower(Y) == -Inf
+@test getUpper(Y) == 2*ones(5,5)
+@test_throws setUpper(X, ones(2,2))
+@test_throws setUpper(X, 1.0)
+@test_throws setUpper(X, rand(3,3))
+
+# Test * getName(x::SDPVar), setName
+@test getName(X) == "X"
+setName(X, "my new name")
+@test getName(X) == "my new name"
+
+# Test: * @defSDPVar
+@test_throws @defSDPVar(m, psd[2] <= rand(2,2))
+@test_throws @defSDPVar(m, -Inf <= unbounded[3] <= Inf)
+@test_throws @defSDPVar(m, ones(4,4) <= constant[4] <= ones(4,4))
+@test_throws @defSDPVar(m, rand(5,5) <= nonsymmetric[5] <= rand(5,5))
+@test_throws @defSDPVar(m, -1.0 <= nonzero[6] <= 1.0)
+@defSDPVar
+
+###########
+# Operators
+###########
+
+# Number--Number
+# Number--Variable
+# Number--AffExpr
+# Number--DualExpr
+let 
+    m = Model()
+    @defVar(m,x)
+    dual = ones(3,3)*x - 2eye(3,3)
+    @test_throws MethodError 2 + dual
+    @test_throws MethodError 2 - dual
+    expr3 = 2 * dual
+    @test isa(expr3, DualExpr)
+    @test isequal(expr3.vars, {x})
+    @test isequal(expr3.coeffs, {2ones(3,3)})
+    @test expr3.constant == -4eye(3,3)
+    @test_throws Exception 2 / dual
+    @test_throws Exception (2 >= dual)
+    con1 = (eye(3,3) >= dual)
+    @test isequal(con1.terms, eye(3,3)-dual)
+    @test con1.sense == :>=
+    con2 = (eye(3,3) <= dual)
+    @test isequal(con2.terms, eye(3,3)-dual)
+    @test con2.sense == :<=
+    con3 = (eye(3,3) == dual)
+    @test isequal(con3.terms, eye(3,3)-dual)
+    @test con3.sense == :(==)
+end
+# Number--AbstractArray
+# Number--MatrixVar
+let 
+    m = Model()
+    @defMatrixVar(m,X[2,2])
+    @test_throws MethodError 2 + X
+    @test_throws MethodError 2 - X
+    expr3 = -2X
+    @test isa(expr3, MatrixExpr)
+    @test isequal(expr3.elem, {X})
+    @test isequal(expr3.pre, {-2𝕀})
+    @test isequal(expr3.post, {𝕀})
+    @test isequal(expr3.constant, spzeros(2,2))
+    @test_throws MethodError 2/X
+    @test_throws Exception (2 >= X)
+    con1 = (0 >= X)
+    @test isequal(con1.terms, -X)
+    @test con1.sense == :>=
+    con2 = (0 <= X)
+    @test isequal(con2.terms, -X)
+    @test con2.sense == :<=
+    con3 = (0 == X)
+    @test isequal(con3.terms, -X)
+    @test con3.sense == :(==)
+end
+# Number--SDPVar
+let 
+    m = Model()
+    @defSDPVar(m,X[2,2])
+    @test_throws MethodError 2 + X
+    @test_throws MethodError 2 - X
+    expr3 = -2X
+    @test isa(expr3, MatrixExpr)
+    @test isequal(expr3.elem, {X})
+    @test isequal(expr3.pre, {-2𝕀})
+    @test isequal(expr3.post, {𝕀})
+    @test isequal(expr3.constant, spzeros(2,2))
+    @test_throws MethodError 2/X
+    @test_throws Exception (2 >= X)
+    con1 = (0 >= X)
+    @test isequal(con1.terms, -X)
+    @test con1.sense == :>=
+    con2 = (0 <= X)
+    @test isequal(con2.terms, -X)
+    @test con2.sense == :<=
+    con3 = (0 == X)
+    @test isequal(con3.terms, -X)
+    @test con3.sense == :(==)
+end
+# Number--MatrixExpr
+let 
+    m = Model()
+    @defSDPVar(m,X[2,2])
+    expr = [-X ones(2); ones(1,2) -3]
+    @test_throws MethodError 2 + expr
+    @test_throws MethodError 2 - expr
+    expr3 = -2expr
+    @test isa(expr3, MatrixExpr)
+    @test length(expr3.elem) == 1
+    @test isequal(expr3.elem[1][1,1], -X[1,1]+0) # lift to ScalarExpr
+    @test isequal(expr3.elem[1][1,2], -X[1,2]+0)
+    @test isequal(expr3.elem[1][2,1], -X[2,1]+0)
+    @test isequal(expr3.elem[1][2,2], -X[2,2]+0)
+    @test isequal(expr3.elem[1][1,3], 1)
+    @test isequal(expr3.elem[1][2,3], 1)
+    @test isequal(expr3.elem[1][3,1], 1)
+    @test isequal(expr3.elem[1][3,2], 1)
+    @test isequal(expr3.elem[1][3,3], -3)
+    @test isequal(expr3.pre,  {-2𝕀})
+    @test isequal(expr3.post, {𝕀})
+    @test isequal(expr3.constant, spzeros(3,3))
+    @test_throws MethodError 2/expr
+    @test_throws MethodError 2/X
+    @test_throws Exception (2 >= expr)
+    con1 = (0 >= expr)
+    @test isequal(con1.terms, -expr)
+    @test con1.sense == :>=
+    con2 = (0 <= expr)
+    @test isequal(con2.terms, expr)
+    @test con2.sense == :>=
+    con3 = (0 == expr)
+    @test isequal(con3.terms, expr)
+    @test con3.sense == :(==)
+end
+# Number--MatrixFuncVar
+let 
+    m = Model()
+    @defSDPVar(m,X[2,2])
+    expr1 = 2 + trace(X)
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, AffExpr(2.0))
+    @test isequal(expr1.matvars, {trace(X)})
+    @test isequal(expr1.normexpr, NormExpr())
+    expr2 = 2 - trace(X)
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, AffExpr(2.0))
+    @test isequal(expr2.matvars, {-trace(X)})
+    @test isequal(expr2.normexpr, NormExpr())
+    expr3 = 2 * trace(X)
+    @test isa(expr3, MatrixFuncVar)
+    @test isequal(expr3.expr, 2X)
+    @test expr3.func == :trace
+    @test_throws MethodError 2 / trace(X)
+    con1 = (1 >= trace(X))
+    @test isequal(con1.terms, 1-trace(X))
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (1 <= trace(X))
+    @test isequal(con2.terms, 1-trace(X))
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (1 == trace(X))
+    @test isequal(con3.terms, 1-trace(X))
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# Number--NormExpr
+let 
+    m = Model()
+    @defMatrixVar(m,X[2])
+    expr = norm(2X - ones(2))
+    expr1 = 2 + expr
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, AffExpr(2.0))
+    @test isempty(expr1.matvars)
+    @test isequal(expr1.normexpr, expr)
+    expr2 = 2 - expr
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, AffExpr(2.0))
+    @test isempty(expr2.matvars)
+    @test isequal(expr2.normexpr, -expr)
+    expr3 = 2 * expr
+    @test isa(expr3, NormExpr)
+    @test isequal(expr3.vars, {2X-ones(2)})
+    @test isequal(expr3.coeffs, [2.0])
+    @test isequal(expr3.form, [:norm2])
+    @test_throws MethodError 2 / expr
+    con1 = (1 >=  expr)
+    @test isequal(con1.terms, 1-expr)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (1 <= expr)
+    @test isequal(con2.terms, 1-expr)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (1 == expr)
+    @test isequal(con3.terms, 1-expr)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# Number--ScalarExpr
+let 
+    m = Model()
+    @defVar(m,x)
+    @defSDPVar(m,X[2])
+    expr = 2x + 3 - 4trace(X) + norm(2X - ones(2,2))
+    expr1 = 2 + expr
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, 2x + 5)
+    @test isequal(expr1.matvars, {-4trace(X)})
+    @test isequal(expr1.normexpr, norm(2X - ones(2,2)))
+    expr2 = 2 - expr
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, -2x - 1)
+    @test isequal(expr2.matvars, {4trace(X)})
+    @test isequal(expr2.normexpr, -norm(2X - ones(2,2)))
+    expr3 = 2 * expr
+    @test isa(expr3, ScalarExpr)
+    @test isequal(expr3.aff, 4x + 6)
+    @test isequal(expr3.matvars, {-8trace(X)})
+    @test isequal(expr3.normexpr, 2norm(2X - ones(2,2)))
+    @test_throws MethodError 2 / expr
+    con1 = (1 >=  expr)
+    @test isequal(con1.terms, 1-expr)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (1 <= expr)
+    @test isequal(con2.terms, 1-expr)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (1 == expr)
+    @test isequal(con3.terms, 1-expr)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+
+# Variable--Number
+# Variable--Variable
+# Variable--AffExpr
+# Variable--DualExpr
+# Variable--AbstractArray
+let
+    m = Model()
+    @defVar(m,x)
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    @test_throws MethodError x + arr
+    @test_throws MethodError x - arr
+    expr3 = x * arr
+    @test isa(expr3, DualExpr)
+    @test isequal(expr3.vars, {x})
+    @test isequal(expr3.coeffs, {arr})
+    @test isequal(expr3.constant, spzeros(4,4))
+    @test_throws MethodError x / arr
+end
+# Variable--MatrixVar
+# Variable--SDPVar
+# Variable--MatrixExpr
+# Variable--MatrixFuncVar
+let
+    m = Model()
+    @defVar(m,x)
+    @defSDPVar(m,X[2])
+    mfv = trace(X)
+    expr1 = x + mfv
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, AffExpr(x))
+    @test isequal(expr1.matvars, {trace(X)})
+    @test isequal(expr1.normexpr, NormExpr())
+    expr2 = x - mfv
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, AffExpr(x))
+    @test isequal(expr2.matvars, {-trace(X)})
+    @test isequal(expr2.normexpr, NormExpr())
+    @test_throws MethodError x * mfv
+    @test_throws MethodError x / mfv
+    con1 = (x >=  trace(X))
+    @test isequal(con1.terms, x-trace(X))
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (x <=  trace(X))
+    @test isequal(con2.terms, x-trace(X))
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (x ==  trace(X))
+    @test isequal(con3.terms, x-trace(X))
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# Variable--NormExpr
+let
+    m = Model()
+    @defVar(m,x)
+    @defMatrixVar(m,X[2])
+    expr = norm(2X - ones(2))
+    expr1 = x + expr
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, AffExpr(x))
+    @test isempty(expr1.matvars)
+    @test isequal(expr1.normexpr, expr)
+    expr2 = x - expr
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr2.aff, AffExpr(x))
+    @test isempty(expr2.matvars)
+    @test isequal(expr2.normexpr, -expr)
+    @test_throws MethodError x * expr
+    @test_throws MethodError x / expr
+    con1 = (x >=  expr)
+    @test isequal(con1.terms, x-expr)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (x <=  expr)
+    @test isequal(con2.terms, x-expr)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (x ==  expr)
+    @test isequal(con3.terms, x-expr)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# Variable--ScalarExpr
+let
+    m = Model()
+    @defVar(m,x)
+    @defVar(m,y)
+    @defSDPVar(m,X[2])
+    @defMatrixVar(m,Y[2])
+    expr = 3 - x + 2trace(X) - 4norm(2Y+ones(2))
+    expr1 = y + expr
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, 3 - x + y)
+    @test isequal(expr1.matvars, {2trace(X)})
+    @test isequal(expr1.normexpr, -4norm(2Y+ones(2)))
+    expr2 = y - expr
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, -3 + x + y)
+    @test isequal(expr2.matvars, {-2trace(X)})
+    @test isequal(expr2.normexpr, 4norm(2Y+ones(2)))
+    @test_throws MethodError x * expr
+    @test_throws MethodError x / expr
+    con1 = (x >=  expr)
+    @test isequal(con1.terms, x-expr)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (x <=  expr)
+    @test isequal(con2.terms, x-expr)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (x ==  expr)
+    @test isequal(con3.terms, x-expr)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+
+# AffExpr--Number
+# AffExpr--Variable
+# AffExpr--AffExpr
+# AffExpr--DualExpr
+# AffExpr--AbstractArray
+let
+    m = Model()
+    @defVar(m,x)
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    @test_throws MethodError (x+1) + arr
+    @test_throws MethodError (x+1) - arr
+    expr3 = (x+1) * arr
+    @test isa(expr3, DualExpr)
+    @test isequal(expr3.vars, {x})
+    @test isequal(expr3.coeffs, {arr})
+    @test isequal(expr3.constant, arr)
+    @test_throws MethodError x / arr
+end
+# AffExpr--MatrixVar
+# AffExpr--SDPVar
+# AffExpr--MatrixExpr
+# AffExpr--MatrixFuncVar
+let
+    m = Model()
+    @defVar(m,x)
+    @defSDPVar(m,X[2])
+    expr1 = (x+1) + (trace(X))
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, x+1)
+    @test isequal(expr1.matvars, {trace(X)})
+    @test isequal(expr1.normexpr, NormExpr())
+    expr2 = (x+1) - (trace(X))
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, x+1)
+    @test isequal(expr2.matvars, {-trace(X)})
+    @test isequal(expr2.normexpr, NormExpr())
+    @test_throws MethodError (x+1) * (trace(X))
+    @test_throws MethodError (x+1) / (trace(X))
+    con1 = ((x+1) >=  trace(X))
+    @test isequal(con1.terms, (x+1)-trace(X))
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = ((x+1) <=  trace(X))
+    @test isequal(con2.terms, (x+1)-trace(X))
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = ((x+1) ==  trace(X))
+    @test isequal(con3.terms, (x+1)-trace(X))
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# AffExpr--NormExpr
+let
+    m = Model()
+    @defVar(m,x)
+    @defMatrixVar(m,Y[2])
+    expr1 = (x+1) + norm(2Y-ones(2))
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, x+1)
+    @test isempty(expr1.matvars)
+    @test isequal(expr1.normexpr, norm(2Y-ones(2)))
+    expr2 = (x+1) - norm(2Y-ones(2))
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, x+1)
+    @test isempty(expr2.matvars)
+    @test isequal(expr2.normexpr, -norm(2Y-ones(2)))
+    @test_throws MethodError (x+1) * norm(2Y-ones(2))
+    @test_throws MethodError (x+1) / norm(2Y-ones(2))
+    con1 = ((x+1) >=  norm(2Y-ones(2)))
+    @test isequal(con1.terms, (x+1)-norm(2Y-ones(2)))
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = ((x+1) <=  norm(2Y-ones(2)))
+    @test isequal(con2.terms, (x+1)-norm(2Y-ones(2)))
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = ((x+1) ==  norm(2Y-ones(2)))
+    @test isequal(con3.terms, (x+1)-norm(2Y-ones(2)))
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# AffExpr--ScalarExpr
+let
+    m = Model()
+    @defVar(m,x)
+    @defVar(m,y)
+    @defSDPVar(m,X[2])
+    @defMatrixVar(m,Y[2])
+    expr = (-2 - y - 3trace(X) + 2norm(2Y-ones(2)))
+    expr1 = (x+1) + expr
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, x-y-1)
+    @test isequal(expr1.matvars, {-3trace(X)})
+    @test isequal(expr1.normexpr, 2norm(2Y-ones(2)))
+    expr2 = (x+1) - expr
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, x+y+3)
+    @test isequal(expr2.matvars, {3trace(X)})
+    @test isequal(expr2.normexpr, -2norm(2Y-ones(2)))
+    @test_throws MethodError (x+1) * expr
+    @test_throws MethodError (x+1) / expr
+    con1 = ((x+1) >=  expr)
+    @test isequal(con1.terms, (x+1)-expr)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = ((x+1) <=  expr)
+    @test isequal(con2.terms, (x+1)-expr)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = ((x+1) ==  expr)
+    @test isequal(con3.terms, (x+1)-expr)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+
+# DualExpr--Number
+# DualExpr--Variable
+# DualExpr--AffExpr
+# DualExpr--DualExpr
+let
+    m = Model()
+    @defVar(m,x)
+    @defVar(m,y)
+    dual1 = x*ones(3,3) - 2eye(3,3)
+    dual2 = -3eye(3,3)*y + 2ones(3,3)
+    expr1 = dual1 + dual2
+    @test isa(expr1, DualExpr)
+    @test isequal(expr1.vars, {x,y})
+    @test isequal(expr1.coeffs, {ones(3,3), -3eye(3,3)})
+    @test expr1.constant == -2eye(3,3)+2ones(3,3)
+    expr2 = dual1 - dual2
+    @test isa(expr2, DualExpr)
+    @test isequal(expr2.vars, {x,y})
+    @test isequal(expr2.coeffs, {ones(3,3), 3eye(3,3)})
+    @test expr2.constant == -2eye(3,3)-2ones(3,3)
+    @test_throws MethodError dual1 * dual2
+    @test_throws MethodError dual1 / dual2
+    con1 = (dual1 >= dual2)
+    @test isequal(con1.terms, dual1-dual2)
+    @test con1.sense == :>=
+    con2 = (dual1 <= dual2)
+    @test isequal(con2.terms, dual1-dual2)
+    @test con2.sense == :<=
+    con3 = (dual1 == dual2)
+    @test isequal(con3.terms, dual1-dual2)
+    @test con3.sense == :(==)
+end
+# DualExpr--AbstractArray
+let
+    m = Model()
+    @defVar(m,x)
+    @defVar(m,y)
+    dual = x*ones(4,4) - 2eye(4,4)
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    expr1 = dual + arr
+    @test isa(expr1, DualExpr)
+    @test isequal(expr1.vars, {x})
+    @test isequal(expr1.coeffs, {ones(4,4)})
+    @test expr1.constant == -2eye(4,4)+arr
+    expr2 = dual - arr
+    @test isa(expr2, DualExpr)
+    @test isequal(expr2.vars, {x})
+    @test isequal(expr2.coeffs, {ones(4,4)})
+    @test expr2.constant == -2eye(4,4)-arr
+    expr3 = dual * arr
+    @test isa(expr3, DualExpr)
+    @test isequal(expr3.vars, {x})
+    @test isequal(expr3.coeffs, {ones(4,4)*arr})
+    @test expr3.constant == -2eye(4,4)*arr
+    @test_throws MethodError dual / arr
+    con1 = (dual >= arr)
+    @test isequal(con1.terms, dual-arr)
+    @test con1.sense == :>=
+    con2 = (dual <= arr)
+    @test isequal(con2.terms, dual-arr)
+    @test con2.sense == :<=
+    con3 = (dual == arr)
+    @test isequal(con3.terms, dual-arr)
+    @test con3.sense == :(==)
+end
+# DualExpr--MatrixVar
+# DualExpr--SDPVar
+# DualExpr--MatrixExpr
+# DualExpr--MatrixFuncVar
+# DualExpr--NormExpr
+# DualExpr--ScalarExpr
+
+# AbstractArray--Number
+# AbstractArray--Variable
+let
+    m = Model()
+    @defVar(m,x)
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    @test_throws MethodError arr + x
+    @test_throws MethodError arr - x
+    expr3 = arr * x
+    @test isa(expr3, DualExpr)
+    @test isequal(expr3.vars, {x})
+    @test isequal(expr3.coeffs, {arr})
+    @test isequal(expr3.constant, spzeros(4,4))
+    @test_throws MethodError arr / x
+end
+# AbstractArray--AffExpr
+let
+    m = Model()
+    @defVar(m,x)
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    @test_throws MethodError arr + (x+1)
+    @test_throws MethodError arr - (x+1)
+    expr3 = arr * (x+1)
+    @test isa(expr3, DualExpr)
+    @test isequal(expr3.vars, {x})
+    @test isequal(expr3.coeffs, {arr})
+    @test isequal(expr3.constant, arr)
+    @test_throws MethodError arr / x
+end
+# AbstractArray--DualExpr
+let
+    m = Model()
+    @defVar(m,x)
+    @defVar(m,y)
+    dual = x*ones(4,4) - 2eye(4,4)
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    expr1 = arr + dual
+    @test isa(expr1, DualExpr)
+    @test isequal(expr1.vars, {x})
+    @test isequal(expr1.coeffs, {ones(4,4)})
+    @test expr1.constant == arr - 2eye(4,4)
+    expr2 = arr - dual
+    @test isa(expr2, DualExpr)
+    @test isequal(expr2.vars, {x})
+    @test isequal(expr2.coeffs, {-ones(4,4)})
+    @test expr2.constant == arr + 2eye(4,4)
+    expr3 = arr * dual
+    @test isa(expr3, DualExpr)
+    @test isequal(expr3.vars, {x})
+    @test isequal(expr3.coeffs, {arr*ones(4,4)})
+    @test expr3.constant == arr*(-2eye(4,4))
+    @test_throws MethodError arr / dual
+    con1 = (arr >= dual)
+    @test isequal(con1.terms, arr-dual)
+    @test con1.sense == :>=
+    con2 = (arr <= dual)
+    @test isequal(con2.terms, arr-dual)
+    @test con2.sense == :<=
+    con3 = (arr == dual)
+    @test isequal(con3.terms, arr-dual)
+    @test con3.sense == :(==)
+end
+# AbstractArray--AbstractArray
+# AbstractArray--MatrixVar
+let
+    m = Model()
+    @defMatrixVar(m, X[4,4])
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    expr1 = arr + X
+    @test isa(expr1, MatrixExpr)
+    @test isequal(expr1.elem, {X})
+    @test isequal(expr1.pre, {𝕀})
+    @test isequal(expr1.post, {𝕀})
+    @test expr1.constant == arr
+    expr2 = arr - X
+    @test isa(expr2, MatrixExpr)
+    @test isequal(expr2.elem, {X})
+    @test isequal(expr2.pre, {-𝕀})
+    @test isequal(expr2.post, {𝕀})
+    @test expr2.constant == arr
+    expr3 = arr * X
+    @test isa(expr3, MatrixExpr)
+    @test isequal(expr3.elem, {X})
+    @test isequal(expr3.pre, {arr})
+    @test isequal(expr3.post, {𝕀})
+    @test expr3.constant == spzeros(4,4)
+    @test_throws MethodError arr / X
+    con1 = (arr >= X)
+    @test isequal(con1.terms, arr-X)
+    @test con1.sense == :>=
+    con2 = (arr <= X)
+    @test isequal(con2.terms, arr-X)
+    @test con2.sense == :<=
+    con3 = (arr == X)
+    @test isequal(con3.terms, arr-X)
+    @test con3.sense == :(==)
+end
+# AbstractArray--SDPVar
+let
+    m = Model()
+    @defSDPVar(m, X[4,4])
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    expr1 = arr + X
+    @test isa(expr1, MatrixExpr)
+    @test isequal(expr1.elem, {X})
+    @test isequal(expr1.pre, {𝕀})
+    @test isequal(expr1.post, {𝕀})
+    @test expr1.constant == arr
+    expr2 = arr - X
+    @test isa(expr2, MatrixExpr)
+    @test isequal(expr2.elem, {X})
+    @test isequal(expr2.pre, {-𝕀})
+    @test isequal(expr2.post, {𝕀})
+    @test expr2.constant == arr
+    expr3 = arr * X
+    @test isa(expr3, MatrixExpr)
+    @test isequal(expr3.elem, {X})
+    @test isequal(expr3.pre, {arr})
+    @test isequal(expr3.post, {𝕀})
+    @test expr3.constant == spzeros(4,4)
+    @test_throws MethodError arr / X
+    con1 = (arr >= X)
+    @test isequal(con1.terms, arr-X)
+    @test con1.sense == :>=
+    con2 = (arr <= X)
+    @test isequal(con2.terms, arr-X)
+    @test con2.sense == :<=
+    con3 = (arr == X)
+    @test isequal(con3.terms, arr-X)
+    @test con3.sense == :(==)
+end
+# AbstractArray--MatrixExpr
+let
+    m = Model()
+    @defMatrixVar(m, X[3,3])
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    expr = [-2 ones(3)'; ones(3) -3X]
+    expr1 = arr + expr
+    @test isa(expr1, MatrixExpr)
+    @test isequal(expr1.elem, expr.elem)
+    @test isequal(expr1.pre, {𝕀})
+    @test isequal(expr1.post, {𝕀})
+    @test expr1.constant == arr + expr.constant
+    expr2 = arr - expr
+    @test isa(expr2, MatrixExpr)
+    @test isequal(expr2.elem, expr.elem)
+    @test isequal(expr2.pre, {-𝕀})
+    @test isequal(expr2.post, {𝕀})
+    @test expr2.constant == arr - expr.constant
+    expr3 = arr * expr
+    @test isa(expr3, MatrixExpr)
+    @test isequal(expr3.elem, expr.elem)
+    @test isequal(expr3.pre, {arr})
+    @test isequal(expr3.post, {𝕀})
+    @test expr3.constant == arr*expr.constant
+    @test_throws MethodError arr / expr
+    con1 = (arr >= expr)
+    @test isequal(con1.terms, arr-expr)
+    @test con1.sense == :>=
+    con2 = (arr <= expr)
+    @test isequal(con2.terms, arr-expr)
+    @test con2.sense == :<=
+    con3 = (arr == expr)
+    @test isequal(con3.terms, arr-expr)
+    @test con3.sense == :(==)
+end
+# AbstractArray--MatrixFuncVar
+let
+    m = Model()
+    @defSDPVar(m, X[4])
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    @test_throws MethodError arr + trace(X)
+    @test_throws MethodError arr - trace(X)
+    expr3 = arr * trace(X)
+    @test isa(expr3, DualExpr)
+    @test isequal(expr3.vars, {trace(X)})
+    @test isequal(expr3.coeffs, {arr})
+    @test expr3.constant == spzeros(4,4)
+    @test_throws MethodError arr / trace(X)
+end
+# AbstractArray--NormExpr
+# AbstractArray--ScalarExpr
+let
+    m = Model()
+    @defVar(m,x)
+    @defSDPVar(m, X[2])
+    @defMatrixVar(m, Y[2])
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    expr = 3 - x + 2trace(X)
+    @test_throws MethodError arr + expr
+    @test_throws MethodError arr - expr
+    expr3 = arr * expr
+    @test isa(expr3, DualExpr)
+    @test isequal(expr3.vars, {2trace(X),x})
+    @test length(expr3.coeffs) == 2
+    @test expr3.coeffs[1] ==  arr
+    @test expr3.coeffs[2] == -arr
+    @test expr3.constant == 3arr
+    nexpr = expr + vecnorm(Y)
+    @test_throws Exception arr * nexpr
+    @test_throws MethodError arr / trace(X)
+end
+
+# MatrixVar--Number
+let 
+    m = Model()
+    @defMatrixVar(m,X[2,2])
+    @test_throws MethodError X + 2
+    @test_throws MethodError X - 2
+    expr3 = X*(-2)
+    @test isa(expr3, MatrixExpr)
+    @test isequal(expr3.elem, {X})
+    @test isequal(expr3.pre, {-2𝕀})
+    @test isequal(expr3.post, {𝕀})
+    @test isequal(expr3.constant, spzeros(2,2))
+    expr4 = X / (-2)
+    @test isa(expr4, MatrixExpr)
+    @test isequal(expr4.elem, {X})
+    @test isequal(expr4.pre, {-0.5𝕀})
+    @test isequal(expr4.post, {𝕀})
+    @test isequal(expr4.constant, spzeros(2,2))
+    @test_throws Exception (X >= 2)
+    con1 = (X >= 0)
+    @test isequal(con1.terms, 1X)
+    @test con1.sense == :>=
+    con2 = (X <= 0)
+    @test isequal(con2.terms, 1X)
+    @test con2.sense == :<=
+    con3 = (X == 0)
+    @test isequal(con3.terms, 1X)
+    @test con3.sense == :(==)
+end
+# MatrixVar--Variable
+# MatrixVar--AffExpr
+# MatrixVar--DualExpr
+# MatrixVar--AbstractArray
+let
+    m = Model()
+    @defMatrixVar(m, X[4,4])
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    expr1 = X + arr
+    @test isa(expr1, MatrixExpr)
+    @test isequal(expr1.elem, {X})
+    @test isequal(expr1.pre, {𝕀})
+    @test isequal(expr1.post, {𝕀})
+    @test expr1.constant == arr
+    expr2 = X - arr
+    @test isa(expr2, MatrixExpr)
+    @test isequal(expr2.elem, {X})
+    @test isequal(expr2.pre, {𝕀})
+    @test isequal(expr2.post, {𝕀})
+    @test expr2.constant == -arr
+    expr3 = X * arr
+    @test isa(expr3, MatrixExpr)
+    @test isequal(expr3.elem, {X})
+    @test isequal(expr3.pre, {𝕀})
+    @test isequal(expr3.post, {arr})
+    @test expr3.constant == spzeros(4,4)
+    @test_throws MethodError X / arr
+    con1 = (X >= arr)
+    @test isequal(con1.terms, X-arr)
+    @test con1.sense == :>=
+    con2 = (X <= arr)
+    @test isequal(con2.terms, X-arr)
+    @test con2.sense == :<=
+    con3 = (X == arr)
+    @test isequal(con3.terms, X-arr)
+    @test con3.sense == :(==)
+end
+# MatrixVar--MatrixVar
+let
+    m = Model()
+    @defMatrixVar(m, X[2])
+    @defMatrixVar(m, Y[2])
+    expr1 = X + Y
+    @test isa(expr1, MatrixExpr)
+    @test isequal(expr1.elem, {X,Y})
+    @test isequal(expr1.pre, {𝕀,𝕀})
+    @test isequal(expr1.post, {𝕀,𝕀})
+    @test expr1.constant == spzeros(2,1)
+    expr2 = X - Y
+    @test isa(expr2, MatrixExpr)
+    @test isequal(expr2.elem, {X,Y})
+    @test isequal(expr2.pre, {𝕀,-𝕀})
+    @test isequal(expr2.post, {𝕀,𝕀})
+    @test expr2.constant == spzeros(2,1)
+    @defMatrixVar(m, Z[3,2])
+    @defMatrixVar(m, W[2,3])
+    # expr3 = Z * W
+    # @test isa(expr3, MatrixExpr)
+    # for i in 1:3, j in 1:3
+    #     @test isequal(expr3[i,j], Z[i,j]*W[j,i])
+    # end
+    @test_throws MethodError X / Y
+    con1 = (X >= Y)
+    @test isequal(con1.terms, X-Y)
+    @test con1.sense == :>=
+    con2 = (X <= Y)
+    @test isequal(con2.terms, X-Y)
+    @test con2.sense == :<=
+    con3 = (X == Y)
+    @test isequal(con3.terms, X-Y)
+    @test con3.sense == :(==)
+end
+# MatrixVar--SDPVar
+let
+    m = Model()
+    @defMatrixVar(m, X[2,2])
+    @defSDPVar(m, Y[2])
+    expr1 = X + Y
+    @test isa(expr1, MatrixExpr)
+    @test isequal(expr1.elem, {X,Y})
+    @test isequal(expr1.pre, {𝕀,𝕀})
+    @test isequal(expr1.post, {𝕀,𝕀})
+    @test expr1.constant == spzeros(2,2)
+    expr2 = X - Y
+    @test isa(expr2, MatrixExpr)
+    @test isequal(expr2.elem, {X,Y})
+    @test isequal(expr2.pre, {𝕀,-𝕀})
+    @test isequal(expr2.post, {𝕀,𝕀})
+    @test expr2.constant == spzeros(2,2)
+    @defMatrixVar(m, Z[3,2])
+    @defMatrixVar(m, W[2,3])
+    # expr3 = Z * W
+    # @test isa(expr3, MatrixExpr)
+    # for i in 1:3, j in 1:3
+    #     @test isequal(expr3[i,j], Z[i,j]*W[j,i])
+    # end
+    @test_throws MethodError X / Y
+    con1 = (X >= Y)
+    @test isequal(con1.terms, X-Y)
+    @test con1.sense == :>=
+    con2 = (X <= Y)
+    @test isequal(con2.terms, X-Y)
+    @test con2.sense == :<=
+    con3 = (X == Y)
+    @test isequal(con3.terms, X-Y)
+    @test con3.sense == :(==)
+end
+# MatrixVar--MatrixExpr
+let
+    m = Model()
+    @defMatrixVar(m, X[2,2])
+    @defMatrixVar(m, Y[2,2])
+    expr = 2Y - eye(2,2)
+    expr1 = X + expr
+    @test isa(expr1, MatrixExpr)
+    @test isequal(expr1.elem, {X,Y})
+    @test isequal(expr1.pre, {𝕀,2𝕀})
+    @test isequal(expr1.post, {𝕀,𝕀})
+    @test expr1.constant == -eye(2,2)
+    expr2 = X - expr
+    @test isa(expr2, MatrixExpr)
+    @test isequal(expr2.elem, {X,Y})
+    @test isequal(expr2.pre, {𝕀,-2𝕀})
+    @test isequal(expr2.post, {𝕀,𝕀})
+    @test expr2.constant == eye(2,2)
+    @defMatrixVar(m, Z[3,2])
+    @defMatrixVar(m, W[2,3])
+    # expr3 = Z * W
+    # @test isa(expr3, MatrixExpr)
+    # for i in 1:3, j in 1:3
+    #     @test isequal(expr3[i,j], Z[i,j]*W[j,i])
+    # end
+    @test_throws MethodError X / expr
+end
+# MatrixVar--MatrixFuncVar
+# MatrixVar--NormExpr
+# MatrixVar--ScalarExpr
+
+# SDPVar--Number
+let 
+    m = Model()
+    @defSDPVar(m,X[2,2])
+    @test_throws MethodError X + 2
+    @test_throws MethodError X - 2
+    expr3 = X*(-2)
+    @test isa(expr3, MatrixExpr)
+    @test isequal(expr3.elem, {X})
+    @test isequal(expr3.pre, {-2𝕀})
+    @test isequal(expr3.post, {𝕀})
+    @test isequal(expr3.constant, spzeros(2,2))
+    expr4 = X / (-2)
+    @test isa(expr4, MatrixExpr)
+    @test isequal(expr4.elem, {X})
+    @test isequal(expr4.pre, {-0.5𝕀})
+    @test isequal(expr4.post, {𝕀})
+    @test isequal(expr4.constant, spzeros(2,2))
+    @test_throws Exception (X >= 2)
+    con1 = (X >= 0)
+    @test isequal(con1.terms, 1X)
+    @test con1.sense == :>=
+    con2 = (X <= 0)
+    @test isequal(con2.terms, 1X)
+    @test con2.sense == :<=
+    con3 = (X == 0)
+    @test isequal(con3.terms, 1X)
+    @test con3.sense == :(==)
+end
+# SDPVar--Variable
+# SDPVar--AffExpr
+# SDPVar--DualExpr
+# SDPVar--AbstractArray
+let
+    m = Model()
+    @defSDPVar(m, X[4,4])
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    expr1 = X + arr
+    @test isa(expr1, MatrixExpr)
+    @test isequal(expr1.elem, {X})
+    @test isequal(expr1.pre, {𝕀})
+    @test isequal(expr1.post, {𝕀})
+    @test expr1.constant == arr
+    expr2 = X - arr
+    @test isa(expr2, MatrixExpr)
+    @test isequal(expr2.elem, {X})
+    @test isequal(expr2.pre, {𝕀})
+    @test isequal(expr2.post, {𝕀})
+    @test expr2.constant == -arr
+    expr3 = X * arr
+    @test isa(expr3, MatrixExpr)
+    @test isequal(expr3.elem, {X})
+    @test isequal(expr3.pre, {𝕀})
+    @test isequal(expr3.post, {arr})
+    @test expr3.constant == spzeros(4,4)
+    @test_throws MethodError X / arr
+    con1 = (X >= arr)
+    @test isequal(con1.terms, X-arr)
+    @test con1.sense == :>=
+    con2 = (X <= arr)
+    @test isequal(con2.terms, X-arr)
+    @test con2.sense == :<=
+    con3 = (X == arr)
+    @test isequal(con3.terms, X-arr)
+    @test con3.sense == :(==)
+end
+# SDPVar--MatrixVar
+let
+    m = Model()
+    @defSDPVar(m, X[2,2])
+    @defMatrixVar(m, Y[2,2])
+    expr1 = X + Y
+    @test isa(expr1, MatrixExpr)
+    @test isequal(expr1.elem, {X,Y})
+    @test isequal(expr1.pre, {𝕀,𝕀})
+    @test isequal(expr1.post, {𝕀,𝕀})
+    @test expr1.constant == spzeros(2,2)
+    expr2 = X - Y
+    @test isa(expr2, MatrixExpr)
+    @test isequal(expr2.elem, {X,Y})
+    @test isequal(expr2.pre, {𝕀,-𝕀})
+    @test isequal(expr2.post, {𝕀,𝕀})
+    @test expr2.constant == spzeros(2,2)
+    @defMatrixVar(m, Z[3,2])
+    @defMatrixVar(m, W[2,3])
+    # expr3 = Z * W
+    # @test isa(expr3, MatrixExpr)
+    # for i in 1:3, j in 1:3
+    #     @test isequal(expr3[i,j], Z[i,j]*W[j,i])
+    # end
+    @test_throws MethodError X / Y
+end
+# SDPVar--SDPVar
+let
+    m = Model()
+    @defSDPVar(m, X[2,2])
+    @defSDPVar(m, Y[2,2])
+    expr1 = X + Y
+    @test isa(expr1, MatrixExpr)
+    @test isequal(expr1.elem, {X,Y})
+    @test isequal(expr1.pre, {𝕀,𝕀})
+    @test isequal(expr1.post, {𝕀,𝕀})
+    @test expr1.constant == spzeros(2,2)
+    expr2 = X - Y
+    @test isa(expr2, MatrixExpr)
+    @test isequal(expr2.elem, {X,Y})
+    @test isequal(expr2.pre, {𝕀,-𝕀})
+    @test isequal(expr2.post, {𝕀,𝕀})
+    @test expr2.constant == spzeros(2,2)
+    @defMatrixVar(m, Z[3,2])
+    @defMatrixVar(m, W[2,3])
+    # expr3 = Z * W
+    # @test isa(expr3, MatrixExpr)
+    # for i in 1:3, j in 1:3
+    #     @test isequal(expr3[i,j], Z[i,j]*W[j,i])
+    # end
+    @test_throws MethodError X / Y
+    con1 = (X >= Y)
+    @test isequal(con1.terms, X-Y)
+    @test con1.sense == :>=
+    con2 = (X <= Y)
+    @test isequal(con2.terms, X-Y)
+    @test con2.sense == :<=
+    con3 = (X == Y)
+    @test isequal(con3.terms, X-Y)
+    @test con3.sense == :(==)
+end
+# SDPVar--MatrixExpr
+let
+    m = Model()
+    @defSDPVar(m, X[2,2])
+    @defMatrixVar(m, Y[2,2])
+    expr = 2Y - eye(2,2)
+    expr1 = X + expr
+    @test isa(expr1, MatrixExpr)
+    @test isequal(expr1.elem, {X,Y})
+    @test isequal(expr1.pre, {𝕀,2𝕀})
+    @test isequal(expr1.post, {𝕀,𝕀})
+    @test expr1.constant == -eye(2,2)
+    expr2 = X - expr
+    @test isa(expr2, MatrixExpr)
+    @test isequal(expr2.elem, {X,Y})
+    @test isequal(expr2.pre, {𝕀,-2𝕀})
+    @test isequal(expr2.post, {𝕀,𝕀})
+    @test expr2.constant == eye(2,2)
+    @defMatrixVar(m, Z[3,2])
+    @defMatrixVar(m, W[2,3])
+    # expr3 = Z * W
+    # @test isa(expr3, MatrixExpr)
+    # for i in 1:3, j in 1:3
+    #     @test isequal(expr3[i,j], Z[i,j]*W[j,i])
+    # end
+    @test_throws MethodError X / expr
+    con1 = (X >= expr)
+    @test isequal(con1.terms, X-expr)
+    @test con1.sense == :>=
+    con2 = (X <= expr)
+    @test isequal(con2.terms, X-expr)
+    @test con2.sense == :<=
+    con3 = (X == expr)
+    @test isequal(con3.terms, X-expr)
+    @test con3.sense == :(==)
+end
+# SDPVar--MatrixFuncVar
+# SDPVar--NormExpr
+# SDPVar--ScalarExpr
+
+# MatrixExpr--Number
+let 
+    m = Model()
+    @defSDPVar(m,X[2,2])
+    expr = [-X ones(2); ones(1,2) -3]
+    @test_throws MethodError expr + 2
+    @test_throws MethodError expr - 2
+    expr3 = expr*(-2)
+    @test isa(expr3, MatrixExpr)
+    @test length(expr3.elem) == 1
+    @test isequal(expr3.elem[1][1,1], -X[1,1]+0) # lift to ScalarExpr
+    @test isequal(expr3.elem[1][1,2], -X[1,2]+0)
+    @test isequal(expr3.elem[1][2,1], -X[2,1]+0)
+    @test isequal(expr3.elem[1][2,2], -X[2,2]+0)
+    @test isequal(expr3.elem[1][1,3], 1)
+    @test isequal(expr3.elem[1][2,3], 1)
+    @test isequal(expr3.elem[1][3,1], 1)
+    @test isequal(expr3.elem[1][3,2], 1)
+    @test isequal(expr3.elem[1][3,3], -3)
+    @test isequal(expr3.pre,  {-2𝕀})
+    @test isequal(expr3.post, {𝕀})
+    @test isequal(expr3.constant, spzeros(3,3))
+    expr4 = expr / -2
+    @test isa(expr4, MatrixExpr)
+    @test length(expr4.elem) == 1
+    @test isequal(expr4.elem[1][1,1], -X[1,1]+0) # lift to ScalarExpr
+    @test isequal(expr4.elem[1][1,2], -X[1,2]+0)
+    @test isequal(expr4.elem[1][2,1], -X[2,1]+0)
+    @test isequal(expr4.elem[1][2,2], -X[2,2]+0)
+    @test isequal(expr4.elem[1][1,3], 1)
+    @test isequal(expr4.elem[1][2,3], 1)
+    @test isequal(expr4.elem[1][3,1], 1)
+    @test isequal(expr4.elem[1][3,2], 1)
+    @test isequal(expr4.elem[1][3,3], -3)
+    @test isequal(expr4.pre,  {-0.5𝕀})
+    @test isequal(expr4.post, {𝕀})
+    @test isequal(expr4.constant, spzeros(3,3))
+end
+# MatrixExpr--Variable
+# MatrixExpr--AffExpr
+# MatrixExpr--DualExpr
+# MatrixExpr--AbstractArray
+let
+    m = Model()
+    @defMatrixVar(m, X[3,3])
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    expr = [-2 ones(3)'; ones(3) -3X]
+    expr1 = expr + arr
+    @test isa(expr1, MatrixExpr)
+    @test isequal(expr1.elem, expr.elem)
+    @test isequal(expr1.pre, {𝕀})
+    @test isequal(expr1.post, {𝕀})
+    @test expr1.constant == expr.constant + arr
+    expr2 = expr - arr
+    @test isa(expr2, MatrixExpr)
+    @test isequal(expr2.elem, expr.elem)
+    @test isequal(expr2.pre, {𝕀})
+    @test isequal(expr2.post, {𝕀})
+    @test expr2.constant == expr.constant - arr
+    expr3 = expr * arr
+    @test isa(expr3, MatrixExpr)
+    @test isequal(expr3.elem, expr.elem)
+    @test isequal(expr3.pre, {𝕀})
+    @test isequal(expr3.post, {arr})
+    @test expr3.constant == expr.constant*arr
+    @test_throws MethodError expr / arr
+end
+# MatrixExpr--MatrixVar
+let
+    m = Model()
+    @defMatrixVar(m, X[2,2])
+    @defMatrixVar(m, Y[2,2])
+    expr = 2Y - eye(2,2)
+    expr1 = expr + X
+    @test isa(expr1, MatrixExpr)
+    @test isequal(expr1.elem, {Y,X})
+    @test isequal(expr1.pre, {2𝕀,𝕀})
+    @test isequal(expr1.post, {𝕀,𝕀})
+    @test expr1.constant == -eye(2,2)
+    expr2 = expr - X
+    @test isa(expr2, MatrixExpr)
+    @test isequal(expr2.elem, {Y,X})
+    @test isequal(expr2.pre, {2𝕀,-𝕀})
+    @test isequal(expr2.post, {𝕀,𝕀})
+    @test expr2.constant == -eye(2,2)
+    @defMatrixVar(m, Z[3,2])
+    @defMatrixVar(m, W[2,3])
+    # expr3 = Z * W
+    # @test isa(expr3, MatrixExpr)
+    # for i in 1:3, j in 1:3
+    #     @test isequal(expr3[i,j], Z[i,j]*W[j,i])
+    # end
+    @test_throws MethodError expr / X
+end
+# MatrixExpr--SDPVar
+let
+    m = Model()
+    @defSDPVar(m, X[2,2])
+    @defMatrixVar(m, Y[2,2])
+    expr = 2Y - eye(2,2)
+    expr1 = expr + X
+    @test isa(expr1, MatrixExpr)
+    @test isequal(expr1.elem, {Y,X})
+    @test isequal(expr1.pre, {2𝕀,𝕀})
+    @test isequal(expr1.post, {𝕀,𝕀})
+    @test expr1.constant == -eye(2,2)
+    expr2 = expr - X
+    @test isa(expr2, MatrixExpr)
+    @test isequal(expr2.elem, {Y,X})
+    @test isequal(expr2.pre, {2𝕀,-𝕀})
+    @test isequal(expr2.post, {𝕀,𝕀})
+    @test expr2.constant == -eye(2,2)
+    @defMatrixVar(m, Z[3,2])
+    @defMatrixVar(m, W[2,3])
+    # expr3 = Z * W
+    # @test isa(expr3, MatrixExpr)
+    # for i in 1:3, j in 1:3
+    #     @test isequal(expr3[i,j], Z[i,j]*W[j,i])
+    # end
+    @test_throws MethodError expr / X
+end
+# MatrixExpr--MatrixExpr
+let
+    m = Model()
+    @defMatrixVar(m, X[3,3])
+    @defSDPVar(m, Y[3,3])
+    mex1 = 2X + eye(3,3)
+    mex2 = -Y + 2ones(3,3)
+    expr1 = mex1 + mex2
+    @test isa(expr1, MatrixExpr)
+    @test isequal(expr1.elem, {X,Y})
+    @test isequal(expr1.pre, {2𝕀,-𝕀})
+    @test isequal(expr1.post, {𝕀,𝕀})
+    @test expr1.constant == eye(3,3) + 2ones(3,3)
+    expr2 = mex1 - mex2
+    @test isa(expr2, MatrixExpr)
+    @test isequal(expr2.elem, {X,Y})
+    @test isequal(expr2.pre, {2𝕀,𝕀})
+    @test isequal(expr2.post, {𝕀,𝕀})
+    @test expr2.constant == eye(3,3) - 2ones(3,3)
+    @test_throws Exception mex1 * mex2
+    @test_throws MethodError mex1 / mex2
+end
+# MatrixExpr--MatrixFuncVar
+# MatrixExpr--NormExpr
+# MatrixExpr--ScalarExpr
+
+# MatrixFuncVar--Number
+let 
+    m = Model()
+    @defSDPVar(m,X[2,2])
+    expr1 = trace(X) + 2
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, AffExpr(2.0))
+    @test isequal(expr1.matvars, {trace(X)})
+    @test isequal(expr1.normexpr, NormExpr())
+    expr2 = trace(X) - 2
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, AffExpr(-2.0))
+    @test isequal(expr2.matvars, {trace(X)})
+    @test isequal(expr2.normexpr, NormExpr())
+    expr3 = trace(X) * 2
+    @test isa(expr3, MatrixFuncVar)
+    @test isequal(expr3.expr, 2X)
+    @test expr3.func == :trace
+    expr4 = trace(X) / 2
+    @test isa(expr4, MatrixFuncVar)
+    @test isequal(expr4.expr, 0.5X)
+    @test expr4.func == :trace
+    con1 = (trace(X) >= 1)
+    @test isequal(con1.terms, trace(X)-1)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (trace(X) <= 1)
+    @test isequal(con2.terms, trace(X)-1)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (trace(X) == 1)
+    @test isequal(con3.terms, trace(X)-1)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# MatrixFuncVar--Variable
+let
+    m = Model()
+    @defVar(m,x)
+    @defSDPVar(m,X[2])
+    mfv = trace(X)
+    expr1 = mfv + x
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, AffExpr(x))
+    @test isequal(expr1.matvars, {trace(X)})
+    @test isequal(expr1.normexpr, NormExpr())
+    expr2 = mfv - x
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, -x)
+    @test isequal(expr2.matvars, {trace(X)})
+    @test isequal(expr2.normexpr, NormExpr())
+    @test_throws MethodError mfv * x
+    @test_throws MethodError mfv / x
+    con1 = (trace(X) >= x)
+    @test isequal(con1.terms, trace(X)-x)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (trace(X) <= x)
+    @test isequal(con2.terms, trace(X)-x)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (trace(X) == x)
+    @test isequal(con3.terms, trace(X)-x)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# MatrixFuncVar--AffExpr
+let
+    m = Model()
+    @defVar(m,x)
+    @defSDPVar(m,X[2])
+    expr1 = (trace(X)) + (x+1)
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, x+1)
+    @test isequal(expr1.matvars, {trace(X)})
+    @test isequal(expr1.normexpr, NormExpr())
+    expr2 = (trace(X)) - (x+1)
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, -x-1)
+    @test isequal(expr2.matvars, {trace(X)})
+    @test isequal(expr2.normexpr, NormExpr())
+    @test_throws MethodError (trace(X)) * (x+1)
+    @test_throws MethodError (trace(X)) / (x+1)
+    con1 = (trace(X) >= (x+1))
+    @test isequal(con1.terms, trace(X)-(x+1))
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (trace(X) <= (x+1))
+    @test isequal(con2.terms, trace(X)-(x+1))
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (trace(X) == (x+1))
+    @test isequal(con3.terms, trace(X)-(x+1))
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# MatrixFuncVar--DualExpr
+# MatrixFuncVar--AbstractArray
+let
+    m = Model()
+    @defSDPVar(m, X[4])
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    @test_throws MethodError trace(X) + arr
+    @test_throws MethodError trace(X) - arr
+    expr3 = trace(X) * arr
+    @test isa(expr3, DualExpr)
+    @test isequal(expr3.vars, {trace(X)})
+    @test isequal(expr3.coeffs, {arr})
+    @test expr3.constant == spzeros(4,4)
+    @test_throws MethodError trace(X) / arr
+end
+# MatrixFuncVar--MatrixVar
+# MatrixFuncVar--SDPVar
+# MatrixFuncVar--MatrixExpr
+# MatrixFuncVar--MatrixFuncVar
+# MatrixFuncVar--NormExpr
+let 
+    m = Model()
+    @defSDPVar(m, X[2,2])
+    @defMatrixVar(m, Y[3])
+    mfv = trace(X)
+    nexpr = norm(2Y-ones(3))
+    expr1 = mfv + nexpr
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, AffExpr())
+    @test isequal(expr1.matvars, {mfv})
+    @test isequal(expr1.normexpr, nexpr)
+    expr2 = mfv - nexpr
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, AffExpr())
+    @test isequal(expr2.matvars, {mfv})
+    @test isequal(expr2.normexpr, -nexpr)   
+    @test_throws MethodError mfv * nexpr
+    @test_throws MethodError mfv / nexpr
+    con1 = (mfv >= nexpr)
+    @test isequal(con1.terms, mfv-nexpr)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (mfv <= nexpr)
+    @test isequal(con2.terms, mfv-nexpr)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (mfv == nexpr)
+    @test isequal(con3.terms, mfv-nexpr)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# MatrixFuncVar--ScalarExpr
+let 
+    m = Model()
+    @defVar(m,x)
+    @defSDPVar(m, X[2,2])
+    @defMatrixVar(m, Y[3])
+    @defSDPVar(m, Z[2])
+    mfv = trace(X)
+    sexpr = norm(2Y-ones(3)) - 2trace(Z) + 3x - 1
+    expr1 = mfv + sexpr
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, 3x-1)
+    @test isequal(expr1.matvars, {mfv,-2trace(Z)})
+    @test isequal(expr1.normexpr, norm(2Y-ones(3)))
+    expr2 = mfv - sexpr
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, -3x+1)
+    @test isequal(expr2.matvars, {mfv,2trace(Z)})
+    @test isequal(expr2.normexpr, -norm(2Y-ones(3)))   
+    @test_throws MethodError mfv * sexpr
+    @test_throws MethodError mfv / sexpr
+    con1 = (mfv >= sexpr)
+    @test isequal(con1.terms, mfv-sexpr)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (mfv <= sexpr)
+    @test isequal(con2.terms, mfv-sexpr)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (mfv == sexpr)
+    @test isequal(con3.terms, mfv-sexpr)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+
+# NormExpr--Number
+let 
+    m = Model()
+    @defMatrixVar(m,X[2])
+    expr = norm(2X - ones(2))
+    expr1 = expr + 2
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, AffExpr(2.0))
+    @test isempty(expr1.matvars)
+    @test isequal(expr1.normexpr, expr)
+    expr2 = expr - 2
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, AffExpr(-2.0))
+    @test isempty(expr2.matvars)
+    @test isequal(expr2.normexpr, expr)
+    expr3 = expr * 2
+    @test isa(expr3, NormExpr)
+    @test isequal(expr3.vars, {2X-ones(2)})
+    @test isequal(expr3.coeffs, [2.0])
+    @test isequal(expr3.form, [:norm2])
+    expr4 = expr / 2
+    @test isa(expr4, NormExpr)
+    @test isequal(expr4.vars, {2X-ones(2)})
+    @test isequal(expr4.coeffs, [0.5])
+    @test isequal(expr4.form, [:norm2])
+    con1 = (expr >= 1)
+    @test isequal(con1.terms, expr-1)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (expr <= 1)
+    @test isequal(con2.terms, expr-1)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (expr == 1)
+    @test isequal(con3.terms, expr-1)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# NormExpr--Variable
+let
+    m = Model()
+    @defVar(m,x)
+    @defMatrixVar(m,X[2])
+    expr = norm(2X - ones(2))
+    expr1 = expr + x
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, AffExpr(x))
+    @test isempty(expr1.matvars)
+    @test isequal(expr1.normexpr, expr)
+    expr2 = expr - x
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr2.aff, -x)
+    @test isempty(expr2.matvars)
+    @test isequal(expr2.normexpr, expr)
+    @test_throws MethodError expr * x
+    @test_throws MethodError expr / x
+    con1 = (expr >= x)
+    @test isequal(con1.terms, expr-x)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (expr <= x)
+    @test isequal(con2.terms, expr-x)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (expr == x)
+    @test isequal(con3.terms, expr-x)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# NormExpr--AffExpr
+let
+    m = Model()
+    @defVar(m,x)
+    @defMatrixVar(m,Y[2])
+    expr1 = norm(2Y-ones(2)) + (x+1)
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, x+1)
+    @test isempty(expr1.matvars)
+    @test isequal(expr1.normexpr, norm(2Y-ones(2)))
+    expr2 = norm(2Y-ones(2)) - (x+1)
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, -x-1)
+    @test isempty(expr2.matvars)
+    @test isequal(expr2.normexpr, norm(2Y-ones(2)))
+    @test_throws MethodError norm(2Y-ones(2)) * (x+1)
+    @test_throws MethodError norm(2Y-ones(2)) / (x+1)
+    con1 = (expr >= (x+1))
+    @test isequal(con1.terms, expr-(x+1))
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (expr <= (x+1))
+    @test isequal(con2.terms, expr-(x+1))
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (expr == (x+1))
+    @test isequal(con3.terms, expr-(x+1))
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# NormExpr--DualExpr
+# NormExpr--AbstractArray
+# NormExpr--MatrixVar
+# NormExpr--SDPVar
+# NormExpr--MatrixExpr
+# NormExpr--MatrixFuncVar
+# NormExpr--NormExpr
+let
+    m = Model()
+    @defMatrixVar(m, X[2])
+    @defMatrixVar(m, Y[3,3])
+    n1 = 2norm(2X-ones(2))
+    n2 = -vecnorm(-Y+2ones(3,3))
+    expr1 = n1 + n2
+    @test isa(expr1, NormExpr)
+    @test isequal(expr1.vars, {2X-ones(2),-Y+2ones(3,3)})
+    @test isequal(expr1.coeffs, {2,-1})
+    @test expr1.form == [:norm2,:normfrob]
+    expr2 = n1 - n2
+    @test isa(expr2, NormExpr)
+    @test isequal(expr2.vars, {2X-ones(2),-Y+2ones(3,3)})
+    @test isequal(expr2.coeffs, {2,1})
+    @test expr2.form == [:norm2,:normfrob]
+    @test_throws MethodError n1 * n2
+    @test_throws MethodError n1 / n2
+    con1 = (n1 >= n2)
+    @test isequal(con1.terms, n1-n2+0)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (n1 <= n2)
+    @test isequal(con2.terms, n1-n2+0)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (n1 == n2)
+    @test isequal(con3.terms, n1-n2+0)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# NormExpr--ScalarExpr
+let
+    m = Model()
+    @defVar(m,x)
+    @defMatrixVar(m, X[2])
+    @defSDPVar(m, Y[3,3])
+    n1 = 2norm(2X-ones(2))
+    n2 = 2x + 1 - vecnorm(-Y+2ones(3,3)) + 2trace(Y)
+    expr1 = n1 + n2
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, 2x+1)
+    @test isequal(expr1.matvars, {2trace(Y)})
+    @test isequal(expr1.normexpr, 2norm(2X-ones(2)) - vecnorm(-Y+2ones(3,3)))
+    expr2 = n1 - n2
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, -2x-1)
+    @test isequal(expr2.matvars, {-2trace(Y)})
+    @test isequal(expr2.normexpr, 2norm(2X-ones(2)) + vecnorm(-Y+2ones(3,3)))
+    @test_throws MethodError n1 * n2
+    @test_throws MethodError n1 / n2
+    con1 = (n1 >= n2)
+    @test isequal(con1.terms, n1-n2)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (n1 <= n2)
+    @test isequal(con2.terms, n1-n2)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (n1 == n2)
+    @test isequal(con3.terms, n1-n2)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+
+# ScalarExpr--Number
+let 
+    m = Model()
+    @defVar(m,x)
+    @defSDPVar(m,X[2])
+    expr = 2x + 3 - 4trace(X) + norm(2X - ones(2,2))
+    expr1 = expr + 2
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, 2x + 5)
+    @test isequal(expr1.matvars, {-4trace(X)})
+    @test isequal(expr1.normexpr, norm(2X - ones(2,2)))
+    expr2 = expr - 2
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, 2x + 1)
+    @test isequal(expr2.matvars, {-4trace(X)})
+    @test isequal(expr2.normexpr, norm(2X - ones(2,2)))
+    expr3 = expr * 2
+    @test isa(expr3, ScalarExpr)
+    @test isequal(expr3.aff, 4x + 6)
+    @test isequal(expr3.matvars, {-8trace(X)})
+    @test isequal(expr3.normexpr, 2norm(2X - ones(2,2)))
+    expr4 = expr / 2
+    @test isa(expr4, ScalarExpr)
+    @test isequal(expr4.aff, x + 1.5)
+    @test isequal(expr4.matvars, {-2trace(X)})
+    @test isequal(expr4.normexpr, 0.5norm(2X - ones(2,2)))
+    con1 = (expr >=  1)
+    @test isequal(con1.terms, expr-1)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (expr <= 1)
+    @test isequal(con2.terms, expr-1)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (expr == 1)
+    @test isequal(con3.terms, expr-1)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# ScalarExpr--Variable
+let
+    m = Model()
+    @defVar(m,x)
+    @defVar(m,y)
+    @defSDPVar(m,X[2])
+    @defMatrixVar(m,Y[2])
+    expr = 3 - x + 2trace(X) - 4norm(2Y+ones(2))
+    expr1 = expr + y
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, 3 - x + y)
+    @test isequal(expr1.matvars, {2trace(X)})
+    @test isequal(expr1.normexpr, -4norm(2Y+ones(2)))
+    expr2 = expr - y
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, 3 - x - y)
+    @test isequal(expr2.matvars, {2trace(X)})
+    @test isequal(expr2.normexpr, -4norm(2Y+ones(2)))
+    @test_throws MethodError x * expr
+    @test_throws MethodError x / expr
+    con1 = (expr >=  x)
+    @test isequal(con1.terms, expr-x)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (expr <= x)
+    @test isequal(con2.terms, expr-x)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (expr == x)
+    @test isequal(con3.terms, expr-x)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+
+# ScalarExpr--AffExpr
+let
+    m = Model()
+    @defVar(m,x)
+    @defVar(m,y)
+    @defSDPVar(m,X[2])
+    @defMatrixVar(m,Y[2])
+    expr1 = (-2 - y - 3trace(X) + 2norm(2Y-ones(2))) + (x+1)
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, -y+x-1)
+    @test isequal(expr1.matvars, {-3trace(X)})
+    @test isequal(expr1.normexpr, 2norm(2Y-ones(2)))
+    expr2 = (-2 - y - 3trace(X) + 2norm(2Y-ones(2))) - (x+1)
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, -y-x-3)
+    @test isequal(expr2.matvars, {-3trace(X)})
+    @test isequal(expr2.normexpr, 2norm(2Y-ones(2)))
+    @test_throws MethodError (-2 - y - 3trace(X) + 2norm(2Y-ones(2))) * (x+1)
+    @test_throws MethodError (-2 - y - 3trace(X) + 2norm(2Y-ones(2))) / (x+1)
+    con1 = (expr >=  (x+1))
+    @test isequal(con1.terms, expr-(x+1))
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (expr <= (x+1))
+    @test isequal(con2.terms, expr-(x+1))
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (expr == (x+1))
+    @test isequal(con3.terms, expr-(x+1))
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# ScalarExpr--DualExpr
+# ScalarExpr--AbstractArray
+let
+    m = Model()
+    @defVar(m,x)
+    @defSDPVar(m, X[2])
+    @defMatrixVar(m, Y[2])
+    arr = 2eye(4,4) - diagm(ones(3), 1) - diagm(ones(3), -1)
+    expr = 3 - x + 2trace(X)
+    @test_throws MethodError expr + arr
+    @test_throws MethodError expr - arr
+    expr3 = expr * arr
+    @test isa(expr3, DualExpr)
+    @test isequal(expr3.vars, {2trace(X),x})
+    @test length(expr3.coeffs) == 2
+    @test expr3.coeffs[1] ==  arr
+    @test expr3.coeffs[2] == -arr
+    @test expr3.constant == 3arr
+    nexpr = expr + vecnorm(Y)
+    @test_throws Exception nexpr * arr
+    @test_throws MethodError arr / trace(X)
+end
+
+# ScalarExpr--MatrixVar
+# ScalarExpr--SDPVar
+# ScalarExpr--MatrixExpr
+# ScalarExpr--MatrixFuncVar
+let 
+    m = Model()
+    @defVar(m,x)
+    @defSDPVar(m, X[2,2])
+    @defMatrixVar(m, Y[3])
+    @defSDPVar(m, Z[2])
+    mfv = trace(X)
+    sexpr = norm(2Y-ones(3)) - 2trace(Z) + 3x - 1
+    expr1 = sexpr + mfv
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, 3x-1)
+    @test isequal(expr1.matvars, {-2trace(Z),mfv})
+    @test isequal(expr1.normexpr, norm(2Y-ones(3)))
+    expr2 = sexpr - mfv
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, 3x-1)
+    @test isequal(expr2.matvars, {-2trace(Z),-mfv})
+    @test isequal(expr2.normexpr, norm(2Y-ones(3)))   
+    @test_throws MethodError sexpr * mfv
+    @test_throws MethodError sexpr / mfv
+    con1 = (mfv >=  sexpr)
+    @test isequal(con1.terms, mfv-sexpr)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (mfv <= sexpr)
+    @test isequal(con2.terms, mfv-sexpr)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (mfv == sexpr)
+    @test isequal(con3.terms, mfv-sexpr)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+
+# ScalarExpr--NormExpr
+let
+    m = Model()
+    @defVar(m,x)
+    @defMatrixVar(m, X[2])
+    @defSDPVar(m, Y[3,3])
+    n1 = 2x + 1 - vecnorm(-Y+2ones(3,3)) + 2trace(Y)
+    n2 = 2norm(2X-ones(2))
+    expr1 = n1 + n2
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, 2x+1)
+    @test isequal(expr1.matvars, {2trace(Y)})
+    @test isequal(expr1.normexpr, -vecnorm(-Y+2ones(3,3)) + 2norm(2X-ones(2)))
+    expr2 = n1 - n2
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, 2x+1)
+    @test isequal(expr2.matvars, {2trace(Y)})
+    @test isequal(expr2.normexpr, - vecnorm(-Y+2ones(3,3)) - 2norm(2X-ones(2)))
+    @test_throws MethodError n1 * n2
+    @test_throws MethodError n1 / n2
+    con1 = (n1 >=  n2)
+    @test isequal(con1.terms, n1-n2)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (n1 <= n2)
+    @test isequal(con2.terms, n1-n2)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (n1 == n2)
+    @test isequal(con3.terms, n1-n2)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end
+# ScalarExpr--ScalarExpr
+let
+    m = Model()
+    @defVar(m,x)
+    @defMatrixVar(m,X[2,2])
+    @defSDPVar(m,Y[2,2])
+    s1 = 2x - 1 + vecnorm(2X) - 2trace(Y)
+    s2 = trace(Y) - 3 - x - vecnorm(X)
+    expr1 = s1 + s2
+    @test isa(expr1, ScalarExpr)
+    @test isequal(expr1.aff, 2x - x - 4)
+    @test isequal(expr1.matvars, {-2trace(Y),trace(Y)})
+    @test isequal(expr1.normexpr, vecnorm(2X) - vecnorm(X))
+    expr2 = s1 - s2
+    @test isa(expr2, ScalarExpr)
+    @test isequal(expr2.aff, 2x + x + 2)
+    @test isequal(expr2.matvars, {-2trace(Y),-trace(Y)})
+    @test isequal(expr2.normexpr, vecnorm(2X) + vecnorm(X))
+    @test_throws MethodError s1 * s2
+    @test_throws MethodError s1 / s2
+    con1 = (s1 >=  s2)
+    @test isequal(con1.terms, s1-s2)
+    @test con1.lb == 0.0
+    @test con1.ub == Inf
+    con2 = (s1 <= s2)
+    @test isequal(con2.terms, s1-s2)
+    @test con2.lb == -Inf
+    @test con2.ub ==  0.0
+    con3 = (s1 == s2)
+    @test isequal(con3.terms, s1-s2)
+    @test con3.lb == 0.0
+    @test con3.ub == 0.0
+end

--- a/test/sdp.jl
+++ b/test/sdp.jl
@@ -66,6 +66,15 @@ setName(X, "my new name")
 @test_throws Exception @defSDPVar(m, -1.0 <= nonzero[6] <= 1.0)
 
 ###########
+# 
+###########
+# transpose
+# size
+# issym
+# getindex
+# hcat, vcat, hvcat 
+
+###########
 # Operators
 ###########
 const 𝕀 = UniformScaling(1)

--- a/test/sdp.jl
+++ b/test/sdp.jl
@@ -53,35 +53,22 @@ B[1:2,1:2] = -1.5*ones(2,2)
 @test getLower(Z) == -Inf
 @test getUpper(Z) == ones(4,4)
 
-# Test: * setLower(x::SDPVar), setUpper
-@test setLower(X) == eye(3,3)
-@test setLower(X) == Inf
-@test getLower(X) == eye(3,3)
-@test getLower(X) == Inf
-@test setLower(Y) == -Inf
-@test setUpper(Y) == 2*ones(5,5)
-@test getLower(Y) == -Inf
-@test getUpper(Y) == 2*ones(5,5)
-@test_throws setUpper(X, ones(2,2))
-@test_throws setUpper(X, 1.0)
-@test_throws setUpper(X, rand(3,3))
-
 # Test * getName(x::SDPVar), setName
 @test getName(X) == "X"
 setName(X, "my new name")
 @test getName(X) == "my new name"
 
 # Test: * @defSDPVar
-@test_throws @defSDPVar(m, psd[2] <= rand(2,2))
-@test_throws @defSDPVar(m, -Inf <= unbounded[3] <= Inf)
-@test_throws @defSDPVar(m, ones(4,4) <= constant[4] <= ones(4,4))
-@test_throws @defSDPVar(m, rand(5,5) <= nonsymmetric[5] <= rand(5,5))
-@test_throws @defSDPVar(m, -1.0 <= nonzero[6] <= 1.0)
-@defSDPVar
+@test_throws Exception @defSDPVar(m, psd[2] <= rand(2,2))
+@test_throws Exception @defSDPVar(m, -Inf <= unbounded[3] <= Inf)
+@test_throws Exception @defSDPVar(m, ones(4,4) <= constant[4] <= ones(4,4))
+@test_throws Exception @defSDPVar(m, rand(5,5) <= nonsymmetric[5] <= rand(5,5))
+@test_throws Exception @defSDPVar(m, -1.0 <= nonzero[6] <= 1.0)
 
 ###########
 # Operators
 ###########
+const 𝕀 = UniformScaling(1)
 
 # Number--Number
 # Number--Variable
@@ -1552,16 +1539,16 @@ let
     @test isequal(expr2.normexpr, norm(2Y-ones(2)))
     @test_throws MethodError norm(2Y-ones(2)) * (x+1)
     @test_throws MethodError norm(2Y-ones(2)) / (x+1)
-    con1 = (expr >= (x+1))
-    @test isequal(con1.terms, expr-(x+1))
+    con1 = (expr1 >= (x+1))
+    @test isequal(con1.terms, expr1-(x+1))
     @test con1.lb == 0.0
     @test con1.ub == Inf
-    con2 = (expr <= (x+1))
-    @test isequal(con2.terms, expr-(x+1))
+    con2 = (expr1 <= (x+1))
+    @test isequal(con2.terms, expr1-(x+1))
     @test con2.lb == -Inf
     @test con2.ub ==  0.0
-    con3 = (expr == (x+1))
-    @test isequal(con3.terms, expr-(x+1))
+    con3 = (expr1 == (x+1))
+    @test isequal(con3.terms, expr1-(x+1))
     @test con3.lb == 0.0
     @test con3.ub == 0.0
 end
@@ -1729,16 +1716,16 @@ let
     @test isequal(expr2.normexpr, 2norm(2Y-ones(2)))
     @test_throws MethodError (-2 - y - 3trace(X) + 2norm(2Y-ones(2))) * (x+1)
     @test_throws MethodError (-2 - y - 3trace(X) + 2norm(2Y-ones(2))) / (x+1)
-    con1 = (expr >=  (x+1))
-    @test isequal(con1.terms, expr-(x+1))
+    con1 = (expr1 >=  (x+1))
+    @test isequal(con1.terms, expr1-(x+1))
     @test con1.lb == 0.0
     @test con1.ub == Inf
-    con2 = (expr <= (x+1))
-    @test isequal(con2.terms, expr-(x+1))
+    con2 = (expr1 <= (x+1))
+    @test isequal(con2.terms, expr1-(x+1))
     @test con2.lb == -Inf
     @test con2.ub ==  0.0
-    con3 = (expr == (x+1))
-    @test isequal(con3.terms, expr-(x+1))
+    con3 = (expr1 == (x+1))
+    @test isequal(con3.terms, expr1-(x+1))
     @test con3.lb == 0.0
     @test con3.ub == 0.0
 end


### PR DESCRIPTION
This pull request adds SDP functionality to JuMP. Primal, dual, and matrix constraints can be used in modeling. Currently only Mosek support is available, although that will change soon. Left remaining before a merge:
- [ ] Extensive tests on types, operators, etc.
- [x] Construct useful example suite
- [x] Documentation
- [x] ~~Macros for ``setObjective``, ``addConstraint``~~
- [x] Absolute values (#48)
- [x] Handle MatrixExpr/NormExpr in setObjective
- [x] matrix operations on MatrixVar/MatrixExpr's

I'm still not quite sure what functionality will be most useful in practice (for instance, converting Lyapanov equations seems like it would be quite handy), so this should probably be considered an experimental feature for a release cycle or two, at the very least.