### PR TITLE
defVar tidy and better messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_install:
     - git config --global user.name "Travis User"
     - git config --global user.email "travis@example.net"
 script:
-    - julia -e 'versioninfo()'
     - julia -e 'Pkg.init()'
     - if [ $JULIAVERSION = "julianightlies" ]; then julia -e 'Pkg.add("Ipopt")'; fi
     - julia -e 'run(`ln -s $(pwd()) $(Pkg.dir("JuMP"))`); Pkg.pin("JuMP"); Pkg.resolve()'

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -273,9 +273,13 @@ macro defVar(m, x, extra...)
                 ub = esc(x.args[3])
                 lb = -Inf
             end
+        else
+            # Its a comparsion, but not using <= ... <=
+            error("in @defVar ($(string(x))): use the form lb <= ... <= ub")
         end
     else
         # No bounds provided - free variable
+        # If it isn't, e.g. something odd like f(x), we'll handle later
         var = x
         lb = -Inf
         ub = Inf


### PR DESCRIPTION
I added comments, and tried to make the error messages more detailed and standardized. By injecting the the variable name it also should help the whole line number issue.

I changed one thing (and can unchange it): allowing 0,1 bounds for Bin, but nothing else. This lets people drop and add Bin to do manual relaxations. You can just do 0<=x<=1,Int, but I thought this might be ok.

Error messages read better now I think

```
ERROR: in @defVar (x): bounds other than [0, 1] may not be specified for binary variables.
These are always taken to have a lower bound of 0 and upper bound of 1.
```

No reason to not be super verbose
