### PR TITLE
addConstraint macro refactor + error message fiddling

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -166,6 +166,11 @@ macro addConstraint(m, x, extra...)
     # Build the constraint
     if length(x.args) == 3
         # Simple comparison - move everything to the LHS
+        if !((x.args[2] == :<=) || (x.args[2] == :≤) ||
+             (x.args[2] == :>=) || (x.args[2] == :≥) ||
+             (x.args[2] == :(==)))
+            error("in @addConstraint ($(string(x))): expected comparison operator (<=, >=, or ==).")
+        end
         lhs = :($(x.args[1]) - $(x.args[3])) 
         code = quote
             aff = AffExpr()


### PR DESCRIPTION
``` julia
using JuMP
m = Model()
@defVar(m, x>=0)

@setObjective(m, 5x)
# Before:
# ERROR: wrong number of arguments
# After:
# ERROR: in @setObjective: need objective (Max or Min) and expression.

@setObjective(m, Max, x^2)
# Before:
# ERROR: Cannot construct an affine expression with a term of type GenericQuadExpr{Float64,Variable}
# Now:
# ERROR: Marcos (@addConstraint, @setObjective) do not support quadratic expressions.
#        Use addConstraint/setObjective instead
```
