### PR TITLE
RFC: addConstraints macro

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Unversioned
 
   * ``buildInternalModel(m::Model)`` added to build solver-level model in memory without optimizing.
   * Deprecate ``load_model_only`` keyword argument to ``solve``.
+  * Add groups of constraints with ``@addConstraints`` macro.
 
 Version 0.5.2 (May 9, 2014)
 ---------------------------

--- a/doc/refexpr.rst
+++ b/doc/refexpr.rst
@@ -43,6 +43,16 @@ Methods
   See Constraint Reference section for details.
 * ``addConstraint(m::Model, con)`` - general way to add linear and quadratic
   constraints.
+* ``@addConstraints`` - add groups of constraints at once, in the same fashion as @addConstraint. The 
+model must be the first argument, and multiple constraints can be added on multiple lines wrapped in 
+a ``begin ... end`` block. For example::
+    
+    @addConstraints m begin
+      x >= 1
+      y - w <= 2
+      sum_to_one[i=1:3], z[i] + y == 1
+    end
+
 * ``addSOS1(m::Model, coll::Vector{AffExpr})`` - adds special ordered set constraint
   of type 1 (SOS1). Specify the set as a vector of weighted variables, e.g. ``coll = [3x, y, 2z]``.
   Note that solvers expect the weights to be unique. See 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -39,7 +39,7 @@ export
     affToStr, quadToStr, conToStr, chgConstrRHS,
     
 # Macros and support functions
-    @addConstraint, @defVar, 
+    @addConstraint, @addConstraints, @defVar, 
     @defConstrRef, @setObjective, addToExpression,
     @setNLObjective, @addNLConstraint
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -123,3 +123,20 @@ let
     @addConstraint(m, d[i=1:5,j=6:-2:2], x[i] - y[j] == 2)
     @test conToStr(m.linconstr[d[4,4].idx]) == "x[4] - y[4] == 2"
 end
+
+# test @addConstraints
+let
+    m = Model()
+    @defVar(m, x)
+    @defVar(m, y[1:3])
+
+    @addConstraints m begin
+        x + y[1] == 1
+        ref[i=1:3], y[1] + y[i] >= i
+    end
+
+    @test conToStr(m.linconstr[1]) == "x + y[1] == 1"
+    @test conToStr(m.linconstr[2]) == "2 y[1] >= 1"
+    @test conToStr(m.linconstr[3]) == "y[1] + y[2] >= 2"
+    @test conToStr(m.linconstr[4]) == "y[1] + y[3] >= 3"
+end


### PR DESCRIPTION
Allows you to write blocks of constraints like this with less boilerplate:

```
@addConstraints m begin
    x[1] >= 1
    x[2] == 2
    x[1] + x[3] <= 3
    c[i=1:3], x[i] + x[1] <= 2
end
```

Soliciting opinions before I spend time writing docs and all that.
