### PR TITLE
clear solution info after failed solve

### DIFF
--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -205,6 +205,7 @@ function solveLP(m::Model; load_model_only=false, suppress_warnings=false)
     elseif stat != :Optimal
         !suppress_warnings && warn("Not solved to optimality, status: $stat")
         fill!(m.colVal, NaN)
+        m.objVal = NaN
         if stat == :Infeasible
             try
                 m.linconstrDuals = getinfeasibilityray(m.internalModel)


### PR DESCRIPTION
If a solve is unsuccessful, it's not clear what  `getValue` and `getObjectiveValue` give you: it could be information for the failed solve (e.g. an unbounded ray), or something residual from a previous solve (e.g. an optimal solution, but maybe for a modified problem). I don't think that solution information should persist past a single `solve` call; if we can provide information, great, but if not, we shouldn't be providing potentially erroneous information, especially if there's no easy way for the user to know what, exactly, we're giving them. 
