### PR TITLE
Better error message when providing wrong number of arguments

### DIFF
--- a/src/JuMPDict.jl
+++ b/src/JuMPDict.jl
@@ -67,7 +67,12 @@ macro gendict(instancename,T,idxsets...)
         end
     end
 
-    funcs = :($getidxlhs = $getidxrhs; $setidxlhs = $setidxrhs; $maplhs = $maprhs)
+    badgetidxlhs = :(Base.getindex(d::$(typename),wrong...))
+    badgetidxrhs = :(error("Wrong number of indices for ",d.name,
+                           ", expected ",length(d.indexsets)))
+
+    funcs = :($getidxlhs = $getidxrhs; $setidxlhs = $setidxrhs;
+              $maplhs = $maprhs; $badgetidxlhs = $badgetidxrhs)
     geninstance = :($(esc(instancename)) = $(typename)(Array($T),$(string(instancename)),$(esc(Expr(:tuple,idxsets...)))))
     for i in 1:N
         push!(geninstance.args[2].args[2].args, :(length($(esc(idxsets[i])))))


### PR DESCRIPTION
I do this all the time when reorganizing models, the default message sucks.

So instead of 

```
ERROR: no method getindex(JuMPDict##7068{Variable}, Int64)
 in include at boot.jl:244
 in include_from_node1 at loading.jl:128
while loading /home/idunning/.julia/v0.3/JuMP/break.jl, in expression starting on line 5
```

we'll now have

```
ERROR: Wrong number of indices for x, expected 2
 in getindex at no file
 in include at boot.jl:244
 in include_from_node1 at loading.jl:128
while loading /home/idunning/.julia/v0.3/JuMP/break.jl, in expression starting on line 5
```

```
using JuMP
m=Model()
@defVar(m, x[1:5,1:5])
x[2,1]
x[1]
```
