### PR TITLE
RFC: Clear internal model if problem modification won't catch it

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -1,9 +1,19 @@
 export setLazyCallback, setCutCallback, setHeuristicCallback
 export setlazycallback
 @Base.deprecate setlazycallback setLazyCallback
-setLazyCallback(m::Model, f::Function) = (m.lazycallback = f)
-setCutCallback(m::Model, f::Function) = (m.cutcallback = f)
-setHeuristicCallback(m::Model, f::Function) = (m.heurcallback = f)
+function setLazyCallback(m::Model, f::Function)
+    m.internalModelLoaded = false
+    m.lazycallback = f
+end
+function setCutCallback(m::Model, f::Function)
+    m.internalModelLoaded = false
+    m.cutcallback = f
+end
+function setHeuristicCallback(m::Model, f::Function)
+    m.internalModelLoaded = false
+    m.heurcallback = f
+end
+
 
 function registercallbacks(m::Model)
     if isa(m.lazycallback, Function)

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -45,6 +45,8 @@ function addQuadratics(m::Model)
 
     if length(m.obj.qvars1) != 0
         assert_isfinite(m.obj)
+        verify_ownership(m, m.obj.qvars1)
+        verify_ownership(m, m.obj.qvars2)
         MathProgBase.setquadobjterms!(m.internalModel, Cint[v.col for v in m.obj.qvars1], Cint[v.col for v in m.obj.qvars2], m.obj.qcoeffs)
     end
 
@@ -82,6 +84,7 @@ function prepProblemBounds(m::Model)
 
     objaff::AffExpr = m.obj.aff
     assert_isfinite(objaff)
+    verify_ownership(m, objaff.vars)
         
     # We already have dense column lower and upper bounds
 
@@ -157,7 +160,7 @@ function solveLP(m::Model; load_model_only=false, suppress_warnings=false)
     f, rowlb, rowub = prepProblemBounds(m)  
 
     # Ready to solve
-    hasQuads = (length(m.quadconstr) > 0) || (length(m.obj.qvars1) > 0)
+    noQuads = (length(m.quadconstr) == 0) && (length(m.obj.qvars1) == 0)
     if m.internalModelLoaded
         if applicable(MathProgBase.setvarLB!, m.internalModel, m.colLower) &&
            applicable(MathProgBase.setvarUB!, m.internalModel, m.colUpper) &&
@@ -201,17 +204,17 @@ function solveLP(m::Model; load_model_only=false, suppress_warnings=false)
         m.colVal = fill(NaN, m.numCols)
         m.objVal = NaN
         if stat == :Infeasible
-            if !hasQuads && applicable(MathProgBase.getinfeasibilityray, m.internalModel)
+            if noQuads && applicable(MathProgBase.getinfeasibilityray, m.internalModel)
                 m.linconstrDuals = MathProgBase.getinfeasibilityray(m.internalModel)
             else
-                !suppress_warnings && warn("Infeasibility ray (Farkas proof) not available")
+                noQuads && !suppress_warnings && warn("Infeasibility ray (Farkas proof) not available")
                 m.linconstrDuals = fill(NaN, length(m.linconstr))
             end
         elseif stat == :Unbounded
-            if !hasQuads && applicable(MathProgBase.getunboundedray, m.internalModel)
+            if noQuads && applicable(MathProgBase.getunboundedray, m.internalModel)
                 m.colVal = MathProgBase.getunboundedray(m.internalModel)
             else
-                !suppress_warnings && warn("Unbounded ray not available")
+                noQuads && !suppress_warnings && warn("Unbounded ray not available")
                 m.colVal = fill(NaN, numCols)
             end
         else
@@ -233,12 +236,12 @@ function solveLP(m::Model; load_model_only=false, suppress_warnings=false)
         m.objVal = MathProgBase.getobjval(m.internalModel)
         m.objVal += m.obj.aff.constant
         m.colVal = MathProgBase.getsolution(m.internalModel)
-        if !hasQuads && applicable(MathProgBase.getreducedcosts, m.internalModel) &&
-                        applicable(MathProgBase.getconstrduals,  m.internalModel)
+        if noQuads && applicable(MathProgBase.getreducedcosts, m.internalModel) &&
+                      applicable(MathProgBase.getconstrduals,  m.internalModel)
             m.redCosts = MathProgBase.getreducedcosts(m.internalModel)
             m.linconstrDuals = MathProgBase.getconstrduals(m.internalModel)
         else
-            !suppress_warnings && warn("Dual solutions not available")
+            noQuads && !suppress_warnings && warn("Dual solutions not available")
             m.redCosts = fill(NaN, length(m.linconstr))
             m.linconstrDuals = fill(NaN, length(m.linconstr))
         end

--- a/test/model.jl
+++ b/test/model.jl
@@ -13,8 +13,6 @@ let
     @test_throws getDual(errVar)
 end
 
-
-
 ###############################################################################
 # Test Model A
 #####################################################################
@@ -161,7 +159,6 @@ println("  !!TODO: test external solvers for reading LP and MPS files")
 setObjectiveSense(modA, :Min)
 @test getObjectiveSense(modA) == :Min
 
-
 #####################################################################
 # Test binary variable handling
 let
@@ -173,7 +170,6 @@ let
     @test status == :Optimal
     @test_approx_eq_eps getValue(x) 1.0 1e-6
 end
-
 
 #####################################################################
 # Test model copying
@@ -201,7 +197,7 @@ let
     # Constraints
     source.linconstr[1].ub = 5.0
     @test dest.linconstr[1].ub == 6.0
-    source.quadconstr[1].sense == :(>=)
+    source.quadconstr[1].sense = :(>=)
     @test dest.quadconstr[1].sense == :(<=)
 end  
 

--- a/test/probmod.jl
+++ b/test/probmod.jl
@@ -130,7 +130,8 @@ function methods_test(solvername, solverobj, supp)
 end
 
 # test there were no regressions in applicable
-const mpb_methods = [(MathProgBase.addconstr!,   ([1],[1.0],1.0,1.0)),
+const mpb_methods = [(MathProgBase.addquadconstr!, (Cint[1],Float64[1.0],Cint[1],Cint[1],Float64[1],'>',1.0)),
+                     (MathProgBase.addconstr!,   ([1],[1.0],1.0,1.0)),
                      (MathProgBase.addsos1!,     ([1],[1.0])),
                      (MathProgBase.addsos2!,     ([1],[1.0])),
                      (MathProgBase.addvar!,      ([1],[1.0],1.0,1.0,1.0)),
@@ -149,18 +150,18 @@ const mpb_methods = [(MathProgBase.addconstr!,   ([1],[1.0],1.0,1.0)),
 
 if Pkg.installed("Gurobi") != nothing
     using Gurobi
-    supp = (true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true)
+    supp = (true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true)
     methods_test("Gurobi", GurobiSolver(), supp)
 end
 
 if Pkg.installed("CPLEX") != nothing
     using CPLEX
-    supp = (true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true)
+    supp = (true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true)
     methods_test("CPLEX", CplexSolver(), supp)
 end
 if Pkg.installed("Clp") != nothing
     using Clp
-    supp = (true,false,false,true,true,true,true,true,true,true,true,true,true,true,true,false)
+    supp = (false,true,false,false,true,true,true,true,true,true,true,true,true,true,true,true,false)
     methods_test("Clp", ClpSolver(), supp)
 end
 if Pkg.installed("Cbc") != nothing
@@ -168,14 +169,14 @@ if Pkg.installed("Cbc") != nothing
 end
 if Pkg.installed("GLPK") != nothing
     using GLPKMathProgInterface
-    supp = (true,false,false,true,true,true,true,true,true,true,false,true,true,true,true,false)
+    supp = (false,true,false,false,true,true,true,true,true,true,true,false,true,true,true,true,false)
     methods_test("GLPK", GLPKSolverLP(), supp)
-    supp = (true,false,false, true,true,true,true,true,true,true,true,false,false,false,false,false)
+    supp = (false,true,false,false, true,true,true,true,true,true,true,true,false,false,false,false,false)
     methods_test("GLPK", GLPKSolverMIP(), supp)
 end
 if Pkg.installed("Mosek") != nothing
     using Mosek
-    supp = (true,false,false,true,true,true,true,true,true,true,true,true,true,true,true,false)
+    supp = (true,true,false,false,true,true,true,true,true,true,true,true,true,true,true,true,false)
     methods_test("Mosek", MosekSolver(), supp)
 end
 


### PR DESCRIPTION
This clears the internal model if the user adds something that won't get caught in the problem modification process:
- linear constraints
- quadratic constraints
- SOS constraints
- quadratic objective
- callbacks

We may want to eventually support these types of modification (assuming the solvers support them), but until then we should try to ensure correctness.

There's also a small fix in the model.jl test independent of these changes, so that should me merged into master regardless.
