### PR TITLE
check for valid coefficients, fixes #210

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -252,6 +252,13 @@ Base.convert(::Type{AffExpr}, v::Real) = AffExpr(Variable[], Float64[], v)
 Base.zero(::Type{AffExpr}) = AffExpr(Variable[],Float64[],0.)
 Base.zero(a::AffExpr) = zero(typeof(a))
 
+function assert_isfinite(a::GenericAffExpr)
+    coeffs = a.coeffs
+    for i in 1:length(a.vars)
+        isfinite(coeffs[i]) || error("Invalid coefficient $(coeffs[i]) on variable $(a.vars[i])")
+    end
+end
+
 function setObjective(m::Model, sense::Symbol, a::AffExpr)
     setObjectiveSense(m, sense)
     m.obj = QuadExpr()
@@ -301,6 +308,13 @@ typealias QuadExpr GenericQuadExpr{Float64,Variable}
 QuadExpr() = QuadExpr(Variable[],Variable[],Float64[],AffExpr())
 
 Base.isempty(q::QuadExpr) = (length(q.qvars1) == 0 && isempty(q.aff))
+
+function assert_isfinite(q::GenericQuadExpr)
+    assert_isfinite(q.aff)
+    for i in 1:length(q.qcoeffs)
+        isfinite(q.qcoeffs[i]) || error("Invalid coefficient $(q.qcoeffs[i]) on quadratic term $(q.qvars1[i])*$(q.qvars2[i])")
+    end
+end
 
 function setObjective(m::Model, sense::Symbol, q::QuadExpr)
     m.obj = q

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -42,6 +42,7 @@ end
 function addQuadratics(m::Model)
 
     if length(m.obj.qvars1) != 0
+        assert_isfinite(m.obj)
         MathProgBase.setquadobjterms!(m.internalModel, Cint[v.col for v in m.obj.qvars1], Cint[v.col for v in m.obj.qvars2], m.obj.qcoeffs)
     end
 
@@ -51,7 +52,8 @@ function addQuadratics(m::Model)
         if !((s = string(qconstr.sense)[1]) in ['<', '>', '='])
             error("Invalid sense for quadratic constraint")
         end
-        terms = qconstr.terms
+        terms::QuadExpr = qconstr.terms
+        assert_isfinite(terms)
         for ind in 1:length(terms.qvars1)
             if (terms.qvars1[ind].m != m) || (terms.qvars2[ind].m != m)
                 error("Variable not owned by model present in constraints")
@@ -95,6 +97,7 @@ end
 function prepProblemBounds(m::Model)
 
     objaff::AffExpr = m.obj.aff
+    assert_isfinite(objaff)
         
     # We already have dense column lower and upper bounds
 
@@ -139,6 +142,7 @@ function prepConstrMatrix(m::Model)
     tmpnzidx = tmprow.nzidx
     for c in 1:numRows
         rowptr[c] = nnz + 1
+        assert_isfinite(m.linconstr[c].terms)
         coeffs = m.linconstr[c].terms.coeffs
         vars = m.linconstr[c].terms.vars
         # collect duplicates

--- a/test/model.jl
+++ b/test/model.jl
@@ -251,3 +251,18 @@ let
     str = string(mod)
     @test str == "Min (nonlinear expression)\nSubject to \n3 nonlinear constraints\nx[i], for all i in {1..5} free\n"
 end
+
+
+######################################################################
+# Test NaN checking
+let
+    mod = Model()
+    @defVar(mod, x)
+    @setObjective(mod, Min, NaN*x)
+    @test_throws solve(mod)
+    setObjective(mod, :Min, NaN*x^2)
+    @test_throws solve(mod)
+    @setObjective(mod, Min, x)
+    @addConstraint(mod, Min, NaN*x == 0)
+    @test_throws solve(mod)
+end


### PR DESCRIPTION
Didn't observe any performance hit on the benchmarks. This doesn't address NaN handling in NLP, but in that  case is not strictly an error because sometimes the solver might try to evaluate the function at a bad point.
