### PR TITLE
Quadratic macros, take 2

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -94,7 +94,7 @@ function addToExpression(quad::QuadExpr,c::Number,x::QuadExpr)
     return quad
 end
 
-addToExpression(aff, c, x) = error("Cannot construct an affine expression with a term of type $(typeof(x))")
+addToExpression(aff, c, x) = error("Cannot construct an affine expression with a term of type ($(typeof(c)))*($(typeof(x)))")
 
 function parseCurly(x::Expr, aff::Symbol, constantCoef)
     if !(x.args[1] == :sum || x.args[1] == :∑ || x.args[1] == :Σ) # allow either N-ARY SUMMATION or GREEK CAPITAL LETTER SIGMA
@@ -144,9 +144,9 @@ function parseCurly(x::Expr, aff::Symbol, constantCoef)
                 sizehint($aff.vars,length($aff.vars)+$len)
                 sizehint($aff.coeffs,length($aff.coeffs)+$len)
             else
-                #sizehint($aff.qvars1,length($aff.qvars1)+$len)
-                #sizehint($aff.qvars2,length($aff.qvars2)+$len)
-                #sizehint($aff.qcoeffs,length($aff.qcoeffs)+$len)
+                sizehint($aff.qvars1,length($aff.qvars1)+$len)
+                sizehint($aff.qvars2,length($aff.qvars2)+$len)
+                sizehint($aff.qcoeffs,length($aff.qcoeffs)+$len)
                 sizehint($aff.aff.vars,length($aff.aff.vars)+$len)
                 sizehint($aff.aff.coeffs,length($aff.aff.coeffs)+$len)
             end
@@ -245,8 +245,7 @@ macro addConstraint(m, x, extra...)
         code = quote
             q = AffExpr()
             $(parseExpr(lhs, :q, 1.0))
-            islinear = isa(q,AffExpr)
-            crefflag && !islinear && error("Three argument form form of @addConstraint does not currently support quadratic constraints")
+            crefflag && !isa(q,AffExpr) && error("Three argument form form of @addConstraint does not currently support quadratic constraints")
             $(refcall) = addConstraint($m, $(x.args[2])(q,0))
         end
     elseif length(x.args) == 5

--- a/test/perf/macro.jl
+++ b/test/perf/macro.jl
@@ -2,35 +2,64 @@
 # Macro-exercising speed tests
 using JuMP
 
-function test_1(N)
+function test_linear(N)
     m = Model()
     @defVar(m, x[1:10N,1:5N])
     @defVar(m, y[1:N,1:N,1:N])
 
-    @addConstraint(m, cons[z=1:10],
-        y[1,1,1]*9 - 5*y[N,N,N] -
-        2*sum{ z*x[j,i*N],                j=((z-1)*N+1):z*N, i=3:4} +
-          sum{ i*(9*x[i,j] + x[j,i]*3),   i=N:2N,            j=N:2N} + 
-        x[1,1] + x[10N,5N] + x[2N,1] + 
-        y[1,1,N]*1 + 2*y[1,N,1] + 3*y[N,1,1] +
-        y[N,N,N] - 2*y[N,N,N] + 3*y[N,N,N] 
-         <=
-        sum{sum{sum{N*i*j*k*y[i,j,k] + x[i,j],k=1:N; i!=j && j!=k},j=1:N},i=1:N} +
-        sum{sum{x[i,j], j=1:5N; j % i == 3}, i=1:10N; i <= z*N}
-        )
+    for z in 1:10
+        @addConstraint(m,
+            9*y[1,1,1] - 5*y[N,N,N] -
+            2*sum{ z*x[j,i*N],                j=((z-1)*N+1):z*N, i=3:4} +
+              sum{ i*(9*x[i,j] + 3*x[j,i]),   i=N:2N,            j=N:2N} + 
+            x[1,1] + x[10N,5N] + x[2N,1] + 
+            1*y[1,1,N] + 2*y[1,N,1] + 3*y[N,1,1] +
+            y[N,N,N] - 2*y[N,N,N] + 3*y[N,N,N] 
+             <=
+            sum{sum{sum{N*i*j*k*y[i,j,k] + x[i,j],k=1:N; i!=j && j!=k},j=1:N},i=1:N} +
+            sum{sum{x[i,j], j=1:5N; j % i == 3}, i=1:10N; i <= N*z}
+            )
+    end
 end
+
+function test_quad(N)
+    m = Model()
+    @defVar(m, x[1:10N,1:5N])
+    @defVar(m, y[1:N,1:N,1:N])
+
+    for z in 1:10
+        @addConstraint(m,
+            9*y[1,1,1] - 5*y[N,N,N] -
+            2*sum{ z*x[j,i*N],                j=((z-1)*N+1):z*N, i=3:4} +
+              sum{ i*(9*x[i,j] + 3*x[j,i]),   i=N:2N,            j=N:2N} + 
+            x[1,1] + x[10N,5N] * x[2N,1] + 
+            1*y[1,1,N] * 2*y[1,N,1] + 3*y[N,1,1] +
+            y[N,N,N] - 2*y[N,N,N] * 3*y[N,N,N] 
+             <=
+            sum{sum{sum{N*i*j*k*y[i,j,k] * x[i,j],k=1:N; i!=j && j!=k},j=1:N},i=1:N} +
+            sum{sum{x[i,j], j=1:5N; j % i == 3}, i=1:10N; i <= N*z}
+            )
+    end
+end
+
 
 # Warmup
 println("Test 1")
-test_1(1)
+test_linear(1)
+test_quad(1)
 for N in [20,50,100]
     println("  Running N=$(N)...")
-    N_times = {}
+    N1_times = {}
+    N2_times = {}
     for iter in 1:10
         tic()
-        test_1(N)
-        push!(N_times, toq())
+        test_linear(N)
+        push!(N1_times, toq())
+        tic()
+        test_quad(N)
+        push!(N2_times, toq())
     end
-    println("    N=$(N) min $(minimum(N_times))")
+    println("    N=$(N) min $(minimum(N1_times))")
+    println("    N=$(N) min $(minimum(N2_times))")
 end
 


### PR DESCRIPTION
Changed the code a bit, and now I'm only seeing a regression on `test/perf/speed.jl` of about 5%. I'm a bit hazy as to whether this is actually type stable or not: the return type for `addToExpression` is deterministic for a given method signature, but not across the function as a whole. Should probably do a bit more thorough job benchmarking.
