### PR TITLE
check that solvers ignore infeasible solutions provided by heuristics

### DIFF
--- a/test/callback.jl
+++ b/test/callback.jl
@@ -64,6 +64,9 @@ function callback_test(solvername, lazysolver, cutsolver, heursolver)
             # Check that solvers ignore infeasible solutions
             setSolutionValue!(cb, x, 3)
             addSolution(cb)
+            setSolutionValue!(cb, x, 3)
+            setSolutionValue!(cb, y, 5)
+            addSolution(cb)
         end
         setHeuristicCallback(mod, myheuristic)
         solve(mod)


### PR DESCRIPTION
This test passes for gurobi but fails for cplex. We're not even providing a full solution, so seems like bad behavior for cplex to complete the solution into something infeasible.
