### PR TITLE
deprecate @defConstrRef

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ JuMP release notes
 Unreleased
 ----------
 
+  * The ``@defConstrRef`` macro is deprecated in favor of the three-argument version of ``@addConstraint``.
   * The ``@addNLConstraint`` macro now supports the three-argument version to define sets of nonlinear constraints.
   * Speed improvements for nonlinear model generation.
   * KNITRO supported as a nonlinear solver.

--- a/doc/refexpr.rst
+++ b/doc/refexpr.rst
@@ -110,18 +110,3 @@ When an LP model is infeasible, ``getDual`` will return the corresponding compon
 infeasibility ray (Farkas proof), if available from the solver.
 
 Dual information is unavailable for MIPs and has not yet been implemented for quadratic constraints.
-
-For users who prefer to generate constraints in an explicit loop, we also
-provide the ``@defConstrRef`` convenience macro, e.g.::
-
-    @defConstrRef constraintName[1:3]
-
-You can then iterate over constraints and store
-references in this structure, e.g.::
-
-    @defVar(m, x[1:5] >= 0)
-    @defConstrRef myCons[1:5]
-    for i = 1:5
-      myCons[i] = @addConstraint(m, x[i] >= i)
-    end
-

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -394,6 +394,7 @@ macro defVar(args...)
 end
 
 macro defConstrRef(var)
+    Base.warn_once("Use of @defConstrRef is deprecated. Use the three-argument version of @addConstraint instead, e.g.,\n\t@addConstraint(m, $var, ...)")
     if isa(var,Symbol)
         # easy case
         return esc(:(local $var))

--- a/test/model.jl
+++ b/test/model.jl
@@ -47,10 +47,9 @@ facts("[model] Test printing a model") do
     @defVar(modA, 2 <= z <= 4)
     @defVar(modA, 0 <= r[i=3:6] <= i)
     @setObjective(modA, Max, ((x + y)/2.0 + 3.0)/3.0 + z + r[3])
-    @defConstrRef constraints[1:3]
-    constraints[1] = @addConstraint(modA, 2 <= x+y <= 4)
-    constraints[2] = @addConstraint(modA, sum{r[i],i=3:5} <= (2 - x)/2.0)
-    constraints[3] = @addConstraint(modA, 7.0*y <= z + r[6]/1.9)
+    @addConstraint(modA, 2 <= x+y <= 4)
+    @addConstraint(modA, sum{r[i],i=3:5} <= (2 - x)/2.0)
+    @addConstraint(modA, 7.0*y <= z + r[6]/1.9)
     #####################################################################
     # Test LP writer
     writeLP(modA, modPath * "A.lp")
@@ -179,10 +178,9 @@ context("With solver $(typeof(solver))") do
     @defVar(modA, 2 <= z <= 4)
     @defVar(modA, 0 <= r[i=3:6] <= i)
     @setObjective(modA, Max, ((x + y)/2.0 + 3.0)/3.0 + z + r[3])
-    @defConstrRef cons[1:3]
-    cons[1] = @addConstraint(modA, x+y >= 2)
-    cons[2] = @addConstraint(modA, sum{r[i],i=3:5} <= (2 - x)/2.0)
-    cons[3] = @addConstraint(modA, 7.0*y <= z + r[6]/1.9)
+    @addConstraint(modA, cons1, x+y >= 2)
+    @addConstraint(modA, cons2, sum{r[i],i=3:5} <= (2 - x)/2.0)
+    @addConstraint(modA, cons3, 7.0*y <= z + r[6]/1.9)
  
     # Solution
     @fact solve(modA) => :Optimal  
@@ -205,9 +203,9 @@ context("With solver $(typeof(solver))") do
     @fact getDual(r)[6] => roughly( 0.03759398, 1e-6)
 
     # Row duals
-    @fact getDual(cons)[1] => roughly(-0.333333, 1e-6)
-    @fact getDual(cons)[2] => roughly( 1.0, 1e-6)
-    @fact getDual(cons)[3] => roughly( 0.0714286, 1e-6)
+    @fact getDual(cons1) => roughly(-0.333333, 1e-6)
+    @fact getDual(cons2) => roughly( 1.0, 1e-6)
+    @fact getDual(cons3) => roughly( 0.0714286, 1e-6)
 end # solver context
 end # loop over solvers
 end # facts block


### PR DESCRIPTION
Now that the three argument versions of ``@addConstraint`` and ``@addNLConstraint`` work in general, I don't see much of a point of keeping this around. Users can always create their own collections of constraint references if needed.