### PR TITLE
add :(<=) symbols to constr_expr output for linear range constraints

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,17 @@ environment:
 #  - JULIAVERSION: "download/win32"
 #  - JULIAVERSION: "download/win64"
 
+branches:
+  only:
+    - master
+    - /release-.*/
+
 install:
+# if there's a newer build queued for the same PR, cancel this one
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/mlubin/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
 # Download most recent Julia Windows binary
   - ps: (new-object net.webclient).DownloadFile($("http://status.julialang.org/"+$env:JULIAVERSION), "C:\projects\julia-binary.exe")
 # Run installer silently, output to C:\projects\julia

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -405,7 +405,7 @@ function MathProgBase.constr_expr(d::JuMPNLPEvaluator,i::Integer)
         constr = d.m.linconstr[i]
         ex = affToExpr(constr.terms, false)
         if sense(constr) == :range
-            return Expr(:comparison, constr.lb, ex, constr.ub)
+            return Expr(:comparison, constr.lb, :(<=), ex, :(<=), constr.ub)
         else
             return Expr(:comparison, ex, sense(constr), rhs(constr))
         end

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -215,7 +215,7 @@ function test_nl_mpb()
     @addConstraint(m, 2x+y <= 1)
     @addConstraint(m, 2x+y <= 0)
     @addConstraint(m, -5 <= 2x+y <= 5)
-    solve(m)
+    #solve(m) # FIXME maybe?
     
     @addConstraint(m, 2x^2+y >= 2)
     @addNLConstraint(m, sin(x)*cos(y) == 5)
@@ -232,7 +232,7 @@ facts("[nonlinear] Expression graph for linear problem") do
     @defVar(m, x)
     @addConstraint(m, 0 <= x <= 1)
     @setObjective(m, Max, x)
-    d = JuMP.JuMPNLPEvaluator(m, prepConstrMatrix(m))
+    d = JuMP.JuMPNLPEvaluator(m, JuMP.prepConstrMatrix(m))
     MathProgBase.initialize(d, [:ExprGraph])
     @fact MathProgBase.obj_expr(d) => :(+(1.0 * x[1]))
 end

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -190,12 +190,16 @@ function MathProgBase.loadnonlinearproblem!(m::DummyNLPModel, numVar, numConstr,
     facts("[nonlinear] Test NL MPB interface ($objexpr)") do
         @fact objexpr => anyof(:(x[1]^x[2]), :(-1.0*x[1]+1.0*x[2]))
         @fact MathProgBase.isconstrlinear(d,1) => true
+        @fact MathProgBase.isconstrlinear(d,3) => true
         @fact MathProgBase.constr_expr(d,1) => :(2.0*x[1] + 1.0*x[2] <= 1.0)
         @fact MathProgBase.constr_expr(d,2) => :(2.0*x[1] + 1.0*x[2] <= 0.0)
-        @fact MathProgBase.constr_expr(d,3) => :(2.0*x[1]*x[1] + 1.0*x[2] + -2.0 >= 0)
-        @fact MathProgBase.constr_expr(d,4) => :(sin(x[1]) * cos(x[2]) - 5 == 0.0)
-        @fact MathProgBase.constr_expr(d,5) => :(1.0*x[1]^2 - 1.0 == 0.0)
-        @fact MathProgBase.constr_expr(d,6) => :(2.0*x[1]^2 - 2.0 == 0.0)
+        @fact MathProgBase.constr_expr(d,3) => :(-5.0 <= 2.0*x[1] + 1.0*x[2] <= 5.0)
+        if numConstr > 3
+            @fact MathProgBase.constr_expr(d,4) => :(2.0*x[1]*x[1] + 1.0*x[2] + -2.0 >= 0)
+            @fact MathProgBase.constr_expr(d,5) => :(sin(x[1]) * cos(x[2]) - 5 == 0.0)
+            @fact MathProgBase.constr_expr(d,6) => :(1.0*x[1]^2 - 1.0 == 0.0)
+            @fact MathProgBase.constr_expr(d,7) => :(2.0*x[1]^2 - 2.0 == 0.0)
+        end
     end
 end
 MathProgBase.setwarmstart!(m::DummyNLPModel,x) = nothing
@@ -210,6 +214,9 @@ function test_nl_mpb()
     @setObjective(m, Min, -x+y)
     @addConstraint(m, 2x+y <= 1)
     @addConstraint(m, 2x+y <= 0)
+    @addConstraint(m, -5 <= 2x+y <= 5)
+    solve(m)
+    
     @addConstraint(m, 2x^2+y >= 2)
     @addNLConstraint(m, sin(x)*cos(y) == 5)
     @addNLConstraint(m, nlconstr[i=1:2], i*x^2 == i)


### PR DESCRIPTION
looks like a simple fix to part of https://github.com/JuliaOpt/JuMP.jl/issues/350#issuecomment-70590225