### PR TITLE
load duals when quadratic constraints present

### DIFF
--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -262,12 +262,12 @@ function solveLP(m::Model; suppress_warnings=false)
         m.objVal = MathProgBase.getobjval(m.internalModel)
         m.objVal += m.obj.aff.constant
         m.colVal = MathProgBase.getsolution(m.internalModel)
-        if noQuads && applicable(MathProgBase.getreducedcosts, m.internalModel) &&
+        if applicable(MathProgBase.getreducedcosts, m.internalModel) &&
                       applicable(MathProgBase.getconstrduals,  m.internalModel)
             m.redCosts = MathProgBase.getreducedcosts(m.internalModel)
             m.linconstrDuals = MathProgBase.getconstrduals(m.internalModel)
         else
-            noQuads && !suppress_warnings && warn("Dual solutions not available")
+            !suppress_warnings && warn("Dual solutions not available")
             m.redCosts = fill(NaN, length(m.linconstr))
             m.linconstrDuals = fill(NaN, length(m.linconstr))
         end

--- a/test/qcqpmodel.jl
+++ b/test/qcqpmodel.jl
@@ -85,6 +85,33 @@ context("With solver $(typeof(solver))") do
 
 end; end; end
 
+facts("[qcqpmodel] Test SOC duals") do
+for solver in soc_solvers
+context("With solver $(typeof(solver))") do
+
+    modQ = Model(solver=solver)
+    @defVar(modQ, x >= 0)
+    @defVar(modQ, y)
+    @defVar(modQ, z)
+    @setObjective(modQ, Min, -y-z)
+    @addConstraint(modQ, eq, x <= 1)
+    @addConstraint(modQ, y^2 + z^2 <= x^2)
+
+    @fact solve(modQ) => :Optimal
+    @fact modQ.objVal => roughly(-sqrt(2), 1e-6)
+    @fact getValue(y) => roughly(1/sqrt(2), 1e-6)
+    @fact getValue(z) => roughly(1/sqrt(2), 1e-6)
+    @fact getDual(eq) => roughly(-sqrt(2), 1e-6)
+
+    @setObjective(modQ, Max, y+z)
+    @fact solve(modQ) => :Optimal
+    @fact modQ.objVal => roughly(sqrt(2), 1e-6)
+    @fact getValue(y) => roughly(1/sqrt(2), 1e-6)
+    @fact getValue(z) => roughly(1/sqrt(2), 1e-6)
+    @fact getDual(eq) => roughly(sqrt(2), 1e-6)
+
+end; end; end
+
 facts("[qcqpmodel] Test quad constraints (discrete)") do
 for solver in quad_mip_solvers
 context("With solver $(typeof(solver))") do

--- a/test/solvers.jl
+++ b/test/solvers.jl
@@ -73,7 +73,7 @@ if glp
 end
 # Quadratic support
 quad_solvers = Any[]
-grb && push!(quad_solvers, Gurobi.GurobiSolver(OutputFlag=0))
+grb && push!(quad_solvers, Gurobi.GurobiSolver(QCPDual=1,OutputFlag=0))
 cpx && push!(quad_solvers, CPLEX.CplexSolver(CPX_PARAM_SCRIND=0))
 mos && push!(quad_solvers, Mosek.MosekSolver(LOG=0))
 quad_mip_solvers = copy(quad_solvers)


### PR DESCRIPTION
I think Gurobi was the only reason why we didn't do this before, but that's addressed in https://github.com/JuliaOpt/Gurobi.jl/commit/8498bed9a35d3b66723fe09e0101fee2d089dd0b.
We still don't expose lagrangian duals of quadratic constraints (#291), but this may not be needed for SOC problems.