### PR TITLE
Add a few more tests for lower bounds of binaries

### DIFF
--- a/test/probmod.jl
+++ b/test/probmod.jl
@@ -231,6 +231,18 @@ context("With solver $(typeof(solver))") do
     setUpper(x, 0.0)
     solve(mod)
     @fact getValue(x) => roughly(0.0)
+    # same thing, other direction
+    mod = Model(solver=solver)
+    @defVar(mod, x, Bin)
+    @setObjective(mod, Min, x)
+    solve(mod)
+    @fact getValue(x) => roughly(0.0)
+    setLower(x, -1.0)
+    solve(mod)
+    @fact getValue(x) => roughly(0.0)
+    setLower(x, 1.0)
+    solve(mod)
+    @fact getValue(x) => roughly(1.0)
 end
 end
 end


### PR DESCRIPTION
OS some bugs with the combination of binary variables and bounds. Thanks for having the tests that identified the bug. This adds the same check but for lower bounds, which OS wasn't doing anything about but it should be.