### PR TITLE
Pass on kwargs to solve hook

### DIFF
--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -1,6 +1,6 @@
-function solve(m::Model; suppress_warnings=false, ignore_solve_hook=(m.solvehook==nothing))
+function solve(m::Model; suppress_warnings=false, ignore_solve_hook=(m.solvehook==nothing), kwargs...)
 
-    ignore_solve_hook || return m.solvehook(m; suppress_warnings=suppress_warnings)
+    ignore_solve_hook || return m.solvehook(m; suppress_warnings=suppress_warnings, kwargs...)
 
     if m.nlpdata != nothing
         if isa(m.solver,UnsetSolver)


### PR DESCRIPTION
This is pretty essential to make JuMPeR work as it is right now. Without this I'll need to have some option-setting lines before the solve, which doesn't feel good.
If this is OK, can it be v0.7.5?