### PR TITLE
limited support for embedded nonlinear expressions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.3
 MathProgBase 0.3.8 0.4.0-
-ReverseDiffSparse 0.1.11-
+ReverseDiffSparse 0.1.12
 ArrayViews
 Compat
 Calculus

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -34,7 +34,8 @@ export
 # Macros and support functions
     @addConstraint, @addConstraints, @defVar,
     @defConstrRef, @setObjective, addToExpression, @defExpr,
-    @setNLObjective, @addNLConstraint, @addNLConstraints
+    @setNLObjective, @addNLConstraint, @addNLConstraints,
+    @defNLExpr
 
 include("JuMPDict.jl")
 #include("JuMPArray.jl")

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -204,6 +204,10 @@ facts("[macros] @addNLConstraints") do
     @fact "$(ReverseDiffSparse.base_expression(m.nlpdata.nlconstr[3].terms))" => "y[i] - 0"
     @fact "$(ReverseDiffSparse.base_expression(m.nlpdata.nlconstr[4].terms))" => "(x + y[1] * y[2] * y[3]) - 0.5"
 
+    @defNLExpr(nl[i=1:2], y[i])
+    @fact "$(ReverseDiffSparse.base_expression(nl[1]))" => "y[i]"
+    @fact "$(ReverseDiffSparse.base_expression(nl[2]))" => "y[i]"
+
 end
 
 facts("[macros] @setObjective with quadratic") do

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -182,6 +182,21 @@ context("With solver $(typeof(nlp_solver))") do
     @fact getValue(x) + getValue(y) => roughly(-1/3, 1e-3)
 end; end; end
 
+facts("[nonlinear] Test maximization objective (embedded expressions)") do
+for nlp_solver in convex_nlp_solvers
+context("With solver $(typeof(nlp_solver))") do
+    m = Model(solver=nlp_solver)
+    @defVar(m, -2 <= x <= 2); setValue(x, -1.8)
+    @defVar(m, -2 <= y <= 2); setValue(y,  1.5)
+    @setNLObjective(m, Max, y - x)
+    @defNLExpr(quadexpr, x + x^2 + x*y + y^2)
+    @addNLConstraint(m, quadexpr <= 1)
+
+    @fact solve(m) => :Optimal
+    @fact getObjectiveValue(m) => roughly(1+4/sqrt(3), 1e-6)
+    @fact getValue(x) + getValue(y) => roughly(-1/3, 1e-3)
+end; end; end
+
 
 facts("[nonlinear] Test infeasibility detection") do
 for nlp_solver in convex_nlp_solvers


### PR DESCRIPTION
Needs docs and a bunch of testing.

The current limitation is that nonlinear subexpressions cannot appear inside of a ``sum{}`` or ``prod{}`` term, because we would need to add in a lot of new infrastructure to handle this case and ensure that subexpressions are homogeneous.

CC @tkelman