### PR TITLE
[RFC] Add info callback and refactor callback code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 JuMP release notes
 ==================
 
+Unversioned
+-----------
+
+  * **Breaking change**: ``set___Callback`` family deprecated in favor of ``add___Callback``.
+  * Multiple callbacks of the same type can be registered.
+  * Added support for informational callbacks via ``addInfoCallback``.
+
 Version 0.7.4 (February 4, 2015)
 --------------------------------
 

--- a/doc/callbacks.rst
+++ b/doc/callbacks.rst
@@ -280,6 +280,32 @@ including::
     cbgetstate(cb)
 
 
+Informational Callbacks
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Sometimes it can be useful to track solver progress without actually changing the algorithm by adding cuts or heuristic solutions. In these cases, informational callbacks can be added, wherein statistics can be tracked via the ``cbget`` functions discussed in the previous section. Informational callbacks are added to a JuMP model with the ``addInfoCallback(m::Model, f::Function)`` function.
+
+For a simple example, we can add a function that tracks the best bound and incumbent objective value as the solver progresses through the branch-and-bound tree::
+
+    # build model ``m`` up here
+
+    type NodeData
+        node::Int
+        obj::Float64
+        bestbound::Float64
+    end
+
+    bbdata = NodeData[]
+
+    function infocallback(cb)
+        node      = cbgetexplorednodes(cb)
+        obj       = cbgetobj(cb)
+        bestbound = cbgetbestbound(cb)
+        push!(bbdata, NodeData(node,obj,bestbound))
+    end
+    setInfoCallback(m, infocallback)
+
+
 Code Design Considerations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -70,9 +70,10 @@ type Model
     solver::MathProgBase.AbstractMathProgSolver
     internalModelLoaded::Bool
     # callbacks
-    lazycallback
-    cutcallback
-    heurcallback
+    callbacks
+    # lazycallback
+    # cutcallback
+    # heurcallback
 
     # hook into a solve call...function of the form f(m::Model; kwargs...),
     # where kwargs get passed along to subsequent solve calls
@@ -107,7 +108,7 @@ function Model(;solver=UnsetSolver())
     Model(QuadExpr(),:Min,LinearConstraint[], QuadConstraint[],SOSConstraint[],
           0,String[],String[],Float64[],Float64[],Symbol[],
           0,Float64[],Float64[],Float64[],nothing,solver,
-          false,nothing,nothing,nothing,nothing,nothing,JuMPContainer[],
+          false,Any[],nothing,nothing,JuMPContainer[],
           IndexedVector(Float64,0),nothing,Dict{Symbol,Any}())
 end
 
@@ -146,9 +147,7 @@ function Base.copy(source::Model)
 
     dest = Model()
     dest.solver = source.solver  # The two models are linked by this
-    dest.lazycallback = source.lazycallback
-    dest.cutcallback  = source.cutcallback
-    dest.heurcallback = source.heurcallback
+    dest.callbacks = copy(source.callbacks)
     dest.ext = source.ext  # Should probably be deep copy
     if length(source.ext) >= 1
         Base.warn_once("Copying model with extensions - not deep copying extension-specific information.")

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -102,13 +102,7 @@ end
 function attach_callbacks(m::Model, cbs::Vector{InfoCallback})
     function infocallback(d::MathProgBase.MathProgCallbackData)
         state = MathProgBase.cbgetstate(d)
-        @assert state == :MIPSol || state == :MIPNode
-        if state == :MIPSol  # This shouldn't happen right?
-            println("Is this ever called?")
-            MathProgBase.cbgetmipsolution(d,m.colVal)
-        else
-            MathProgBase.cbgetlpsolution(d,m.colVal)
-        end
+        @assert state == :MIPInfo
         for cb in cbs
             cb.f(d)
         end

--- a/test/callback.jl
+++ b/test/callback.jl
@@ -7,7 +7,7 @@
 # Testing callbacks
 # Must be run as part of runtests.jl, as it needs a list of solvers.
 #############################################################################
-using JuMP, FactCheck
+using JuMP, MathProgBase, FactCheck, Compat
 
 facts("[callback] Test lazy constraints") do
 for lazysolver in lazy_solvers
@@ -95,3 +95,66 @@ context("With solver $(typeof(heursolver))") do
     @fact getValue(x) => roughly(1.0, 1e-6)
     @fact getValue(y) => roughly(2.0, 1e-6)
 end; end; end
+
+facts("[callback] Test informational callback") do
+for infosolver in info_solvers
+context("With solver $(typeof(infosolver))") do
+    nodes      = Int[]
+    objs       = Float64[]
+    bestbounds = Float64[]
+
+    srand(100)
+    N = 10000
+    mod = Model(solver=infosolver)
+    @defVar(mod, x[1:N], Bin)
+    @setObjective(mod, Max, dot(rand(N),x))
+    @addConstraint(mod, c[1:10], dot(rand(N),x) <= rand()*N/10)
+    # Test that solver fills solution correctly
+    function myinfo(cb)
+        push!(nodes,      MathProgBase.cbgetexplorednodes(cb))
+        push!(objs,       MathProgBase.cbgetobj(cb))
+        push!(bestbounds, MathProgBase.cbgetbestbound(cb))
+    end
+    addInfoCallback(mod, myinfo)
+    @fact solve(mod) => :Optimal
+    mono_node, mono_obj, mono_bestbound = true, true, true
+    for n in 2:length(nodes)
+        mono_node &= (nodes[n-1] <= nodes[n] + 1e-8)
+        if nodes[n] > 0 # all bets are off at monotonicity at root node
+            mono_obj &= (objs[n-1] <= objs[n] + 1e-8)
+            mono_bestbound &= (bestbounds[n-1] >= bestbounds[n] - 1e-8)
+        end
+    end
+    @fact mono_node      => true
+    @fact mono_obj       => true
+    @fact mono_bestbound => true
+end; end; end
+
+facts("[callback] Test multiple callbacks") do
+for solver in intersect(lazy_solvers,cut_solvers,heur_solvers)
+context("With solver $(typeof(solver))") do
+
+    mod = Model(solver=solver)
+    @defVar(mod, 0 <= x <= 2, Int)
+    @defVar(mod, 0 <= y <= 2, Int)
+    @setObjective(mod, Max, x + 2y)
+    @addConstraint(mod, y + x <= 3.5)
+    cb_tracker = @compat Dict(
+        :l_1 => false,
+        :l_2 => false,
+        :c_1 => false,
+        :c_2 => false,
+        :h_1 => false,
+        :h_2 => false
+    )
+    addLazyCallback(mod, cb -> (cb_tracker[:l_1] = true))
+    addLazyCallback(mod, cb -> (cb_tracker[:l_2] = true))
+    addCutCallback(mod, cb -> (cb_tracker[:c_1] = true))
+    addCutCallback(mod, cb -> (cb_tracker[:c_2] = true))
+    addHeuristicCallback(mod, cb -> (cb_tracker[:h_1] = true))
+    addHeuristicCallback(mod, cb -> (cb_tracker[:h_2] = true))
+
+    @fact solve(mod) => :Optimal
+    @fact collect(values(cb_tracker)) => fill(true,6)
+end; end; end
+

--- a/test/callback.jl
+++ b/test/callback.jl
@@ -82,7 +82,7 @@ context("With solver $(typeof(heursolver))") do
     @fact getValue(x) => roughly(1.0, 1e-6)
     @fact getValue(y) => roughly(2.0, 1e-6)
 
-    empty!(m.callbacks)
+    empty!(mod.callbacks)
     # Test that solver rejects infeasible partial solutions...
     function myheuristic2(cb)
         x_val = getValue(x)

--- a/test/callback.jl
+++ b/test/callback.jl
@@ -26,7 +26,7 @@ context("With solver $(typeof(lazysolver))") do
             @addLazyConstraint(cb, y + 0.5x + 0.5x <= 3)
         end
     end
-    setLazyCallback(mod, corners)
+    addLazyCallback(mod, corners)
     @fact solve(mod) => :Optimal
     @fact getValue(x) => roughly(1.0, 1e-6)
     @fact getValue(y) => roughly(2.0, 1e-6)
@@ -51,7 +51,7 @@ context("With solver $(typeof(cutsolver))") do
             @addUserCut(cb, y + x <= 3)
         end
     end
-    setCutCallback(mod, mycutgenerator)
+    addCutCallback(mod, mycutgenerator)
     @fact solve(mod) => :Optimal
     @fact getValue(x) => roughly(1.0, 1e-6)
     @fact getValue(y) => roughly(2.0, 1e-6)
@@ -77,11 +77,12 @@ context("With solver $(typeof(heursolver))") do
         # In case of Gurobi - try to figure out what it should be
         addSolution(cb)
     end
-    setHeuristicCallback(mod, myheuristic1)
+    addHeuristicCallback(mod, myheuristic1)
     @fact solve(mod) => :Optimal
     @fact getValue(x) => roughly(1.0, 1e-6)
     @fact getValue(y) => roughly(2.0, 1e-6)
 
+    empty!(m.callbacks)
     # Test that solver rejects infeasible partial solutions...
     function myheuristic2(cb)
         x_val = getValue(x)
@@ -89,7 +90,7 @@ context("With solver $(typeof(heursolver))") do
         setSolutionValue!(cb, x, 3)
         addSolution(cb)
     end
-    setHeuristicCallback(mod, myheuristic2)
+    addHeuristicCallback(mod, myheuristic2)
     @fact solve(mod) => :Optimal
     @fact getValue(x) => roughly(1.0, 1e-6)
     @fact getValue(y) => roughly(2.0, 1e-6)

--- a/test/solvers.jl
+++ b/test/solvers.jl
@@ -59,7 +59,7 @@ grb && push!(sos_solvers, Gurobi.GurobiSolver(OutputFlag=0))
 cpx && push!(sos_solvers, CPLEX.CplexSolver(CPX_PARAM_SCRIND=0))
 cbc && push!(sos_solvers, Cbc.CbcSolver())
 # Callback solvers
-lazy_solvers, cut_solvers, heur_solvers = Any[], Any[], Any[]
+lazy_solvers, cut_solvers, heur_solvers, info_solvers = Any[], Any[], Any[], Any[]
 if grb
     push!(lazy_solvers, Gurobi.GurobiSolver(OutputFlag=0))
     push!( cut_solvers, Gurobi.GurobiSolver(PreCrush=1, Cuts=0, Presolve=0, Heuristics=0.0, OutputFlag=0))
@@ -69,6 +69,7 @@ if cpx
     push!(lazy_solvers, CPLEX.CplexSolver(CPX_PARAM_PRELINEAR=0, CPX_PARAM_PREIND=0, CPX_PARAM_ADVIND=0, CPX_PARAM_MIPSEARCH=1,CPX_PARAM_MIPCBREDLP=0,CPX_PARAM_SCRIND=0))
     push!( cut_solvers, CPLEX.CplexSolver(CPX_PARAM_PRELINEAR=0, CPX_PARAM_PREIND=0, CPX_PARAM_ADVIND=0, CPX_PARAM_MIPSEARCH=1,CPX_PARAM_MIPCBREDLP=0,CPX_PARAM_SCRIND=0))
     push!(heur_solvers, CPLEX.CplexSolver(CPX_PARAM_PRELINEAR=0, CPX_PARAM_PREIND=0, CPX_PARAM_ADVIND=0, CPX_PARAM_MIPSEARCH=1,CPX_PARAM_MIPCBREDLP=0,CPX_PARAM_SCRIND=0))
+    push!(info_solvers, CPLEX.CplexSolver(CPX_PARAM_PRELINEAR=0, CPX_PARAM_PREIND=0, CPX_PARAM_ADVIND=0, CPX_PARAM_MIPSEARCH=1,CPX_PARAM_MIPCBREDLP=0,CPX_PARAM_SCRIND=0))
 end
 if glp
     push!(lazy_solvers, GLPKMathProgInterface.GLPKSolverMIP())


### PR DESCRIPTION
Adds informational callback through the standard interface. Also refactors the callback handling code to allow multiple callbacks to be registered; it is the responsibility of the solver to handle multiple callbacks added to the same model. Thoughts? Maybe it's better to merge together the callbacks at the JuMP level.

cc @mlubin @IainNZ 