### PR TITLE
RFC: another try at nonlinear subexpressions, now embeddable

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.3
 MathProgBase 0.3.8 0.4.0-
-ReverseDiffSparse 0.1.11-
+ReverseDiffSparse 0.2.1
 ArrayViews
 Compat
 Calculus

--- a/doc/nlp.rst
+++ b/doc/nlp.rst
@@ -71,12 +71,6 @@ the syntax for linear and quadratic expressions. We note some important points b
 
     @defNLExpr(myexpr[i=1:n], sin(x[i]))
     @addNLConstraint(m, myconstr[i=1:n], myexpr[i] <= 0.5)
-- Nonlinear expression objects currently cannot appear inside of ``sum{}`` or ``prod{}``. For example::
-
-    @defNLExpr(myexpr[i=1:n], sin(x[i]))
-    # This is not supported!
-    @addNLConstraint(m, myconstr, sum{myexpr[i], i=1:n} <= 0.5)
-
 
 Performance: Solution time
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -34,7 +34,8 @@ export
 # Macros and support functions
     @addConstraint, @addConstraints, @defVar,
     @defConstrRef, @setObjective, addToExpression, @defExpr,
-    @setNLObjective, @addNLConstraint, @addNLConstraints
+    @setNLObjective, @addNLConstraint, @addNLConstraints,
+    @defNLExpr
 
 include("JuMPDict.jl")
 #include("JuMPArray.jl")

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -572,3 +572,18 @@ macro addNLConstraint(m, x, extra...)
 
     return assert_validmodel(m, code)
 end
+
+macro defNLExpr(x, extra...)
+    # Two formats:
+    # - @defNLExpr(a*x <= 5)
+    # - @defNLExpr(myref[a=1:5], sin(x^a))
+    length(extra) > 1 && error("in @defNLExpr: too many arguments.")
+    # Canonicalize the arguments
+    c = length(extra) == 1 ? x        : nothing
+    x = length(extra) == 1 ? extra[1] : x
+
+    refcall, idxvars, idxsets, idxpairs = buildrefsets(c)
+    varname = isexpr(refcall,:ref) ? refcall.args[1] : refcall
+    macrocall = Expr(:macrocall, symbol("@parametricExpr"), [esc(v) for v in idxvars]..., esc(x))
+    return :($(varname) = $macrocall)
+end


### PR DESCRIPTION
The syntax is the same as before but now can be embedded inside ``sum{}`` and ``prod{}``
```
@defNLExpr(entropy[i=1:N], -x[i]*log(x[i]))
@setNLObjective(m, Max, sum{entropy[i], i = 1:N})
```
The syntax is a bit misleading because we actually just create a single ParametricExpression object that needs index parameters like ``i`` but doesn't do anything with the index sets ``1:N``. This is probably better than inventing a new syntax, and later on we can add assertions that indices are valid. As it is now, you're free to use ``entropy[x]`` even when ``x`` isn't in ``1:N``.
CC @tkelman 