### PR TITLE
[RFC] Remove comparison operators

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 JuMP release notes
 ==================
 
+Unversioned
+-----------
+
+  * Comparison operators for constructing constraints (e.g. ``2x >= 1``) have been deprecated. Instead, construct the constraints explicitly in
+    the ``@addConstraint`` macro to add them to the model, or in the ``@LinearConstraint`` macro to create a stand-alone linear constraint instance.
+
 Version 0.8.0 (February 17, 2015)
 ---------------------------------
 

--- a/doc/refexpr.rst
+++ b/doc/refexpr.rst
@@ -71,6 +71,8 @@ The ``ref`` accepts index sets in the same way as ``@defVar``, and those indices
   See `here <http://lpsolve.sourceforge.net/5.5/SOS.htm>`_ for more details.
 * ``@LinearConstraint(expr)`` - Constructs a ``LinearConstraint`` instance efficiently by parsing the ``expr``. The same as ``@addConstraint``, except it does not attach the constraint to any model.
 * ``@LinearConstraints(expr)`` - Constructs a vector of ``LinearConstraint``s. Similar to ``@LinearConstraint``, except it accepts multiple constraints as input as long as they are separated by newlines.
+* ``@QuadConstraint(expr)`` - Constructs a ``QuadConstraint`` instance efficiently by parsing the ``expr``. The same as ``@addConstraint``, except it does not attach the constraint to any model.
+* ``@QuadConstraints(expr)`` - Constructs a vector of ``QuadConstraint``s. Similar to ``@QuadConstraint``, except it accepts multiple constraints as input as long as they are separated by newlines.
 * ``push!(aff::AffExpr, new_coeff::Float64, new_var::Variable)`` - efficient
   way to grow an affine expression by one term. For example, to add ``5x`` to
   an existing expression ``aff``, use ``push!(aff, 5.0, x)``. This is

--- a/doc/refexpr.rst
+++ b/doc/refexpr.rst
@@ -69,6 +69,8 @@ The ``ref`` accepts index sets in the same way as ``@defVar``, and those indices
   of type 2 (SOS2). Specify the set as a vector of weighted variables, e.g. ``coll = [3x, y, 2z]``.
   Note that solvers expect the weights to be unique.
   See `here <http://lpsolve.sourceforge.net/5.5/SOS.htm>`_ for more details.
+* ``@LinearConstraint(expr)`` - Constructs a ``LinearConstraint`` instance efficiently by parsing the ``expr``. The same as ``@addConstraint``, except it does not attach the constraint to any model.
+* ``@LinearConstraints(expr)`` - Constructs a vector of ``LinearConstraint``s. Similar to ``@LinearConstraint``, except it accepts multiple constraints as input as long as they are separated by newlines.
 * ``push!(aff::AffExpr, new_coeff::Float64, new_var::Variable)`` - efficient
   way to grow an affine expression by one term. For example, to add ``5x`` to
   an existing expression ``aff``, use ``push!(aff, 5.0, x)``. This is

--- a/examples/qcp.jl
+++ b/examples/qcp.jl
@@ -23,9 +23,9 @@ m = Model()
 @setObjective(m, Max, x)
 
 # Subject to 1 linear and 2 nonlinear constraints
-addConstraint(m, x + y + z == 1)
-addConstraint(m, x*x + y*y - z*z <= 0)
-addConstraint(m, x*x - y*z <= 0)
+@addConstraint(m, x + y + z == 1)
+@addConstraint(m, x*x + y*y - z*z <= 0)
+@addConstraint(m, x*x - y*z <= 0)
 
 # Print the model to check correctness
 print(m)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -32,7 +32,8 @@ export
     affToStr, quadToStr, conToStr, chgConstrRHS,
 
 # Macros and support functions
-    @addConstraint, @addConstraints, @LinearConstraint, @LinearConstraints,
+    @addConstraint, @addConstraints,
+    @LinearConstraint, @LinearConstraints, @QuadConstraint, @QuadConstraints,
     @defVar, @defConstrRef, @setObjective, addToExpression, @defExpr,
     @setNLObjective, @addNLConstraint, @addNLConstraints,
     @defNLExpr

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -32,8 +32,8 @@ export
     affToStr, quadToStr, conToStr, chgConstrRHS,
 
 # Macros and support functions
-    @addConstraint, @addConstraints, @defVar,
-    @defConstrRef, @setObjective, addToExpression, @defExpr,
+    @addConstraint, @addConstraints, @LinearConstraint, @LinearConstraints,
+    @defVar, @defConstrRef, @setObjective, addToExpression, @defExpr,
     @setNLObjective, @addNLConstraint, @addNLConstraints,
     @defNLExpr
 

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -166,10 +166,11 @@ macro addLazyConstraint(cbdata, x)
     if length(x.args) == 3 # simple comparison
         lhs = :($(x.args[1]) - $(x.args[3])) # move everything to the lhs
         newaff, parsecode = parseExpr(lhs, :aff, [1.0])
+        sense = _canonicalize_sense(x.args[2])
         quote
             aff = AffExpr()
             $parsecode
-            constr = $(x.args[2])($newaff,0)
+            constr = _construct_constraint!($newaff, $(quot(sense)))
             addLazyConstraint($cbdata, constr)
         end
     else
@@ -199,10 +200,11 @@ macro addUserCut(cbdata, x)
     if length(x.args) == 3 # simple comparison
         lhs = :($(x.args[1]) - $(x.args[3])) # move everything to the lhs
         newaff, parsecode = parseExpr(lhs, :aff, [1.0])
+        sense = _canonicalize_sense(x.args[2])
         quote
             aff = AffExpr()
             $parsecode
-            constr = $(x.args[2])($newaff,0)
+            constr = _construct_constraint!($newaff, $(quot(sense)))
             addUserCut($cbdata, constr)
         end
     else

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -257,18 +257,6 @@ function Base.dot{N}(lhs::JuMPArray{Float64,N},rhs::JuMPArray{Float64,N})
     return sum(lhs.innerArray .* rhs.innerArray)
 end
 
-#############################################################################
-# JuMPDict comparison operators (all errors)
-
-# for sgn in (:<=, :(==), :>=)
-#     for term in (:Real, :Variable, :AffExpr)
-#         @eval begin
-#             $(sgn)(a::JuMPContainer, b::$(term)) = error("Cannot construct constraint with a JuMPDict term")
-#             $(sgn)(a::$(term), b::JuMPContainer) = error("Cannot construct constraint with a JuMPDict term")
-#         end
-#     end
-# end
-
 ###############################################################################
 # Add nonlinear function fallbacks for JuMP built-in types
 const op_hint = "Are you trying to build a nonlinear problem? Make sure you use @addNLConstraint/@setNLObjective."

--- a/src/print.jl
+++ b/src/print.jl
@@ -31,6 +31,7 @@ const DIMS = ["i","j","k","l","m","n"]
 # e.g.   5.3  =>  5.3
 #        1.0  =>  1
 function str_round(f::Float64)
+    abs(f) == 0.0 && return "0" # strip sign off zero
     str = string(f)
     length(str) >= 2 && str[end-1:end] == ".0" ? str[1:end-2] : str
 end

--- a/test/model.jl
+++ b/test/model.jl
@@ -279,7 +279,7 @@ facts("[model] Test model copying") do
     @defVar(source, 0 <= y <= 1, Int)
     @setObjective(source, Max, 3*x + 1*y)
     @addConstraint(source, x + 2.0*y <= 6)
-    addConstraint(source, x*x <= 1)
+    @addConstraint(source, x*x <= 1)
 
     # uncomment when NLP copying is implemented
     # @addNLConstraint(source, c[k=1:3], x^2 + y^3 * sin(x+k*y) >= 1)
@@ -322,7 +322,7 @@ facts("[model] Test variable/model 'hygiene'") do
     @addConstraint(modA, x+y == 1)
     @fact_throws solve(modA)
 
-    addConstraint(modB, x*y >= 1)
+    @addConstraint(modB, x*y >= 1)
     @fact_throws solve(modB)
 end
 

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -70,9 +70,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(1 ≤ q) => "2.5 y*z + 7.1 x + 1.5 $geq 0"
     @fact conToStr(1 == q) => "2.5 y*z + 7.1 x + 1.5 $eq 0"
     @fact conToStr(1 ≥ q) => "2.5 y*z + 7.1 x + 1.5 $leq 0"
-    @fact conToStr(@LinearConstraint(1 ≤ q)) => "-2.5 y*z - 7.1 x - 1.5 $leq 0"
-    @fact conToStr(@LinearConstraint(1 == q)) => "-2.5 y*z - 7.1 x - 1.5 $eq 0"
-    @fact conToStr(@LinearConstraint(1 ≥ q)) => "-2.5 y*z - 7.1 x - 1.5 $geq 0"
+    @fact conToStr(@QuadConstraint(1 ≤ q)) => "-2.5 y*z - 7.1 x - 1.5 $leq 0"
+    @fact conToStr(@QuadConstraint(1 == q)) => "-2.5 y*z - 7.1 x - 1.5 $eq 0"
+    @fact conToStr(@QuadConstraint(1 ≥ q)) => "-2.5 y*z - 7.1 x - 1.5 $geq 0"
     end
 
     # 2. Variable tests
@@ -94,9 +94,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(@LinearConstraint(w ≤ 1)) => "w $leq 1"
     @fact conToStr(@LinearConstraint(w == 1)) => "w $eq 1"
     @fact conToStr(@LinearConstraint(w ≥ 1)) => "w $geq 1"
-    @fact conToStr(@LinearConstraint(x*y ≤ 1)) => "x*y - 1 $leq 0"
-    @fact conToStr(@LinearConstraint(x*y == 1)) => "x*y - 1 $eq 0"
-    @fact conToStr(@LinearConstraint(x*y ≥ 1)) => "x*y - 1 $geq 0"
+    @fact conToStr(@QuadConstraint(x*y ≤ 1)) => "x*y - 1 $leq 0"
+    @fact conToStr(@QuadConstraint(x*y == 1)) => "x*y - 1 $eq 0"
+    @fact conToStr(@QuadConstraint(x*y ≥ 1)) => "x*y - 1 $geq 0"
     # 2-2 Variable--Variable
     @fact affToStr(w + x) => "w + x"
     @fact affToStr(w - x) => "w - x"
@@ -115,9 +115,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(@LinearConstraint(w ≤ x)) => "w - x $leq 0"
     @fact conToStr(@LinearConstraint(w == x)) => "w - x $eq 0"
     @fact conToStr(@LinearConstraint(w ≥ x)) => "w - x $geq 0"
-    @fact conToStr(@LinearConstraint(y*z ≤ x)) => "y*z - x $leq 0"
-    @fact conToStr(@LinearConstraint(y*z == x)) => "y*z - x $eq 0"
-    @fact conToStr(@LinearConstraint(y*z ≥ x)) => "y*z - x $geq 0"
+    @fact conToStr(@QuadConstraint(y*z ≤ x)) => "y*z - x $leq 0"
+    @fact conToStr(@QuadConstraint(y*z == x)) => "y*z - x $eq 0"
+    @fact conToStr(@QuadConstraint(y*z ≥ x)) => "y*z - x $geq 0"
     @fact conToStr(@LinearConstraint(x ≤ x)) => "0 $leq 0"
     @fact conToStr(@LinearConstraint(x == x)) => "0 $eq 0"
     @fact conToStr(@LinearConstraint(x ≥ x)) => "0 $geq 0"
@@ -146,9 +146,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(w ≤ q) => "-2.5 y*z - 7.1 x + w - 2.5 $leq 0"
     @fact conToStr(w == q) => "-2.5 y*z - 7.1 x + w - 2.5 $eq 0"
     @fact conToStr(w ≥ q) => "-2.5 y*z - 7.1 x + w - 2.5 $geq 0"
-    @fact conToStr(@LinearConstraint(w ≤ q)) => "-2.5 y*z + w - 7.1 x - 2.5 $leq 0"
-    @fact conToStr(@LinearConstraint(w == q)) => "-2.5 y*z + w - 7.1 x - 2.5 $eq 0"
-    @fact conToStr(@LinearConstraint(w ≥ q)) => "-2.5 y*z + w - 7.1 x - 2.5 $geq 0"
+    @fact conToStr(@QuadConstraint(w ≤ q)) => "-2.5 y*z + w - 7.1 x - 2.5 $leq 0"
+    @fact conToStr(@QuadConstraint(w == q)) => "-2.5 y*z + w - 7.1 x - 2.5 $eq 0"
+    @fact conToStr(@QuadConstraint(w ≥ q)) => "-2.5 y*z + w - 7.1 x - 2.5 $geq 0"
     end
 
     # 3. AffExpr tests
@@ -210,9 +210,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(aff2 ≤ q) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $leq 0"
     @fact conToStr(aff2 == q) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $eq 0"
     @fact conToStr(aff2 ≥ q) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $geq 0"
-    @fact conToStr(@LinearConstraint(aff2 ≤ q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $leq 0"
-    @fact conToStr(@LinearConstraint(aff2 == q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $eq 0"
-    @fact conToStr(@LinearConstraint(aff2 ≥ q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $geq 0"
+    @fact conToStr(@QuadConstraint(aff2 ≤ q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $leq 0"
+    @fact conToStr(@QuadConstraint(aff2 == q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $eq 0"
+    @fact conToStr(@QuadConstraint(aff2 ≥ q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $geq 0"
     end
 
     # 4. QuadExpr
@@ -228,9 +228,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(q ≥ 1) => "2.5 y*z + 7.1 x + 1.5 $geq 0"
     @fact conToStr(q == 1) => "2.5 y*z + 7.1 x + 1.5 $eq 0"
     @fact conToStr(q ≤ 1) => "2.5 y*z + 7.1 x + 1.5 $leq 0"
-    @fact conToStr(@LinearConstraint(aff2 ≤ q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $leq 0"
-    @fact conToStr(@LinearConstraint(aff2 == q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $eq 0"
-    @fact conToStr(@LinearConstraint(aff2 ≥ q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $geq 0"
+    @fact conToStr(@QuadConstraint(aff2 ≤ q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $leq 0"
+    @fact conToStr(@QuadConstraint(aff2 == q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $eq 0"
+    @fact conToStr(@QuadConstraint(aff2 ≥ q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $geq 0"
     # 4-2 QuadExpr--Variable
     @fact quadToStr(q + w) => "2.5 y*z + 7.1 x + w + 2.5"
     @fact quadToStr(q - w) => "2.5 y*z + 7.1 x - w + 2.5"
@@ -239,9 +239,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(q ≤ w) => "2.5 y*z + 7.1 x - w + 2.5 $leq 0"
     @fact conToStr(q == w) => "2.5 y*z + 7.1 x - w + 2.5 $eq 0"
     @fact conToStr(q ≥ w) => "2.5 y*z + 7.1 x - w + 2.5 $geq 0"
-    @fact conToStr(@LinearConstraint(q ≤ w)) => "2.5 y*z + 7.1 x - w + 2.5 $leq 0"
-    @fact conToStr(@LinearConstraint(q == w)) => "2.5 y*z + 7.1 x - w + 2.5 $eq 0"
-    @fact conToStr(@LinearConstraint(q ≥ w)) => "2.5 y*z + 7.1 x - w + 2.5 $geq 0"
+    @fact conToStr(@QuadConstraint(q ≤ w)) => "2.5 y*z + 7.1 x - w + 2.5 $leq 0"
+    @fact conToStr(@QuadConstraint(q == w)) => "2.5 y*z + 7.1 x - w + 2.5 $eq 0"
+    @fact conToStr(@QuadConstraint(q ≥ w)) => "2.5 y*z + 7.1 x - w + 2.5 $geq 0"
     # 4-3 QuadExpr--AffExpr
     @fact quadToStr(q + aff2) => "2.5 y*z + 7.1 x + 1.2 y + 3.7"
     @fact quadToStr(q - aff2) => "2.5 y*z + 7.1 x - 1.2 y + 1.3"
@@ -250,9 +250,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(q ≤ aff2) => "2.5 y*z + 7.1 x - 1.2 y + 1.3 $leq 0"
     @fact conToStr(q == aff2) => "2.5 y*z + 7.1 x - 1.2 y + 1.3 $eq 0"
     @fact conToStr(q ≥ aff2) => "2.5 y*z + 7.1 x - 1.2 y + 1.3 $geq 0"
-    @fact conToStr(@LinearConstraint(q ≤ aff2)) => "2.5 y*z + 7.1 x - 1.2 y + 1.3 $leq 0"
-    @fact conToStr(@LinearConstraint(q == aff2)) => "2.5 y*z + 7.1 x - 1.2 y + 1.3 $eq 0"
-    @fact conToStr(@LinearConstraint(q ≥ aff2)) => "2.5 y*z + 7.1 x - 1.2 y + 1.3 $geq 0"
+    @fact conToStr(@QuadConstraint(q ≤ aff2)) => "2.5 y*z + 7.1 x - 1.2 y + 1.3 $leq 0"
+    @fact conToStr(@QuadConstraint(q == aff2)) => "2.5 y*z + 7.1 x - 1.2 y + 1.3 $eq 0"
+    @fact conToStr(@QuadConstraint(q ≥ aff2)) => "2.5 y*z + 7.1 x - 1.2 y + 1.3 $geq 0"
     # 4-4 QuadExpr--QuadExpr
     @fact quadToStr(q + q2) => "8 x*z + 2.5 y*z + 7.1 x + 1.2 y + 3.7"
     @fact quadToStr(q - q2) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3"
@@ -261,9 +261,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(q ≤ q2) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 $leq 0"
     @fact conToStr(q == q2) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 $eq 0"
     @fact conToStr(q ≥ q2) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 $geq 0"
-    @fact conToStr(@LinearConstraint(q ≤ q2)) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 $leq 0"
-    @fact conToStr(@LinearConstraint(q == q2)) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 $eq 0"
-    @fact conToStr(@LinearConstraint(q ≥ q2)) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 $geq 0"
+    @fact conToStr(@QuadConstraint(q ≤ q2)) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 $leq 0"
+    @fact conToStr(@QuadConstraint(q == q2)) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 $eq 0"
+    @fact conToStr(@QuadConstraint(q ≥ q2)) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 $geq 0"
     end
 end
 

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -48,6 +48,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(2.1 ≤ w) => "w $geq 2.1"
     @fact conToStr(2.1 == w) => "w $eq 2.1"
     @fact conToStr(2.1 ≥ w) => "w $leq 2.1"
+    @fact conToStr(@LinearConstraint(2.1 ≤ w)) => "-w $leq -2.1"
+    @fact conToStr(@LinearConstraint(2.1 == w)) => "-w $eq -2.1"
+    @fact conToStr(@LinearConstraint(2.1 ≥ w)) => "-w $geq -2.1"
     # 1-3 Number--AffExpr
     @fact affToStr(1.5 + aff) => "7.1 x + 4"
     @fact affToStr(1.5 - aff) => "-7.1 x - 1"
@@ -56,6 +59,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(1 ≤ aff) => "7.1 x $geq -1.5"
     @fact conToStr(1 == aff) => "7.1 x $eq -1.5"
     @fact conToStr(1 ≥ aff) => "7.1 x $leq -1.5"
+    @fact conToStr(@LinearConstraint(1 ≤ aff)) => "-7.1 x $leq 1.5"
+    @fact conToStr(@LinearConstraint(1 == aff)) => "-7.1 x $eq 1.5"
+    @fact conToStr(@LinearConstraint(1 ≥ aff)) => "-7.1 x $geq 1.5"
     # 1-4 Number--QuadExpr
     @fact quadToStr(1.5 + q) => "2.5 y*z + 7.1 x + 4"
     @fact quadToStr(1.5 - q) => "-2.5 y*z - 7.1 x - 1"
@@ -64,6 +70,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(1 ≤ q) => "2.5 y*z + 7.1 x + 1.5 $geq 0"
     @fact conToStr(1 == q) => "2.5 y*z + 7.1 x + 1.5 $eq 0"
     @fact conToStr(1 ≥ q) => "2.5 y*z + 7.1 x + 1.5 $leq 0"
+    @fact conToStr(@LinearConstraint(1 ≤ q)) => "-2.5 y*z - 7.1 x - 1.5 $leq 0"
+    @fact conToStr(@LinearConstraint(1 == q)) => "-2.5 y*z - 7.1 x - 1.5 $eq 0"
+    @fact conToStr(@LinearConstraint(1 ≥ q)) => "-2.5 y*z - 7.1 x - 1.5 $geq 0"
     end
 
     # 2. Variable tests
@@ -82,6 +91,12 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(x*y ≤ 1) => "x*y - 1 $leq 0"
     @fact conToStr(x*y == 1) => "x*y - 1 $eq 0"
     @fact conToStr(x*y ≥ 1) => "x*y - 1 $geq 0"
+    @fact conToStr(@LinearConstraint(w ≤ 1)) => "w $leq 1"
+    @fact conToStr(@LinearConstraint(w == 1)) => "w $eq 1"
+    @fact conToStr(@LinearConstraint(w ≥ 1)) => "w $geq 1"
+    @fact conToStr(@LinearConstraint(x*y ≤ 1)) => "x*y - 1 $leq 0"
+    @fact conToStr(@LinearConstraint(x*y == 1)) => "x*y - 1 $eq 0"
+    @fact conToStr(@LinearConstraint(x*y ≥ 1)) => "x*y - 1 $geq 0"
     # 2-2 Variable--Variable
     @fact affToStr(w + x) => "w + x"
     @fact affToStr(w - x) => "w - x"
@@ -97,6 +112,15 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(x ≤ x) => "0 $leq 0"
     @fact conToStr(x == x) => "0 $eq 0"
     @fact conToStr(x ≥ x) => "0 $geq 0"
+    @fact conToStr(@LinearConstraint(w ≤ x)) => "w - x $leq 0"
+    @fact conToStr(@LinearConstraint(w == x)) => "w - x $eq 0"
+    @fact conToStr(@LinearConstraint(w ≥ x)) => "w - x $geq 0"
+    @fact conToStr(@LinearConstraint(y*z ≤ x)) => "y*z - x $leq 0"
+    @fact conToStr(@LinearConstraint(y*z == x)) => "y*z - x $eq 0"
+    @fact conToStr(@LinearConstraint(y*z ≥ x)) => "y*z - x $geq 0"
+    @fact conToStr(@LinearConstraint(x ≤ x)) => "0 $leq 0"
+    @fact conToStr(@LinearConstraint(x == x)) => "0 $eq 0"
+    @fact conToStr(@LinearConstraint(x ≥ x)) => "0 $geq 0"
     # 2-3 Variable--AffExpr
     @fact affToStr(z + aff) => "7.1 x + z + 2.5"
     @fact affToStr(z - aff) => "-7.1 x + z - 2.5"
@@ -108,6 +132,12 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(7.1 * x - aff ≤ 0) => "0 $leq 2.5"
     @fact conToStr(7.1 * x - aff == 0) => "0 $eq 2.5"
     @fact conToStr(7.1 * x - aff ≥ 0) => "0 $geq 2.5"
+    @fact conToStr(@LinearConstraint(z ≤ aff)) => "z - 7.1 x $leq 2.5"
+    @fact conToStr(@LinearConstraint(z == aff)) => "z - 7.1 x $eq 2.5"
+    @fact conToStr(@LinearConstraint(z ≥ aff)) => "z - 7.1 x $geq 2.5"
+    @fact conToStr(@LinearConstraint(7.1 * x - aff ≤ 0)) => "0 $leq 2.5"
+    @fact conToStr(@LinearConstraint(7.1 * x - aff == 0)) => "0 $eq 2.5"
+    @fact conToStr(@LinearConstraint(7.1 * x - aff ≥ 0)) => "0 $geq 2.5"
     # 2-4 Variable--QuadExpr
     @fact quadToStr(w + q) => "2.5 y*z + 7.1 x + w + 2.5"
     @fact quadToStr(w - q) => "-2.5 y*z - 7.1 x + w - 2.5"
@@ -116,6 +146,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(w ≤ q) => "-2.5 y*z - 7.1 x + w - 2.5 $leq 0"
     @fact conToStr(w == q) => "-2.5 y*z - 7.1 x + w - 2.5 $eq 0"
     @fact conToStr(w ≥ q) => "-2.5 y*z - 7.1 x + w - 2.5 $geq 0"
+    @fact conToStr(@LinearConstraint(w ≤ q)) => "-2.5 y*z + w - 7.1 x - 2.5 $leq 0"
+    @fact conToStr(@LinearConstraint(w == q)) => "-2.5 y*z + w - 7.1 x - 2.5 $eq 0"
+    @fact conToStr(@LinearConstraint(w ≥ q)) => "-2.5 y*z + w - 7.1 x - 2.5 $geq 0"
     end
 
     # 3. AffExpr tests
@@ -131,6 +164,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(aff ≤ 1) => "7.1 x $leq -1.5"
     @fact conToStr(aff == 1) => "7.1 x $eq -1.5"
     @fact conToStr(aff ≥ 1) => "7.1 x $geq -1.5"
+    @fact conToStr(@LinearConstraint(aff ≤ 1)) => "7.1 x $leq -1.5"
+    @fact conToStr(@LinearConstraint(aff == 1)) => "7.1 x $eq -1.5"
+    @fact conToStr(@LinearConstraint(aff ≥ 1)) => "7.1 x $geq -1.5"
     # 3-2 AffExpr--Variable
     @fact affToStr(aff + z) => "7.1 x + z + 2.5"
     @fact affToStr(aff - z) => "7.1 x - z + 2.5"
@@ -142,6 +178,12 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(aff - 7.1 * x ≤ 0) => "0 $leq -2.5"
     @fact conToStr(aff - 7.1 * x == 0) => "0 $eq -2.5"
     @fact conToStr(aff - 7.1 * x ≥ 0) => "0 $geq -2.5"
+    @fact conToStr(@LinearConstraint(aff ≤ z)) => "7.1 x - z $leq -2.5"
+    @fact conToStr(@LinearConstraint(aff == z)) => "7.1 x - z $eq -2.5"
+    @fact conToStr(@LinearConstraint(aff ≥ z)) => "7.1 x - z $geq -2.5"
+    @fact conToStr(@LinearConstraint(aff - 7.1 * x ≤ 0)) => "0 $leq -2.5"
+    @fact conToStr(@LinearConstraint(aff - 7.1 * x == 0)) => "0 $eq -2.5"
+    @fact conToStr(@LinearConstraint(aff - 7.1 * x ≥ 0)) => "0 $geq -2.5"
     # 3-3 AffExpr--AffExpr
     @fact affToStr(aff + aff2) => "7.1 x + 1.2 y + 3.7"
     @fact affToStr(aff - aff2) => "7.1 x - 1.2 y + 1.3"
@@ -154,6 +196,12 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(aff-aff ≤ 0) => "0 $leq 0"
     @fact conToStr(aff-aff == 0) => "0 $eq 0"
     @fact conToStr(aff-aff ≥ 0) => "0 $geq 0"
+    @fact conToStr(@LinearConstraint(aff ≤ aff2)) => "7.1 x - 1.2 y $leq -1.3"
+    @fact conToStr(@LinearConstraint(aff == aff2)) => "7.1 x - 1.2 y $eq -1.3"
+    @fact conToStr(@LinearConstraint(aff ≥ aff2)) => "7.1 x - 1.2 y $geq -1.3"
+    @fact conToStr(@LinearConstraint(aff-aff ≤ 0)) => "0 $leq 0"
+    @fact conToStr(@LinearConstraint(aff-aff == 0)) => "0 $eq 0"
+    @fact conToStr(@LinearConstraint(aff-aff ≥ 0)) => "0 $geq 0"
     # 3-4 AffExpr--QuadExpr
     @fact quadToStr(aff2 + q) => "2.5 y*z + 1.2 y + 7.1 x + 3.7"
     @fact quadToStr(aff2 - q) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3"
@@ -162,6 +210,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(aff2 ≤ q) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $leq 0"
     @fact conToStr(aff2 == q) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $eq 0"
     @fact conToStr(aff2 ≥ q) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $geq 0"
+    @fact conToStr(@LinearConstraint(aff2 ≤ q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $leq 0"
+    @fact conToStr(@LinearConstraint(aff2 == q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $eq 0"
+    @fact conToStr(@LinearConstraint(aff2 ≥ q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $geq 0"
     end
 
     # 4. QuadExpr
@@ -177,6 +228,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(q ≥ 1) => "2.5 y*z + 7.1 x + 1.5 $geq 0"
     @fact conToStr(q == 1) => "2.5 y*z + 7.1 x + 1.5 $eq 0"
     @fact conToStr(q ≤ 1) => "2.5 y*z + 7.1 x + 1.5 $leq 0"
+    @fact conToStr(@LinearConstraint(aff2 ≤ q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $leq 0"
+    @fact conToStr(@LinearConstraint(aff2 == q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $eq 0"
+    @fact conToStr(@LinearConstraint(aff2 ≥ q)) => "-2.5 y*z + 1.2 y - 7.1 x - 1.3 $geq 0"
     # 4-2 QuadExpr--Variable
     @fact quadToStr(q + w) => "2.5 y*z + 7.1 x + w + 2.5"
     @fact quadToStr(q - w) => "2.5 y*z + 7.1 x - w + 2.5"
@@ -185,6 +239,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(q ≤ w) => "2.5 y*z + 7.1 x - w + 2.5 $leq 0"
     @fact conToStr(q == w) => "2.5 y*z + 7.1 x - w + 2.5 $eq 0"
     @fact conToStr(q ≥ w) => "2.5 y*z + 7.1 x - w + 2.5 $geq 0"
+    @fact conToStr(@LinearConstraint(q ≤ w)) => "2.5 y*z + 7.1 x - w + 2.5 $leq 0"
+    @fact conToStr(@LinearConstraint(q == w)) => "2.5 y*z + 7.1 x - w + 2.5 $eq 0"
+    @fact conToStr(@LinearConstraint(q ≥ w)) => "2.5 y*z + 7.1 x - w + 2.5 $geq 0"
     # 4-3 QuadExpr--AffExpr
     @fact quadToStr(q + aff2) => "2.5 y*z + 7.1 x + 1.2 y + 3.7"
     @fact quadToStr(q - aff2) => "2.5 y*z + 7.1 x - 1.2 y + 1.3"
@@ -193,6 +250,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(q ≤ aff2) => "2.5 y*z + 7.1 x - 1.2 y + 1.3 $leq 0"
     @fact conToStr(q == aff2) => "2.5 y*z + 7.1 x - 1.2 y + 1.3 $eq 0"
     @fact conToStr(q ≥ aff2) => "2.5 y*z + 7.1 x - 1.2 y + 1.3 $geq 0"
+    @fact conToStr(@LinearConstraint(q ≤ aff2)) => "2.5 y*z + 7.1 x - 1.2 y + 1.3 $leq 0"
+    @fact conToStr(@LinearConstraint(q == aff2)) => "2.5 y*z + 7.1 x - 1.2 y + 1.3 $eq 0"
+    @fact conToStr(@LinearConstraint(q ≥ aff2)) => "2.5 y*z + 7.1 x - 1.2 y + 1.3 $geq 0"
     # 4-4 QuadExpr--QuadExpr
     @fact quadToStr(q + q2) => "8 x*z + 2.5 y*z + 7.1 x + 1.2 y + 3.7"
     @fact quadToStr(q - q2) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3"
@@ -201,6 +261,9 @@ facts("[operator] Testing basic operator overloads") do
     @fact conToStr(q ≤ q2) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 $leq 0"
     @fact conToStr(q == q2) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 $eq 0"
     @fact conToStr(q ≥ q2) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 $geq 0"
+    @fact conToStr(@LinearConstraint(q ≤ q2)) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 $leq 0"
+    @fact conToStr(@LinearConstraint(q == q2)) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 $eq 0"
+    @fact conToStr(@LinearConstraint(q ≥ q2)) => "-8 x*z + 2.5 y*z + 7.1 x - 1.2 y + 1.3 $geq 0"
     end
 end
 

--- a/test/print.jl
+++ b/test/print.jl
@@ -468,9 +468,11 @@ facts("[print] expressions") do
     io_test(REPLMode, mod.linconstr[end], "x[1] + 2 y[2,3] $le 3")
     io_test(IJuliaMode, mod.linconstr[end], "x_{1} + 2 y_{2,3} \\leq 3")
 
-    @addConstraint(mod, (x[1]+x[2])*(y[2,2]+3.0) <= 1)
-    io_test(REPLMode, mod.quadconstr[end], "x[1]*y[2,2] + x[2]*y[2,2] + 3 x[1] + 3 x[2] - 1 $le 0")
-    io_test(IJuliaMode, mod.quadconstr[end], "x_{1}\\timesy_{2,2} + x_{2}\\timesy_{2,2} + 3 x_{1} + 3 x_{2} - 1 \\leq 0")
+    if VERSION > v"0.4.0-"
+        @addConstraint(mod, (x[1]+x[2])*(y[2,2]+3.0) <= 1)
+        io_test(REPLMode, mod.quadconstr[end], "x[1]*y[2,2] + x[2]*y[2,2] + 3 x[1] + 3 x[2] - 1 $le 0")
+        io_test(IJuliaMode, mod.quadconstr[end], "x_{1}\\timesy_{2,2} + x_{2}\\timesy_{2,2} + 3 x_{1} + 3 x_{2} - 1 \\leq 0")
+    end
 
     @addConstraint(mod, (y[2,2]+3.0)*(x[1]+x[2]) <= 1)
     io_test(REPLMode, mod.quadconstr[end], "x[1]*y[2,2] + x[2]*y[2,2] + 3 x[1] + 3 x[2] - 1 $le 0")

--- a/test/print.jl
+++ b/test/print.jl
@@ -468,9 +468,9 @@ facts("[print] expressions") do
     io_test(REPLMode, mod.linconstr[end], "x[1] + 2 y[2,3] $le 3")
     io_test(IJuliaMode, mod.linconstr[end], "x_{1} + 2 y_{2,3} \\leq 3")
 
-    # @addConstraint(mod, (x[1]+x[2])*(y[2,2]+3.0) <= 1)
-    # io_test(REPLMode, mod.quadconstr[end], "x[1]*y[2,2] + x[2]*y[2,2] + 3 x[1] + 3 x[2] - 1 $le 0")
-    # io_test(IJuliaMode, mod.quadconstr[end], "x_{1}\\timesy_{2,2} + x_{2}\\timesy_{2,2} + 3 x_{1} + 3 x_{2} - 1 \\leq 0")
+    @addConstraint(mod, (x[1]+x[2])*(y[2,2]+3.0) <= 1)
+    io_test(REPLMode, mod.quadconstr[end], "x[1]*y[2,2] + x[2]*y[2,2] + 3 x[1] + 3 x[2] - 1 $le 0")
+    io_test(IJuliaMode, mod.quadconstr[end], "x_{1}\\timesy_{2,2} + x_{2}\\timesy_{2,2} + 3 x_{1} + 3 x_{2} - 1 \\leq 0")
 
     @addConstraint(mod, (y[2,2]+3.0)*(x[1]+x[2]) <= 1)
     io_test(REPLMode, mod.quadconstr[end], "x[1]*y[2,2] + x[2]*y[2,2] + 3 x[1] + 3 x[2] - 1 $le 0")

--- a/test/print.jl
+++ b/test/print.jl
@@ -468,11 +468,11 @@ facts("[print] expressions") do
     io_test(REPLMode, mod.linconstr[end], "x[1] + 2 y[2,3] $le 3")
     io_test(IJuliaMode, mod.linconstr[end], "x_{1} + 2 y_{2,3} \\leq 3")
 
-     addConstraint(mod, (x[1]+x[2])*(y[2,2]+3.0) <= 1)
-    io_test(REPLMode, mod.quadconstr[end], "x[1]*y[2,2] + x[2]*y[2,2] + 3 x[1] + 3 x[2] - 1 $le 0")
-    io_test(IJuliaMode, mod.quadconstr[end], "x_{1}\\timesy_{2,2} + x_{2}\\timesy_{2,2} + 3 x_{1} + 3 x_{2} - 1 \\leq 0")
+    # @addConstraint(mod, (x[1]+x[2])*(y[2,2]+3.0) <= 1)
+    # io_test(REPLMode, mod.quadconstr[end], "x[1]*y[2,2] + x[2]*y[2,2] + 3 x[1] + 3 x[2] - 1 $le 0")
+    # io_test(IJuliaMode, mod.quadconstr[end], "x_{1}\\timesy_{2,2} + x_{2}\\timesy_{2,2} + 3 x_{1} + 3 x_{2} - 1 \\leq 0")
 
-     addConstraint(mod, (y[2,2]+3.0)*(x[1]+x[2]) <= 1)
+    @addConstraint(mod, (y[2,2]+3.0)*(x[1]+x[2]) <= 1)
     io_test(REPLMode, mod.quadconstr[end], "x[1]*y[2,2] + x[2]*y[2,2] + 3 x[1] + 3 x[2] - 1 $le 0")
     io_test(IJuliaMode, mod.quadconstr[end], "x_{1}\\timesy_{2,2} + x_{2}\\timesy_{2,2} + 3 x_{1} + 3 x_{2} - 1 \\leq 0")
 end

--- a/test/qcqpmodel.jl
+++ b/test/qcqpmodel.jl
@@ -122,7 +122,7 @@ context("With solver $(typeof(solver))") do
     @defVar(modQ, -2 <= x <= 2, Int )
     @defVar(modQ, -2 <= y <= 2, Int )
     @setObjective(modQ, Min, x - y )
-    addConstraint(modQ, x + x*x + x*y + y*y <= 1 )
+    @addConstraint(modQ, x + x*x + x*y + y*y <= 1 )
 
     @fact solve(modQ) => :Optimal
     @fact modQ.objVal => roughly(-3, 1e-6)
@@ -137,12 +137,12 @@ context("With solver $(typeof(solver))") do
 
     modQ = Model(solver=solver)
     @defVar(modQ, x >= 0)
-    addConstraint(modQ, x*x <= 1)
+    @addConstraint(modQ, x*x <= 1)
     @setObjective(modQ, Max, x)
     @fact solve(modQ) => :Optimal
     @fact getObjectiveValue(modQ) => roughly(1.0, 1e-6)
 
-    addConstraint(modQ, 2x*x <= 1)
+    @addConstraint(modQ, 2x*x <= 1)
     @fact modQ.internalModelLoaded => true
     @fact solve(modQ) => :Optimal
     @fact getObjectiveValue(modQ) => roughly(sqrt(0.5), 1e-6)


### PR DESCRIPTION
Ref #340, this passes all tests except for some of the operators ones, where there's something issues with ``a^Tx <= b`` becoming ``-a^Tx >= -b``. Still needs docs and all that, as well as deprecations for the operators.

cc @mlubin @IainNZ 