### PR TITLE
fix writeLP issue with negative coeffs

### DIFF
--- a/src/writers.jl
+++ b/src/writers.jl
@@ -221,11 +221,19 @@ function writeLP(m::Model, fname::String)
     write(f, " obj: ")
     nnz = length(objaff.coeffs)
     for ind in 1:(nnz-1)
-        print_shortest(f, objaff.coeffs[ind])
-        @printf(f, " VAR%d + ", objaff.vars[ind].col)
+        if ind == 1
+            print_shortest(f, objaff.coeffs[ind])
+        else
+            print_shortest(f, abs(objaff.coeffs[ind]))
+        end
+        @printf(f, " VAR%d %s ", objaff.vars[ind].col, (objaff.coeffs[ind+1] < 0)? "-" : "+")
     end
     if nnz >= 1
-        print_shortest(f, objaff.coeffs[nnz])
+        if nnz == 1
+            print_shortest(f, objaff.coeffs[nnz])
+        else
+            print_shortest(f, abs(objaff.coeffs[nnz]))
+        end
         @printf(f, " VAR%d\n", objaff.vars[nnz].col)
     end
 
@@ -233,11 +241,19 @@ function writeLP(m::Model, fname::String)
     function writeconstrterms(c::LinearConstraint)
         nnz = length(c.terms.coeffs)
         for ind in 1:(nnz-1)
-            print_shortest(f, c.terms.coeffs[ind])
-            @printf(f, " VAR%d + ", c.terms.vars[ind].col)
+            if ind == 1
+                print_shortest(f, c.terms.coeffs[ind])
+            else
+                print_shortest(f, abs(c.terms.coeffs[ind]))
+            end
+            @printf(f, " VAR%d %s ", c.terms.vars[ind].col, (c.terms.coeffs[ind+1] < 0)? "-" : "+")
         end
         if nnz >= 1
-            print_shortest(f, c.terms.coeffs[nnz])
+            if nnz == 1
+                print_shortest(f, c.terms.coeffs[nnz])
+            else
+                print_shortest(f, abs(c.terms.coeffs[nnz]))
+            end
             @printf(f, " VAR%d", c.terms.vars[nnz].col)
         end
     end

--- a/test/model.jl
+++ b/test/model.jl
@@ -65,7 +65,7 @@ facts("[model] Test printing a model") do
     "c1: 1 VAR1 + 1 VAR2 >= 2",
     "c2: 1 VAR1 + 1 VAR2 <= 4",
     "c3: 1 VAR4 + 1 VAR5 + 1 VAR6 + .5 VAR1 <= 1",
-    "c4: 7 VAR2 + -1 VAR3 + -.5263157894736842 VAR7 <= 0",
+    "c4: 7 VAR2 - 1 VAR3 - .5263157894736842 VAR7 <= 0",
     "Bounds",
     "0 <= VAR1 <= +inf",
     "-inf <= VAR2 <= 5",


### PR DESCRIPTION
Cplex doesn't like .lp files containing stuff like "C1 VAR1 + -C2 VAR2".