### PR TITLE
generalize defExpr for extensions

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -363,14 +363,21 @@ macro defExpr(args...)
 
     refcall, idxvars, idxsets, idxpairs = buildrefsets(c)
     newaff, parsecode = parseExpr(x, :q, [1.0])
-    code = quote
-        q = AffExpr()
-        $parsecode
+    if VERSION <= v"0.4-"
+        code = quote
+            q = AffExpr()
+            $parsecode
+        end
+    else
+        code = quote
+            q = 0.0
+            $parsecode
+        end
     end
     if isa(c,Expr)
         code = quote
             $code
-            isa($newaff,AffExpr) || error("Three argument form of @defExpr does not currently support quadratic expressions")
+            isa($newaff,AffExpr) || error("Three argument form of @defExpr only supports linear expressions")
         end
     end
     code = quote

--- a/src/parseExpr_staged.jl
+++ b/src/parseExpr_staged.jl
@@ -26,6 +26,18 @@ function addToExpression(ex::Number, c::AffExpr, x::AffExpr)
     return q
 end
 
+function addToExpression(ex::Number, c::AffExpr, x::Variable)
+    q = c*x
+    q.aff.constant += ex
+    return q
+end
+
+function addToExpression(ex::Number, c::QuadExpr, x::Number)
+    q = c*x
+    q.aff.constant += ex
+    return q
+end
+
 function addToExpression(aff::AffExpr, c::Number, x::Number)
     aff.constant += c*x
     return aff


### PR DESCRIPTION
This makes a difference when building up expressions in an extension which don't have ``AffExpr``s as constant terms. E.g.,

```
using JuMPChance, JuMP
m = ChanceModel()
@defIndepNormal(m, x, mean=1, var=1)
# before
typeof(@defExpr(x+1)) # -> GenericAffExpr{GenericAffExpr{Float64,Variable},IndepNormal} (constructor with 2 methods)
# after
typeof(@defExpr(x+1)) # -> GenericAffExpr{Float64,IndepNormal}
```
This only works with 0.4, unfortunately.