### PR TITLE
generalize two-sided addConstraint

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -297,6 +297,8 @@ type GenericAffExpr{CoefType,VarType}
     constant::CoefType
 end
 
+coeftype{CoefType,VarType}(::GenericAffExpr{CoefType,VarType}) = CoefType
+
 Base.zero{CoefType,VarType}(::Type{GenericAffExpr{CoefType,VarType}}) =
     GenericAffExpr{CoefType,VarType}(VarType[],CoefType[],zero(CoefType))
 Base.one{CoefType,VarType}(::Type{GenericAffExpr{CoefType,VarType}}) =
@@ -376,6 +378,9 @@ type GenericQuadExpr{CoefType,VarType}
     qcoeffs::Vector{CoefType}
     aff::GenericAffExpr{CoefType,VarType}
 end
+
+coeftype{CoefType,VarType}(::GenericQuadExpr{CoefType,VarType}) = CoefType
+
 typealias QuadExpr GenericQuadExpr{Float64,Variable}
 
 QuadExpr() = QuadExpr(Variable[],Variable[],Float64[],AffExpr())

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -232,6 +232,11 @@ macro addConstraint(args...)
             newlb, parselb = parseExpr(x.args[1],:lb,[1.0])
             newub, parseub = parseExpr(x.args[5],:ub,[1.0])
         end
+        constraintcall = :(addConstraint($m, _construct_constraint!($newaff,$newlb,$newub)))
+        for kw in kwargs.args
+            @assert isexpr(kw, :kw)
+            push!(constraintcall.args, esc(kw))
+        end
         code = quote
             aff = AffExpr()
             $parsecode
@@ -250,7 +255,7 @@ macro addConstraint(args...)
             catch
                 error(string("in @addConstraint (",$x_str,"): expected ",$ub_str," to be a ", CoefType, "."))
             end
-            $(refcall) = addConstraint($m, _construct_constraint!($newaff,$newlb,$newub))
+            $(refcall) = $constraintcall
         end
     else
         # Unknown

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -49,6 +49,12 @@ facts("[macros] Check @addConstraint basics") do
     @fact conToStr(m.linconstr[end]) => "-1 $leq x - y $leq 10"
     @addConstraint(m, -1 <= x+1 <= 1)
     @fact conToStr(m.linconstr[end]) => "-2 $leq x $leq 0"
+    @addConstraint(m, -1 <= x <= 1)
+    @fact conToStr(m.linconstr[end]) => "-1 $leq x $leq 1"
+    if VERSION > v"0.4-"
+        @addConstraint(m, -1 <= x <= sum{0.5, i = 1:2})
+        @fact conToStr(m.linconstr[end]) => "-1 $leq x $leq 1"
+    end
     @fact_throws @addConstraint(m, x <= t <= y)
 
     @defExpr(aff, 3x - y - 3.3(w + 2z) + 5)


### PR DESCRIPTION
Now can be used by extensions. Lower and upper bounds should match the coefficient type of the affine expression.