### PR TITLE
fix ambiguity warnings for * in quadexpr

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -272,6 +272,8 @@ end
 
 *{T<:QuadExpr,S<:Union(Variable,AffExpr,QuadExpr)}(::T,::S) =
     error( "*(::$T,::$S) is not defined. $op_hint")
+(*)(lhs::QuadExpr, rhs::QuadExpr) =
+    error( "*(::QuadExpr,::QuadExpr) is not defined. $op_hint")
 *{T<:QuadExpr,S<:Union(Variable,AffExpr,QuadExpr)}(::S,::T) =
     error( "*(::$S,::$T) is not defined. $op_hint")
 /{S<:Union(Number,Variable,AffExpr,QuadExpr),T<:Union(Variable,AffExpr,QuadExpr)}(::S,::T) =


### PR DESCRIPTION
See #383.

Just a shot in the dark.. by following the messages, since I can't reproduce the warnings. Do I just make it error out here?