### PR TITLE
Fix 0.4-dev warnings

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -258,7 +258,7 @@ function fill_var_names(mode, colNames, v::JuMPArray{Variable})
     for (ind,var) in enumerate(v.innerArray)
         idx_strs = [string( idxsets[1][mod1(ind,lengths[1])] )]
         for i = 2:N
-            push!(idx_strs, string(idxsets[i][int(ceil(mod1(ind,cprod[i]) / cprod[i-1]))]))
+            push!(idx_strs, string(idxsets[i][@compat Int(ceil(mod1(ind,cprod[i]) / cprod[i-1]))]))
         end
         if mode == IJuliaMode
             colNames[var.col] = string(name, "_{", join(idx_strs,",") , "}")

--- a/test/model.jl
+++ b/test/model.jl
@@ -19,7 +19,7 @@ const leq = JuMP.repl_leq
 const geq = JuMP.repl_geq
 const  eq = JuMP.repl_eq
 
-modPath = joinpath(Pkg.dir("JuMP"),"test","mod")
+modPath = joinpath(dirname(@__FILE__), "mod")
 
 facts("[model] Check error cases") do
     @fact_throws Model(solver=:Foo)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@
 #############################################################################
 
 using JuMP
+using Compat
 using FactCheck
 #FactCheck.setstyle(:compact)
 

--- a/test/solvers.jl
+++ b/test/solvers.jl
@@ -106,7 +106,7 @@ ipt && push!(nlp_solvers, Ipopt.IpoptSolver(print_level=0))
 nlo && push!(nlp_solvers, NLopt.NLoptSolver(algorithm=:LD_SLSQP))
 kni && push!(nlp_solvers, KNITRO.KnitroSolver(objrange=1e16,outlev=0))
 osl && push!(nlp_solvers, CoinOptServices.OsilSolver(CoinOptServices.OSOption("sb","yes",solver="ipopt")))
-nlw && osl && push!(nlp_solvers, AmplNLWriter.AmplNLSolver(CoinOptServices.bonmin,["bonmin.nlp_log_level"=>0,"bonmin.bb_log_level"=>0]))
+nlw && osl && push!(nlp_solvers, AmplNLWriter.AmplNLSolver(CoinOptServices.bonmin,@compat Dict("bonmin.nlp_log_level"=>0,"bonmin.bb_log_level"=>0)))
 convex_nlp_solvers = copy(nlp_solvers)
 mos && push!(convex_nlp_solvers, Mosek.MosekSolver())
 # Mixed-Integer Nonlinear solvers
@@ -114,7 +114,7 @@ minlp_solvers = Any[]
 kni && push!(minlp_solvers, KNITRO.KnitroSolver(outlev=0))
 osl && push!(minlp_solvers, CoinOptServices.OsilBonminSolver(CoinOptServices.OSOption("sb","yes",category="ipopt")))
 osl && push!(minlp_solvers, CoinOptServices.OsilCouenneSolver())
-nlw && osl && push!(minlp_solvers, AmplNLWriter.AmplNLSolver(CoinOptServices.bonmin,["bonmin.nlp_log_level"=>0,"bonmin.bb_log_level"=>0]))
+nlw && osl && push!(minlp_solvers, AmplNLWriter.AmplNLSolver(CoinOptServices.bonmin, @compat Dict("bonmin.nlp_log_level"=>0,"bonmin.bb_log_level"=>0)))
 nlw && osl && push!(minlp_solvers, AmplNLWriter.AmplNLSolver(CoinOptServices.couenne))
 
 const error_map = Dict()


### PR DESCRIPTION
This fixes certain deprecation warnings on `0.4`.

Also use `@__FILE__` instead of `Pkg.dir` to find current dir so that the tests can be run in any directories.
