### PR TITLE
Warn only once when getValue(x) doesn't work

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -278,11 +278,15 @@ function setValue(v::Variable, val::Number)
     end
 end
 
+# internal method that doesn't print a warning if the value is NaN
+_getValue(v::Variable) = v.m.colVal[v.col]
+
 function getValue(v::Variable)
-    if isnan(v.m.colVal[v.col])
-        warn("Variable $(getName(v))'s value not defined. Check that the model was properly solved.")
+    ret = _getValue(v)
+    if isnan(ret)
+        Base.warn("Variable value not defined. Check that the model was properly solved.")
     end
-    return v.m.colVal[v.col]
+    ret
 end
 
 getValue(arr::Array{Variable}) = map(getValue, arr)

--- a/src/JuMPDict.jl
+++ b/src/JuMPDict.jl
@@ -132,8 +132,20 @@ macro gendict(instancename,T,idxpairs,idxsets...)
 end
 
 # duck typing approach -- if eltype(innerArray) doesn't support accessor, will fail
-for accessor in (:getValue, :getDual, :getLower, :getUpper)
+for accessor in (:getDual, :getLower, :getUpper)
     @eval $accessor(x::JuMPContainer) = map($accessor,x)
+end
+
+# Special-case this so we don't dump a huge amount of redundant warnings to screen
+function getValue(x::JuMPContainer)
+    ret = map(_getValue, x)
+    if any(ret) do tmp
+            v = tmp[end]
+            isnan(v)
+        end
+        warn("Variable value not defined for entry of $(v.name). Check that the model was properly solved.")
+    end
+    ret
 end
 
 # delegate zero-argument functions


### PR DESCRIPTION
I was tired of getting pages of warnings that filled up the buffer on my terminal.