### PR TITLE
Make dot more generic (and safer)

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -307,8 +307,10 @@ end
 
 getCategory(v::Variable) = v.m.colCat[v.col]
 
-Base.zero(v::Type{Variable}) = AffExpr(Variable[],Float64[],0.0)
-Base.zero(v::Variable) = zero(typeof(v))
+Base.zero(::Type{Variable}) = AffExpr(Variable[],Float64[],0.0)
+Base.zero(::Variable) = zero(typeof(v))
+Base.one(::Type{Variable}) = AffExpr(Variable[],Float64[],1.0)
+Base.one(::Variable) = one(typeof(v))
 
 verify_ownership(m::Model, vec::Vector{Variable}) = all(v->isequal(v.m,m), vec)
 


### PR DESCRIPTION
Also adds a missing method so that e.g. ``+(::OneIndexedArray, ::OneIndexedArray)`` works as expected.