### PR TITLE
special case map for OneIndexedArrays

### DIFF
--- a/src/JuMPDict.jl
+++ b/src/JuMPDict.jl
@@ -80,7 +80,11 @@ macro gendict(instancename,T,idxpairs,idxsets...)
         getidxrhs = :(Base.getindex(d.innerArray))
         setidxrhs = :(setindex!(d.innerArray,val))
         maplhs = :(Base.map(f::Function,d::$(typename)))
-        maprhs = :($(typename)(map(f,d.innerArray),d.name,d.indexsets,d.indexexprs))
+        if truearray # return a julia Array here
+            maprhs = :(map(f,d.innerArray))
+        else
+            maprhs = :($(typename)(map(f,d.innerArray),d.name,d.indexsets,d.indexexprs))
+        end
         for i in 1:N
             varname = symbol(string("x",i))
 
@@ -134,8 +138,6 @@ end
 # duck typing approach -- if eltype(innerArray) doesn't support accessor, will fail
 for accessor in (:getDual, :getLower, :getUpper)
     @eval $accessor(x::JuMPContainer) = map($accessor,x)
-    # return a matrix here
-    @eval $accessor(x::OneIndexedArray) = map($accessor, x.innerArray)
 end
 
 # Special-case this so we don't dump a huge amount of redundant warnings to screen

--- a/test/model.jl
+++ b/test/model.jl
@@ -619,3 +619,9 @@ facts("[model] Test getLinearIndex") do
         @fact isequal(Variable(m,getLinearIndex(x[i])),x[i]) => true
     end
 end
+
+facts("[model] Test getValue on OneIndexedArrays") do
+    m = Model()
+    @defVar(m, x[i=1:5], start=i)
+    @fact typeof(getValue(x)) => Vector{Float64}
+end


### PR DESCRIPTION
Ref https://github.com/JuliaOpt/JuMP.jl/commit/cc001eaac3865a06889aad9068c4b676c53eef66#commitcomment-12310195. Not sure what happened there.

This change doesn't fix any performance issues with getValue: https://github.com/JuliaOpt/JuMP.jl/commit/f3d3774f4ee20490ccf7453e71f008d923cc908d#commitcomment-11664585