### PR TITLE
Typo rand->randn for normal distribution?

### DIFF
--- a/examples/mle.jl
+++ b/examples/mle.jl
@@ -9,7 +9,7 @@ using JuMP
 # aka the sample mean and variance
 
 n = 1000
-data = rand(n)
+data = randn(n)
 
 m = Model()
 


### PR DESCRIPTION
The example says it computes the mle of a *normal* distribution. I assume you want to use 
data = randn(n) and not rand?