### PR TITLE
[RFC] Faster iteration for JuMPContainers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@ Unversioned
   * Introduce warnings for two common performance traps: too many calls to ``getValue()`` on a collection of variables and use of the ``+`` operator in a loop to sum expressions.
   * Second-order cone constraints can be written directly with the ``norm()`` and ``norm2{}`` syntax.
   * Implement MathProgBase interface for querying Hessian-vector products.
-  * Iteration over ``JuMPContainers`` is deprecated; instead, use the ``keys`` and ``values`` functions, and ``zip(keys(d),values(d))`` for the old behavior.
+  * Iteration over ``JuMPContainer``s is deprecated; instead, use the ``keys`` and ``values`` functions, and ``zip(keys(d),values(d))`` for the old behavior.
 
 Version 0.9.2 (June 27, 2015)
 -----------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,8 @@ Unversioned
   * Dual solutions are now available for general nonlinear problems. You may call ``getDual`` on a reference object for a nonlinear constraint, and ``getDual`` on a variable object for Lagrange multipliers from active bounds.
   * Introduce warnings for two common performance traps: too many calls to ``getValue()`` on a collection of variables and use of the ``+`` operator in a loop to sum expressions.
   * Second-order cone constraints can be written directly with the ``norm()`` and ``norm2{}`` syntax.
-  * Implement MathProgBase interface for querying Hessian-vector products
+  * Implement MathProgBase interface for querying Hessian-vector products.
+  * Iteration over ``JuMPContainers`` is deprecated; instead, use the ``keys`` and ``values`` functions, and ``zip(keys(d),values(d))`` for the old behavior.
 
 Version 0.9.2 (June 27, 2015)
 -----------------------------

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -51,7 +51,7 @@ export
     @setNLObjective, @addNLConstraint, @addNLConstraints,
     @defNLExpr
 
-include("JuMPDict.jl")
+include("JuMPContainer.jl")
 #include("JuMPArray.jl")
 include("utils.jl")
 
@@ -549,8 +549,8 @@ Base.norm{T<:Union(Variable,GenericAffExpr)}(x::JuMPArray{T,1}) = vecnorm(x)
 function Base.norm(x::JuMPDict{Variable})
     ndims(x) == 1 || error("Cannot use norm() on a multidimensional JuMPDict. Use vecnorm instead.")
     arr = Array(Variable, length(x))
-    for (it,v) in enumerate(x)
-        arr[it] = v[end]
+    for (it,v) in enumerate(values(x))
+        arr[it] = v
     end
     Norm{2}(arr)
 end
@@ -561,8 +561,8 @@ Base.vecnorm{T<:Union(Variable,GenericAffExpr)}(x::JuMPArray{T}) =
     Norm{2}(collect(x.innerArray))
 function Base.vecnorm(x::JuMPDict{Variable})
     arr = Array(Variable, length(x))
-    for (it,v) in enumerate(x)
-        arr[it] = v[end]
+    for (it,v) in enumerate(values(x))
+        arr[it] = v
     end
     Norm{2}(arr)
 end
@@ -934,7 +934,7 @@ end
 
 # usage warnings
 function getvalue_warn(x::JuMPContainer{Variable})
-    v = last(first(x))
+    v = first(values(x))
     m = v.m
     m.getvalue_counter += 1
     if m.getvalue_counter > 400

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -46,8 +46,7 @@ function Base.map{T,N}(f::Function, d::JuMPDict{T,N})
     return x
 end
 
-Base.isempty(d::JuMPArray) = (isempty(d.innerArray))
-Base.isempty(d::JuMPDict)  = (isempty(d.tupledict))
+Base.isempty(d::JuMPContainer) = isempty(_innercontainer(d))
 
 # generate and instantiate a type which is indexed by the given index sets
 # the following types of index sets are allowed:
@@ -166,7 +165,6 @@ function _getValueInner(x)
     vals
 end
 
-
 JuMPContainer_from(x::JuMPDict,inner) =
     JuMPDict(inner, x.name, x.indexsets, x.indexexprs, x.condition)
 JuMPContainer_from(x::OneIndexedArray, inner) = inner
@@ -176,14 +174,17 @@ function getValue(x::JuMPContainer)
     JuMPContainer_from(x,_getValueInner(x))
 end
 
+_iteration_depwarn() = Base.warn_once("Iteration over JuMP containers is deprecated. Use keys(d) and values(d) instead")
+
 # delegate zero-argument functions
 for f in (:(Base.endof), :(Base.ndims), :(Base.length), :(Base.abs), :(Base.start))
     @eval $f(x::JuMPArray) = $f(x.innerArray)
 end
 
-for f in (:(Base.first), :(Base.length), :(Base.start))
-    @eval $f(x::JuMPDict)  = $f(x.tupledict)
-end
+Base.first(x::JuMPDict)  =  first(x.tupledict)
+Base.length(x::JuMPDict) = length(x.tupledict)
+Base.start(x::JuMPDict)  = (_iteration_depwarn(); start(x.tupledict))
+
 Base.ndims{T,N}(x::JuMPDict{T,N}) = N
 Base.abs(x::JuMPDict) = map(abs, x)
 # delegate one-argument functions
@@ -194,31 +195,65 @@ Base.trace(x::OneIndexedArray) = trace(x.innerArray)
 Base.diag(x::OneIndexedArray) = diag(x.innerArray)
 Base.diagm{T}(x::JuMPArray{T,1,true}) = diagm(x.innerArray)
 
-function _local_index(indexsets, dim, k)
-    n = length(indexsets)
-    cprod = 1
-    for i in 1:(dim-1)
-        cprod *= length(indexsets[i])
-    end
-    idx = Compat.ceil(Integer, mod1(k,cprod*length(indexsets[dim])) / cprod)
-    return indexsets[dim][idx]
-end
+# special-case OneIndexedArray iteration
+Base.start(x::OneIndexedArray)   = start(x.innerArray)
+Base.next(x::OneIndexedArray, k) =  next(x.innerArray, k)
+Base.done(x::OneIndexedArray, k) =  done(x.innerArray, k)
 
 function Base.next(x::JuMPArray,k)
-    (var, gidx) = next(x.innerArray, k)
-    key = map(i->_local_index(x.indexsets, i, k), 1:length(x.indexsets))
-    return (tuple(key..., var), gidx)
+    _iteration_depwarn()
+    var, gidx = next(x.innerArray, k)
+    keys = _next_index(x,k)
+    tuple(keys..., x[keys...]), gidx
 end
+
+_next_index{T,N}(x::JuMPArray{T,N}, k) =
+    ntuple(N) do index
+        cprod = 1
+        for i in 1:(index-1)
+            cprod *= length(x.indexsets[i])
+        end
+        locidxset = x.indexsets[index]
+        idx = Compat.ceil(Int, mod1(k, cprod*length(locidxset)) / cprod)
+        locidxset[idx]
+    end
+
 function Base.next(x::JuMPDict,k)
+    _iteration_depwarn()
     ((idx,var),gidx) = next(x.tupledict,k)
     return (tuple(idx..., var), gidx)
 end
-Base.done(x::JuMPArray,k) = done(x.innerArray,k)
-Base.done(x::JuMPDict,k)  = done(x.tupledict,k)
+
+Base.done(x::JuMPArray,k) = (_iteration_depwarn(); done(x.innerArray,k))
+Base.done(x::JuMPDict,k)  = (_iteration_depwarn(); done(x.tupledict,k))
 
 Base.eltype{T}(x::JuMPContainer{T}) = T
 
 Base.full(x::JuMPContainer) = x
 Base.full(x::OneIndexedArray) = x.innerArray
+
+# keys/vals iterations for JuMPContainers
+Base.keys(d::JuMPDict)    = keys(d.tupledict)
+Base.values(d::JuMPDict)  = values(d.tupledict)
+
+Base.keys(d::JuMPArray)   = KeyIterator(d)
+Base.values(d::JuMPArray) = ValueIterator(d.innerArray)
+
+# Wrapper type so that you can't access the values directly
+type ValueIterator{T,N}
+    x::Array{T,N}
+end
+Base.start(it::ValueIterator)   =  start(it.x)
+Base.next(it::ValueIterator, k) =   next(it.x, k)
+Base.done(it::ValueIterator, k) =   done(it.x, k)
+Base.length(it::ValueIterator)  = length(it.x)
+
+type KeyIterator{JA<:JuMPArray}
+    x::JA
+end
+Base.start(it::KeyIterator)   =  start(it.x.innerArray)
+Base.next(it::KeyIterator, k) =  _next_index(it.x, k), next(it.x.innerArray, k)[2]
+Base.done(it::KeyIterator, k) =   done(it.x.innerArray, k)
+Base.length(it::KeyIterator)  = length(it.x.innerArray)
 
 export @gendict

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -174,8 +174,6 @@ function getValue(x::JuMPContainer)
     JuMPContainer_from(x,_getValueInner(x))
 end
 
-_iteration_depwarn() = Base.warn_once("Iteration over JuMP containers is deprecated. Use keys(d) and values(d) instead")
-
 # delegate zero-argument functions
 for f in (:(Base.endof), :(Base.ndims), :(Base.length), :(Base.abs), :(Base.start))
     @eval $f(x::JuMPArray) = $f(x.innerArray)
@@ -183,7 +181,6 @@ end
 
 Base.first(x::JuMPDict)  =  first(x.tupledict)
 Base.length(x::JuMPDict) = length(x.tupledict)
-Base.start(x::JuMPDict)  = (_iteration_depwarn(); start(x.tupledict))
 
 Base.ndims{T,N}(x::JuMPDict{T,N}) = N
 Base.abs(x::JuMPDict) = map(abs, x)
@@ -200,8 +197,12 @@ Base.start(x::OneIndexedArray)   = start(x.innerArray)
 Base.next(x::OneIndexedArray, k) =  next(x.innerArray, k)
 Base.done(x::OneIndexedArray, k) =  done(x.innerArray, k)
 
+function Base.start(x::JuMPContainer)
+    warn("Iteration over JuMP containers is deprecated. Use keys(d) and values(d) instead")
+    start(x.tupledict)
+end
+
 function Base.next(x::JuMPArray,k)
-    _iteration_depwarn()
     var, gidx = next(x.innerArray, k)
     keys = _next_index(x,k)
     tuple(keys..., x[keys...]), gidx
@@ -219,13 +220,12 @@ _next_index{T,N}(x::JuMPArray{T,N}, k) =
     end
 
 function Base.next(x::JuMPDict,k)
-    _iteration_depwarn()
     ((idx,var),gidx) = next(x.tupledict,k)
     return (tuple(idx..., var), gidx)
 end
 
-Base.done(x::JuMPArray,k) = (_iteration_depwarn(); done(x.innerArray,k))
-Base.done(x::JuMPDict,k)  = (_iteration_depwarn(); done(x.tupledict,k))
+Base.done(x::JuMPArray,k) = done(x.innerArray,k)
+Base.done(x::JuMPDict,k)  = done(x.tupledict,k)
 
 Base.eltype{T}(x::JuMPContainer{T}) = T
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -259,7 +259,7 @@ facts("[macros] Triangular indexing, iteration") do
     @fact MathProgBase.numconstr(trimod) --> n*(n+1)/2
 
     cntr = zeros(Bool, n, n)
-    for (i,j,var) in x
+    for ((i,j),var) in zip(keys(x),values(x))
         @fact x[i,j] --> exactly(var)
         cntr[i,j] = true
     end
@@ -275,8 +275,8 @@ facts("[macros] Multidimensional indexing") do
     I3 = 5:6
     @defVar(model, x[1:5,2:8,5:6])
     coll = Int[]
-    for v in x
-        push!(coll, v[end].col)
+    for v in values(x)
+        push!(coll, v.col)
     end
     p = 1
     match = true

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -91,3 +91,24 @@ if VERSION >= v"0.4-"
         @fact string(condmod) --> "Min 0\nSubject to\n x[i] free for all i in {1,2..9,10} s.t. iseven(i)\n y[j,k] free for all j in {1,2..9,10}, k in {3,5,7,9} s.t. isodd(j + k) and k <= 8\n"
     end
 end
+
+facts("[variable] JuMPContainer iteration") do
+    m = Model()
+    @defVar(m, oia[1:3,1:4,1:2])
+    @defVar(m, ja[1:3,2:5,1:2])
+    @defVar(m, jd[1:3,[:red,:blue]])
+
+    @fact length(keys(oia)) == length(values(oia)) == 3*4*2 --> true
+    @fact length(keys(ja))  == length(values(ja))  == 3*4*2 --> true
+    @fact length(keys(jd))  == length(values(jd))  == 3*2   --> true
+
+    for (key,val) in zip(keys(oia),values(oia))
+        @fact oia[key...] === val --> true
+    end
+    for (key,val) in zip(keys(ja),values(ja))
+        @fact ja[key...] === val --> true
+    end
+    for (key,val) in zip(keys(jd),values(jd))
+        @fact jd[key...] === val --> true
+    end
+end


### PR DESCRIPTION
ref #509, currently iteration for JuMPArrays is very inefficient, since the contract is that iteration returns ``(key..., val)`` for any JuMPContainer. First, this should move to returning ``key=>val`` to mirror changes in Base. 

Second, I'm wondering if we should just encourage people to use ``vals(d)`` for efficient iteration over the entries. More radically, we could just change iteration to act like ``vals(d)`` and encourage people that want the current behavior to use ``zip(keys(d), vals(d))``.