### PR TITLE
Strip zeros from affine part of quadratic expressions

### DIFF
--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -138,11 +138,19 @@ function addQuadratics(m::Model)
                 error("Variable not owned by model present in constraints")
             end
         end
-        affidx  = Cint[v.col for v in qconstr.terms.aff.vars]
+        n_aff = length(qconstr.terms.aff.coeffs)
+        affcoef = Float64[]; sizehint!(affcoef, n_aff)
+        affidx  = Cint[];    sizehint!(affidx,  n_aff)
+        for (coeff, var) in qconstr.terms.aff
+            if coeff != 0.0
+                push!(affcoef, coeff)
+                push!(affidx, var.col)
+            end
+        end
         var1idx = Cint[v.col for v in qconstr.terms.qvars1]
         var2idx = Cint[v.col for v in qconstr.terms.qvars2]
-        if applicable(MathProgBase.addquadconstr!, m.internalModel, affidx, qconstr.terms.aff.coeffs, var1idx, var2idx, qconstr.terms.qcoeffs, s, -qconstr.terms.aff.constant)
-            MathProgBase.addquadconstr!(m.internalModel, affidx, qconstr.terms.aff.coeffs, var1idx, var2idx, qconstr.terms.qcoeffs, s, -qconstr.terms.aff.constant)
+        if applicable(MathProgBase.addquadconstr!, m.internalModel, affidx, affcoef, var1idx, var2idx, qconstr.terms.qcoeffs, s, -qconstr.terms.aff.constant)
+            MathProgBase.addquadconstr!(m.internalModel, affidx, affcoef, var1idx, var2idx, qconstr.terms.qcoeffs, s, -qconstr.terms.aff.constant)
         else
             error("Solver does not support quadratic constraints")
         end


### PR DESCRIPTION
```
julia> using JuMP

julia> m=Model()
Feasibility problem with:
 * 0 linear constraints
 * 0 variables
Solver set to Default

julia> @defVar(m, 0 <= x[1:3] <= 1)
0 ≤ x[i] ≤ 1 for all i in {1,2,3}

julia> @defVar(m, y >= 0)
y

julia> @addConstraint(m, dot(x,x) <= y*y)
x[1]² + x[2]² + x[3]² - y² + 0 ≤ 0
```

That extra 0 is actually a `0y`, which causes this model to die if passed through the conic MPB path. I fixed it here, because its generally a useful thing I figure. I don't know the `0y` appears in the first place.