### PR TITLE
Extend setvalue to JuMPArrays

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -346,6 +346,14 @@ function setValue(v::Variable, val::Number)
     end
 end
 
+function setValue(set::Array{Variable}, val::Array)
+    promote_shape(size(set), size(val)) # Check dimensions match
+    for I in eachindex(set)
+        setValue(set[I], val[I])
+    end
+    nothing
+end
+
 # internal method that doesn't print a warning if the value is NaN
 _getValue(v::Variable) = v.m.colVal[v.col]
 

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -65,6 +65,21 @@ facts("[variable] get and set bounds") do
     @fact getUpper(fixedvar) --> 5
 end
 
+facts("[variable] get and set values") do
+    m = Model()
+    @defVar(m, x[1:3])
+    x0 = [1:3]
+    setValue(x, x0)
+    @fact getValue(x) --> x0
+
+    @defVar(m, y[1:3,1:2])
+    if VERSION >= v"0.4-"
+        @fact_throws DimensionMismatch setValue(y, [1:6])
+    else
+        @fact_throws ErrorException setValue(y, [1:6])
+    end
+end
+
 facts("[variable] get and set category") do
     m = Model()
     @defVar(m, x[1:3])


### PR DESCRIPTION
This commit enables us to run
```julia
@defVar(m, x[1:n])
setValue(x, x0)
```
for an array of numbers, x0.

Hope I put the code in the right place?

