### PR TITLE
Stop redundant SOS constraints being added

### DIFF
--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -672,9 +672,9 @@ function buildInternalModel(m::Model, traits=problemclass(m); suppress_warnings=
 
             MathProgBase.loadproblem!(m.internalModel, A, m.colLower, m.colUpper, f, rowlb, rowub, m.objSense)
             addQuadratics(m)
+            addSOS(m)
         end
 
-        addSOS(m)
         registercallbacks(m)
     end
 


### PR DESCRIPTION
Came up during my code review. If you have an LP with Gurobi as the solver, add some continuous variables and an SOS constraint, and just keep hitting solve, you'll add SOS constraints each time to the internal model. I think this is all thats required to fix this, as the addSOS constraint methods already do problem modification if possible, and reset internalModelLoaded if not.