### PR TITLE
Refactor printing & add precompile hints, 2-4x speedup

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -582,7 +582,7 @@ function aff_str(mode, a::AffExpr, show_constant=true)
     end
 
     # Get reference to models included in this expression
-    moddict = Dict{Model,IndexedVector}()
+    moddict = Dict{Model,IndexedVector{Float64}}()
     for var in a.vars
         if !haskey(moddict, var.m)
             moddict[var.m] = IndexedVector(Float64,var.m.numCols)
@@ -628,9 +628,14 @@ function aff_str(mode, a::AffExpr, show_constant=true)
         return ret
     end
 end
-
 # Backwards compatability shim
 affToStr(a::AffExpr) = aff_str(REPLMode,a)
+
+# Precompile for faster boot times
+Base.precompile(aff_str, (Type{JuMP.REPLMode}, AffExpr, Bool))
+Base.precompile(aff_str, (Type{JuMP.IJuliaMode}, AffExpr, Bool))
+Base.precompile(aff_str, (Type{JuMP.REPLMode}, AffExpr))
+Base.precompile(aff_str, (Type{JuMP.IJuliaMode}, AffExpr))
 
 
 #------------------------------------------------------------------------

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -6,9 +6,9 @@ using Base.Test
 
 # To ensure the tests work on Windows and Linux/OSX, we need
 # to use the correct comparison operators
-const leq = JuMP.repl_leq
-const geq = JuMP.repl_geq
-const  eq = JuMP.repl_eq
+const leq = JuMP.repl[:leq]
+const geq = JuMP.repl[:geq]
+const  eq = JuMP.repl[:eq]
 
 facts("[macros] Check Julia expression parsing") do
     sumexpr = :(sum{x[i,j] * y[i,j], i = 1:N, j = 1:M; i != j})

--- a/test/model.jl
+++ b/test/model.jl
@@ -15,9 +15,9 @@ using JuMP, FactCheck
 
 # To ensure the tests work on Windows and Linux/OSX, we need
 # to use the correct comparison operators
-const leq = JuMP.repl_leq
-const geq = JuMP.repl_geq
-const  eq = JuMP.repl_eq
+const leq = JuMP.repl[:leq]
+const geq = JuMP.repl[:geq]
+const  eq = JuMP.repl[:eq]
 
 const TOL = 1e-4
 

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -14,9 +14,9 @@ using JuMP, FactCheck
 
 # To ensure the tests work on both Windows and Linux/OSX, we need
 # to use the correct comparison operators in the strings
-const leq = JuMP.repl_leq
-const geq = JuMP.repl_geq
-const  eq = JuMP.repl_eq
+const leq = JuMP.repl[:leq]
+const geq = JuMP.repl[:geq]
+const  eq = JuMP.repl[:eq]
 
 facts("[operator] Testing basic operator overloads") do
     m = Model()

--- a/test/perf/timetoprint.jl
+++ b/test/perf/timetoprint.jl
@@ -1,0 +1,72 @@
+# Compile speed tests
+# Tests time to get from nothing to certain tasks
+using JuMP  # Ensure compiled before running the tests
+
+# Test 1
+# Size 100, aff_str into model_str
+tic()
+run(`$(ENV["_"]) -e """
+using JuMP
+m = Model()
+N = 100
+@defVar(m, x[1:N])
+@addConstraint(m, sum{i*x[i],i=1:N} >= N)
+@time JuMP.aff_str(JuMP.REPLMode, m.linconstr[end].terms)
+@time JuMP.model_str(JuMP.REPLMode, m)"""
+`)
+test1_time = toq()
+
+# Test 2
+# Size 100, model_str
+tic()
+run(`$(ENV["_"]) -e """
+using JuMP
+m = Model()
+N = 100
+@defVar(m, x[1:N])
+@addConstraint(m, sum{i*x[i],i=1:N} >= N)
+@time JuMP.model_str(JuMP.REPLMode, m)"""
+`)
+test2_time = toq()
+
+# Test 3
+# Size 10,000, print model
+tic()
+run(`$(ENV["_"]) -e """
+using JuMP
+m = Model()
+N = 10000
+@defVar(m, x[1:N])
+@addConstraint(m, sum{i*x[i],i=1:N} >= N)
+@time sprint(print, m)"""
+`)
+test3_time = toq()
+
+# Test 4
+# Size 10, 4 variables, print model
+tic()
+run(`$(ENV["_"]) -e """
+using JuMP
+m = Model()
+N = 10
+@defVar(m, x1[1:N])
+@defVar(m, x2[1:N,f=1:N])
+@defVar(m, x3[1:N,f=1:2:N])
+@defVar(m, x4[[:a,:b,:c]])
+@defVar(m, x5[[:a,:b,:c],[:d,"e",4]])
+@addConstraint(m,
+    sum{i*x1[i],i=1:N} +
+    sum{i*f*x2[i,f],i=1:N,f=1:N} + 
+    sum{i*f*x3[i,f],i=1:N,f=1:2:N} +
+    sum(x4) >= N)
+@time sprint(print, m)"""
+`)
+test4_time = toq()
+
+println("Julia ", VERSION)
+println("Current branch: $(chomp(readall(`git rev-parse --abbrev-ref HEAD`)))")
+println("Current commit: $(chomp(readall(`git rev-parse HEAD`)))")
+@printf("Test 1: %7.2f s\n", test1_time)
+@printf("Test 2: %7.2f s\n", test2_time)
+@printf("Test 3: %7.2f s\n", test3_time)
+@printf("Test 4: %7.2f s\n", test4_time)

--- a/test/print.jl
+++ b/test/print.jl
@@ -25,7 +25,7 @@ end
 
 
 facts("[print] JuMPContainer{Variable}") do
-    le, ge = JuMP.repl_leq, JuMP.repl_geq
+    le, ge = JuMP.repl[:leq], JuMP.repl[:geq]
     m = Model()
 
     #------------------------------------------------------------------
@@ -297,7 +297,7 @@ end
 
 
 facts("[print] Model") do
-    le, ge = JuMP.repl_leq, JuMP.repl_geq
+    le, ge = JuMP.repl[:leq], JuMP.repl[:geq]
 
     #------------------------------------------------------------------
 
@@ -417,7 +417,7 @@ Solver set to Default""", repl=:show)
 end
 
 facts("[print] changing variable categories") do
-    le, ge = JuMP.repl_leq, JuMP.repl_geq
+    le, ge = JuMP.repl[:leq], JuMP.repl[:geq]
     mod = Model()
     @defVar(mod, x[1:3])
     @defVar(mod, y[i=1:3,i:3])
@@ -460,7 +460,7 @@ end
 facts("[print] expressions") do
     # Most of the expression logic is well covered by test/operator.jl
     # This is really just to check IJulia printing for expressions
-    le, ge = JuMP.repl_leq, JuMP.repl_geq
+    le, ge = JuMP.repl[:leq], JuMP.repl[:geq]
 
     #------------------------------------------------------------------
     mod = Model()


### PR DESCRIPTION
# Test Script
```julia
# Compile speed tests
# Tests time to get from nothing to certain tasks
using JuMP  # Ensure compiled before running the tests

# Test 1
# Size 100, aff_str into model_str
tic()
run(`$(ENV["_"]) -e """
using JuMP
m = Model()
N = 100
@defVar(m, x[1:N])
@addConstraint(m, sum{i*x[i],i=1:N} >= N)
@time JuMP.aff_str(JuMP.REPLMode, m.linconstr[end].terms)
@time JuMP.model_str(JuMP.REPLMode, m)"""
`)
test1_time = toq()

# Test 2
# Size 100, model_str
tic()
run(`$(ENV["_"]) -e """
using JuMP
m = Model()
N = 100
@defVar(m, x[1:N])
@addConstraint(m, sum{i*x[i],i=1:N} >= N)
@time JuMP.model_str(JuMP.REPLMode, m)"""
`)
test2_time = toq()

# Test 3
# Size 10,000, print model
tic()
run(`$(ENV["_"]) -e """
using JuMP
m = Model()
N = 10000
@defVar(m, x[1:N])
@addConstraint(m, sum{i*x[i],i=1:N} >= N)
@time sprint(print, m)"""
`)
test3_time = toq()

# Test 4
# Size 10, 4 variables, print model
tic()
run(`$(ENV["_"]) -e """
using JuMP
m = Model()
N = 10
@defVar(m, x1[1:N])
@defVar(m, x2[1:N,f=1:N])
@defVar(m, x3[1:N,f=1:2:N])
@defVar(m, x4[[:a,:b,:c]])
@defVar(m, x5[[:a,:b,:c],[:d,"e",4]])
@addConstraint(m,
    sum{i*x1[i],i=1:N} +
    sum{i*f*x2[i,f],i=1:N,f=1:N} + 
    sum{i*f*x3[i,f],i=1:N,f=1:2:N} +
    sum(x4) >= N)
@time sprint(print, m)"""
`)
test4_time = toq()

println("Julia ", VERSION)
println("Current branch: $(chomp(readall(`git rev-parse --abbrev-ref HEAD`)))")
println("Current commit: $(chomp(readall(`git rev-parse HEAD`)))")
@printf("Test 1: %7.2f s\n", test1_time)
@printf("Test 2: %7.2f s\n", test2_time)
@printf("Test 3: %7.2f s\n", test3_time)
@printf("Test 4: %7.2f s\n", test4_time)
```