### PR TITLE
Tweak buildInternalModel for compile speed

### DIFF
--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -74,7 +74,7 @@ function solve(m::Model; suppress_warnings=false,
     traits = ProblemTraits(m)
 
     # Build the MathProgBase model from the JuMP model
-    buildInternalModel(m, traits, suppress_warnings=suppress_warnings)
+    buildInternalModel(m, traits, suppress_warnings)
 
     # If the model is a general nonlinear, use different logic in
     # nlp.jl to solve the problem
@@ -174,8 +174,7 @@ end
 
 # Converts the JuMP Model into a MathProgBase model based on the
 # traits of the model
-function buildInternalModel(m::Model, traits=ProblemTraits(m);
-                            suppress_warnings=false)
+function buildInternalModel(m::Model, traits::ProblemTraits, suppress_warnings::Bool)
     # Set solver based on the model's traits if it hasn't provided
     if isa(m.solver, UnsetSolver)
         m.solver = default_solver(traits)
@@ -290,6 +289,7 @@ function buildInternalModel(m::Model, traits=ProblemTraits(m);
     m.internalModelLoaded = true
     nothing
 end
+Base.precompile(buildInternalModel, (Model, ProblemTraits, Bool))
 
 # Add the quadratic part of the objective and all quadratic constraints
 # to the internal MPB model

--- a/test/model.jl
+++ b/test/model.jl
@@ -575,7 +575,7 @@ context("With solver $(typeof(solver))") do
     mod = Model(solver=solver)
     @defVar(mod, x[1:3], Bin)
     @defVar(mod, y[k=1:2] == k)
-    buildInternalModel(mod)
+    buildInternalModel(mod, JuMP.ProblemTraits(mod), false)
     @fact MathProgBase.getvartype(getInternalModel(mod)) --> [:Bin,:Bin,:Bin,:Cont,:Cont]
 end; end; end
 

--- a/test/probmod.jl
+++ b/test/probmod.jl
@@ -184,7 +184,7 @@ context("With solver $(typeof(solver))") do
     @defVar(m, y >= 0)
     @addConstraint(m, x + y == 1)
     @setObjective(m, Max, y)
-    buildInternalModel(m)
+    buildInternalModel(m, JuMP.ProblemTraits(m), false)
     @fact getInternalModel(m) --> not(nothing)
     @fact m.internalModelLoaded --> true
     stat = solve(m)
@@ -207,7 +207,7 @@ context("With solver $(typeof(solver))") do
     @defVar(m, y, Bin)
     @addConstraint(m, x + y == 1)
     @setObjective(m, Max, y)
-    buildInternalModel(m)
+    buildInternalModel(m, JuMP.ProblemTraits(m), false)
     @fact getInternalModel(m) --> not(nothing)
     @fact m.internalModelLoaded --> true
     stat = solve(m)


### PR DESCRIPTION
Unfortunately this is all I could get. Next thing to hit would be to precompile `loadproblem!` for JuMP's inputs and their own internal model types. Thats a bit messy.

```
using Gurobi

macro howlong(stage)
    esc(quote
        println($stage, " ", (time_ns()-start_t)/10^9)
        start_t = time_ns()
    end)
end

start_t = time_ns()
@howlong "start"
using JuMP
@howlong "using"
m = Model(solver=GurobiSolver(OutputFlag=0))
@howlong "model"
N=1000
@defVar(m, x[1:N])
@howlong "defvr"
@addConstraint(m, sum{i*x[i],i=1:N} >= N)
@howlong "addcn"
solve(m)
@howlong "solve"
```

```
# Master
using 0.280585613
solve 1.886616573

# After buildInternalModel change
using 0.271496954
solve 1.433308388
```

The other methods could be precompiled, but they didn't really seem to register, possibly are precompiled just by precompiled buildInternalModel? Also `solve` with the kwargs didn't really help much either.