### PR TITLE
Revert "generalize addToExpression (0 -> zero(C))"

### DIFF
--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -24,8 +24,7 @@ type GenericAffExpr{CoefType,VarType}
     coeffs::Vector{CoefType}
     constant::CoefType
 end
-coeftype{T<:GenericAffExpr}(::T) = coeftype(T)
-coeftype{C,V}(::Type{GenericAffExpr{C,V}}) = C
+coeftype{C,V}(::GenericAffExpr{C,V}) = C
 
 Base.zero{C,V}(::Type{GenericAffExpr{C,V}}) = GenericAffExpr{C,V}(V[],C[],zero(C))
 Base.one{ C,V}(::Type{GenericAffExpr{C,V}}) = GenericAffExpr{C,V}(V[],C[], one(C))

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -26,8 +26,7 @@ type GenericQuadExpr{CoefType,VarType}
     qcoeffs::Vector{CoefType}
     aff::GenericAffExpr{CoefType,VarType}
 end
-coeftype{T<:GenericQuadExpr}(::T) = coeftype(T)
-coeftype{C,V}(::Type{GenericQuadExpr{C,V}}) = C
+coeftype{C,V}(::GenericQuadExpr{C,V}) = C
 
 Base.isempty(q::GenericQuadExpr) = (length(q.qvars1) == 0 && isempty(q.aff))
 Base.zero{C,V}(::Type{GenericQuadExpr{C,V}}) = GenericQuadExpr(V[], V[], C[], zero(GenericAffExpr{C,V}))

--- a/src/v0.3/parseExpr_0.3.jl
+++ b/src/v0.3/parseExpr_0.3.jl
@@ -91,9 +91,9 @@ function addToExpression(quad::GenericQuadExpr,c::Number,x::Number)
 end
 
 function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::V,x::V)
-    push!(quad.qvars1, x)
-    push!(quad.qvars2, c)
-    push!(quad.qcoeffs, 1.0)
+    push!(quad.qvars1, c)
+    push!(quad.qvars2, x)
+    push!(quad.qcoeffs, one(C))
     quad
 end
 

--- a/src/v0.3/parseExpr_0.3.jl
+++ b/src/v0.3/parseExpr_0.3.jl
@@ -34,7 +34,7 @@ function addToExpression(aff::GenericAffExpr,c::Number,x::Number)
 end
 
 function addToExpression{C,V}(aff::GenericAffExpr{C,V}, c::Number, x::V)
-    if c != zero(C)
+    if c != 0
         push!(aff.vars,   x)
         push!(aff.coeffs, c)
     end
@@ -42,7 +42,7 @@ function addToExpression{C,V}(aff::GenericAffExpr{C,V}, c::Number, x::V)
 end
 
 function addToExpression{C,V}(aff::GenericAffExpr{C,V},c::Number,x::GenericAffExpr{C,V})
-    if c != zero(C)
+    if c != 0
         append!(aff.vars, x.vars)
         append!(aff.coeffs, c*x.coeffs)
         aff.constant += c*x.constant
@@ -68,7 +68,7 @@ addToExpression{C}(aff::GenericAffExpr{C,Variable},c::Variable,x::GenericAffExpr
                                 addToExpression(aff,x.constant,c))
 
 function addToExpression{C,V}(aff::GenericAffExpr{C,V}, c::Number, x::GenericQuadExpr{C,V})
-    if c == zero(C)
+    if c == 0
         convert(GenericQuadExpr{C,V}, aff)
     else
         GenericQuadExpr{C,V}(copy(x.qvars1),
@@ -79,7 +79,7 @@ function addToExpression{C,V}(aff::GenericAffExpr{C,V}, c::Number, x::GenericQua
 end
 
 function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::Number,x::V)
-    if c != zero(C)
+    if c != 0
         push!(quad.aff,convert(C,c),x)
     end
     quad
@@ -91,14 +91,14 @@ function addToExpression(quad::GenericQuadExpr,c::Number,x::Number)
 end
 
 function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::V,x::V)
-    push!(quad.qvars1, c)
-    push!(quad.qvars2, x)
-    push!(quad.qcoeffs, one(C))
+    push!(quad.qvars1, x)
+    push!(quad.qvars2, c)
+    push!(quad.qcoeffs, 1.0)
     quad
 end
 
 function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::Number,x::GenericAffExpr{C,V})
-    if c != zero(C)
+    if c != 0
         append!(quad.aff.vars, x.vars)
         append!(quad.aff.coeffs, c*x.coeffs)
         quad.aff.constant += c*x.constant
@@ -107,7 +107,7 @@ function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::Number,x::GenericAff
 end
 
 function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::GenericAffExpr{C,V},x::Number)
-    if x != zero(C)
+    if x != 0
         append!(quad.aff.vars, c.vars)
         append!(quad.aff.coeffs, c.coeffs*x)
         quad.aff.constant += c.constant*x
@@ -133,7 +133,7 @@ function addToExpression{C}(quad::GenericQuadExpr{C,Variable},c::Variable,x::Gen
 end
 
 function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::GenericQuadExpr{C,V},x::Number)
-    if x != zero(C)
+    if x != 0
         append!(quad.qvars1,c.qvars1)
         append!(quad.qvars2,c.qvars2)
         append!(quad.qcoeffs,c.qcoeffs*x)
@@ -143,7 +143,7 @@ function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::GenericQuadExpr{C,V}
 end
 
 function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::Number,x::GenericQuadExpr{C,V})
-    if c != zero(C)
+    if c != 0
         append!(quad.qvars1,x.qvars1)
         append!(quad.qvars2,x.qvars2)
         append!(quad.qcoeffs,c*x.qcoeffs)

--- a/src/v0.4/parseExpr_staged.jl
+++ b/src/v0.4/parseExpr_staged.jl
@@ -11,7 +11,7 @@ addToExpression(ex::Number, c::Number, x::Variable) = AffExpr([x],[c],ex)
 
 function addToExpression{T<:GenericAffExpr}(ex::Number, c::Number, x::T)
     # It's only safe to mutate the first argument.
-    if c == zero(coeftype(T))
+    if c == 0
         T(ex)
     else
         x = copy(x)
@@ -24,7 +24,7 @@ end
 
 function addToExpression{T<:GenericQuadExpr}(ex::Number, c::Number, x::T)
     # It's only safe to mutate the first argument.
-    if c == zero(coeftype(T))
+    if c == 0
         T(ex)
     else
         x = copy(x)
@@ -51,7 +51,7 @@ function addToExpression{C,V}(ex::Number, c::GenericAffExpr{C,V}, x::V)
 end
 
 function addToExpression{T<:GenericQuadExpr}(ex::Number, c::T, x::Number)
-    if x == zero(coeftype(T))
+    if x == 0
         T(ex)
     else
         q = c*x
@@ -66,7 +66,7 @@ function addToExpression(aff::GenericAffExpr, c::Number, x::Number)
 end
 
 function addToExpression{C,V}(aff::GenericAffExpr{C,V}, c::Number, x::V)
-    if c != zero(C)
+    if c != 0
         push!(aff.vars,   x)
         push!(aff.coeffs, c)
     end
@@ -74,7 +74,7 @@ function addToExpression{C,V}(aff::GenericAffExpr{C,V}, c::Number, x::V)
 end
 
 function addToExpression{C,V}(aff::GenericAffExpr{C,V},c::Number,x::GenericAffExpr{C,V})
-    if c != zero(C)
+    if c != 0
         append!(aff.vars, x.vars)
         sizehint!(aff.coeffs, length(aff.coeffs)+length(x.coeffs))
         for i in 1:length(x.coeffs)
@@ -86,11 +86,11 @@ function addToExpression{C,V}(aff::GenericAffExpr{C,V},c::Number,x::GenericAffEx
 end
 
 # help w/ ambiguity
-addToExpression{C,V<:Number}(aff::GenericAffExpr{C,V}, c::Number, x::Number) = aff + c*x
-
+addToExpression{C,V<:Number}(aff::GenericAffExpr{C,V}, c::Number, x::Number) =
+    __addToExpression__(aff, c, x)
 
 function addToExpression{C,V}(aff::GenericAffExpr{C,V}, c::V, x::Number)
-    if x != zero(C)
+    if x != 0
         push!(aff.vars,   c)
         push!(aff.coeffs, x)
     end
@@ -114,7 +114,7 @@ addToExpression(aff::AffExpr,c::Variable,x::AffExpr) =
              addToExpression(aff,c,x.constant))
 
 function addToExpression{C,V}(aff::GenericAffExpr{C,V},c::GenericAffExpr{C,V},x::Number)
-    if x != zero(C)
+    if x != 0
         append!(aff.vars, c.vars)
         append!(aff.coeffs, c.coeffs * x)
         aff.constant += c.constant * x
@@ -123,7 +123,7 @@ function addToExpression{C,V}(aff::GenericAffExpr{C,V},c::GenericAffExpr{C,V},x:
 end
 
 function addToExpression{C,V}(aff::GenericAffExpr{C,V}, c::GenericQuadExpr{C,V}, x::Number)
-    if x == zero(C)
+    if x == 0
         GenericQuadExpr{C,V}(aff)
     else
         GenericQuadExpr{C,V}(copy(c.qvars1),
@@ -134,7 +134,7 @@ function addToExpression{C,V}(aff::GenericAffExpr{C,V}, c::GenericQuadExpr{C,V},
 end
 
 function addToExpression{C,V}(aff::GenericAffExpr{C,V}, c::Number, x::GenericQuadExpr{C,V})
-    if c == zero(C)
+    if c == 0
         GenericQuadExpr{C,V}(aff)
     else
         GenericQuadExpr{C,V}(copy(x.qvars1),
@@ -151,7 +151,7 @@ function addToExpression{C,V}(ex::GenericAffExpr{C,V}, c::GenericAffExpr{C,V}, x
 end
 
 function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::Number,x::V)
-    if c != zero(C)
+    if c != 0
         push!(quad.aff, convert(C,c), x)
     end
     quad
@@ -170,7 +170,7 @@ function addToExpression{C,V}(quad::GenericQuadExpr{C,V},x::V,y::V)
 end
 
 function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::Number,x::GenericAffExpr{C,V})
-    if c != zero(C)
+    if c != 0
         append!(quad.aff.vars, x.vars)
         sizehint!(quad.aff.coeffs, length(quad.aff.coeffs)+length(x.coeffs))
         for i in 1:length(x.coeffs)
@@ -182,7 +182,7 @@ function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::Number,x::GenericAff
 end
 
 function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::GenericAffExpr{C,V},x::Number)
-    if x != zero(C)
+    if x != 0
         addToExpression(quad.aff,c,x)
     end
     quad
@@ -205,7 +205,7 @@ function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::V,x::GenericAffExpr{
 end
 
 function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::GenericQuadExpr{C,V},x::Number)
-    if x != zero(C)
+    if x != 0
         append!(quad.qvars1,c.qvars1)
         append!(quad.qvars2,c.qvars2)
         sizehint!(quad.qcoeffs, length(quad.qcoeffs)+length(c.qcoeffs))
@@ -218,7 +218,7 @@ function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::GenericQuadExpr{C,V}
 end
 
 function addToExpression{C,V}(quad::GenericQuadExpr{C,V},c::Number,x::GenericQuadExpr{C,V})
-    if c != zero(C)
+    if c != 0
         append!(quad.qvars1,x.qvars1)
         append!(quad.qvars2,x.qvars2)
         sizehint!(quad.qcoeffs, length(quad.qcoeffs)+length(x.qcoeffs))
@@ -232,7 +232,7 @@ end
 
 function addToExpression{C,V}(ex::GenericQuadExpr{C,V}, c::GenericAffExpr{C,V}, x::GenericAffExpr{C,V})
     q = c*x
-    addToExpression(ex, one(C), q)
+    addToExpression(ex, 1.0, q)
     ex
 end
 

--- a/src/v0.4/parseExpr_staged.jl
+++ b/src/v0.4/parseExpr_staged.jl
@@ -86,8 +86,7 @@ function addToExpression{C,V}(aff::GenericAffExpr{C,V},c::Number,x::GenericAffEx
 end
 
 # help w/ ambiguity
-addToExpression{C,V<:Number}(aff::GenericAffExpr{C,V}, c::Number, x::Number) =
-    __addToExpression__(aff, c, x)
+addToExpression{C,V<:Number}(aff::GenericAffExpr{C,V}, c::Number, x::Number) = aff + c*x
 
 function addToExpression{C,V}(aff::GenericAffExpr{C,V}, c::V, x::Number)
     if x != 0


### PR DESCRIPTION
This commit broke cases where affine expressions are coefficients of another expression, i.e., JuMPChance. We can't use ``!=`` like this until we kill the deprecated comparison operators. It's also a big performance issue to create and throw away expressions all the time.

Is there a reason why we don't want to compare ``Number`` types with zero? It's pretty much guaranteed to always be defined.