### PR TITLE
Wrap indices used in macros in let/local

### DIFF
--- a/src/v0.4/parseExpr_staged.jl
+++ b/src/v0.4/parseExpr_staged.jl
@@ -299,17 +299,23 @@ function parseSum(x::Expr, aff::Symbol, lcoeffs, rcoeffs, newaff)
             end
         end
         for level in length(x.args):-1:4
-            code = :(
-            for $(esc(x.args[level].args[1])) in $(esc(x.args[level].args[2]))
-                $code
+            idxvar = esc(x.args[level].args[1])
+            code = :(let
+                $(localvar(idxvar))
+                for $idxvar in $(esc(x.args[level].args[2]))
+                    $code
+                end
             end)
         end
     else # no condition
         inneraff, code = parseExpr(x.args[2], aff, lcoeffs, rcoeffs, aff)
         for level in length(x.args):-1:3
-            code = :(
-            for $(esc(x.args[level].args[1])) in $(esc(x.args[level].args[2]))
-                $code
+            idxvar = esc(x.args[level].args[1])
+            code = :(let
+                $(localvar(idxvar))
+                for $idxvar in $(esc(x.args[level].args[2]))
+                    $code
+                end
             end)
         end
         len = :len
@@ -317,7 +323,13 @@ function parseSum(x::Expr, aff::Symbol, lcoeffs, rcoeffs, newaff)
         # this is unncessary if we're just summing constants
         preblock = :($len += length($(esc(x.args[length(x.args)].args[2]))))
         for level in (length(x.args)-1):-1:3
-            preblock = Expr(:for, esc(x.args[level]),preblock)
+            idxvar = esc(x.args[level].args[1])
+            preblock = :(let
+                $(localvar(idxvar))
+                for $idxvar in $(esc(x.args[level].args[2]))
+                    $preblock
+                end
+            end)
         end
         preblock = quote
             $len = 0
@@ -351,9 +363,12 @@ function parseNorm(normp::Symbol, x::Expr, aff::Symbol, lcoeffs, rcoeffs, newaff
             end
         end
         for level in length(x.args):-1:4
-            code = :(
-            for $(esc(x.args[level].args[1])) in $(esc(x.args[level].args[2]))
-                $code
+            idxvar = esc(x.args[level].args[1])
+            code = :(let
+                $(localvar(idxvar))
+                for $idxvar in $(esc(x.args[level].args[2]))
+                    $code
+                end
             end)
         end
         preblock = :($normexpr = GenericAffExpr[])
@@ -362,11 +377,19 @@ function parseNorm(normp::Symbol, x::Expr, aff::Symbol, lcoeffs, rcoeffs, newaff
         code = :(normaff = 0.0; $code; push!($normexpr, $inneraff))
         preblock = :($len += length($(esc(x.args[length(x.args)].args[2]))))
         for level in length(x.args):-1:3
-            code = :(
-            for $(esc(x.args[level].args[1])) in $(esc(x.args[level].args[2]))
-                $code
+            idxvar = esc(x.args[level].args[1])
+            code = :(let
+                $(localvar(idxvar))
+                for $idxvar in $(esc(x.args[level].args[2]))
+                    $code
+                end
             end)
-            preblock = Expr(:for, esc(x.args[level]),preblock)
+            preblock = :(let
+                $(localvar(idxvar))
+                for $idxvar in $(esc(x.args[level].args[2]))
+                    $preblock
+                end
+            end)
         end
         preblock = quote
             $len = 0

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -389,3 +389,47 @@ facts("[macros] Special-case binary multiplication in addToExpression_reorder (#
     @fact conToStr(dual.linconstr[3]) --> "γ - α[3] $leq 0"
 end
 end
+
+facts("[macros] Indices in macros don't leak out of scope (#582)") do
+    m = Model()
+    cnt = 4
+    for i in 5:8
+        @defVar(m, x[i=1:3,j=1:3] ≤ i)
+        cnt += 1
+        @fact i --> cnt
+    end
+    cnt = 4
+    for i in 5:8
+        @defVar(m, y[i=2:4,j=1:3] ≤ i)
+        cnt += 1
+        @fact i --> cnt
+    end
+    cnt = 4
+    for i in 5:8
+        @defVar(m, z[i=[1:3;],j=1:3] ≤ i)
+        cnt += 1
+        @fact i --> cnt
+    end
+    @fact m.colUpper --> vcat(repeat([1.0,2.0,3.0], inner=[3], outer=[4]),
+                              repeat([2.0,3.0,4.0], inner=[3], outer=[4]),
+                              repeat([1.0,2.0,3.0], inner=[3], outer=[4]))
+    @defVar(m, x[i=1:3] ≤ i)
+    cnt = 4
+    for i in 5:8
+        @addConstraint(m, sum{x[i], i=1, j=1, k=1} == 1)
+        cnt += 1
+        @fact i --> cnt
+    end
+    cnt = 4
+    for i in 5:8
+        @addConstraint(m, norm2{x[i], i=1, j=1, k=1} <= 1)
+        cnt += 1
+        @fact i --> cnt
+    end
+    cnt = 4
+    for i in 5:8
+        @addConstraint(m, c[i=1:3,j=1:3], x[i] == 1)
+        cnt += 1
+        @fact i --> cnt
+    end
+end


### PR DESCRIPTION
Ref #582, this seems like a reasonable change in that it makes JuMP behave more like a DSL. Haven't added v0.3 support yet, nor done perf testing to see if this slows things down.