### PR TITLE
Use staged functions in ``@defVar``

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -119,7 +119,7 @@ function getloopedcode(c::Expr, code, condition, idxvars, idxsets, idxpairs, sym
         N = length(idxsets)
         mac = :($(esc(varname)) = JuMPDict{$(sym),$N}())
     else
-        mac = Expr(:macrocall,symbol("@gendict"),esc(varname),sym,idxpairs,idxsets...)
+        mac = Expr(:macrocall,symbol("@gendict"),esc(varname),sym,idxsets...)
     end
     return quote
         $mac
@@ -877,7 +877,7 @@ macro defConstrRef(var)
         idxsets = var.args[2:end]
         idxpairs = IndexPair[]
 
-        mac = Expr(:macrocall,symbol("@gendict"),varname,:ConstraintRef,idxpairs, idxsets...)
+        mac = Expr(:macrocall,symbol("@gendict"), varname, :ConstraintRef, idxsets...)
         code = quote
             $(esc(mac))
             nothing

--- a/test/perf/JuMPArray-iteration.jl
+++ b/test/perf/JuMPArray-iteration.jl
@@ -18,3 +18,23 @@ bench(1)
 bench(100)
 bench(1000)
 bench(2000)
+
+function bench_runtime(n)
+    t1 = @elapsed begin
+        m = Model()
+        I, J = 1:n, 2:n
+        @defVar(m, x[I,J])
+    end
+    t2 = @elapsed begin
+        cntr = 0
+        for (ii,jj,v) in x
+            cntr += ii + jj + v.col
+        end
+    end
+    t1, t2
+end
+
+bench_runtime(1)
+bench_runtime(100)
+bench_runtime(1000)
+bench_runtime(2000)

--- a/test/perf/macro.jl
+++ b/test/perf/macro.jl
@@ -63,3 +63,67 @@ for N in [20,50,100]
     println("    N=$(N) min $(minimum(N2_times))")
 end
 
+function test_linear_runtime(N)
+    m = Model()
+    I,J = 1:10N, 1:5N
+    @defVar(m, x[I,J])
+    K = 1:N
+    @defVar(m, y[K,K,K])
+
+    for z in 1:10
+        @addConstraint(m,
+            9*y[1,1,1] - 5*y[N,N,N] -
+            2*sum{ z*x[j,i*N],                j=((z-1)*N+1):z*N, i=3:4} +
+              sum{ i*(9*x[i,j] + 3*x[j,i]),   i=N:2N,            j=N:2N} +
+            x[1,1] + x[10N,5N] + x[2N,1] +
+            1*y[1,1,N] + 2*y[1,N,1] + 3*y[N,1,1] +
+            y[N,N,N] - 2*y[N,N,N] + 3*y[N,N,N]
+             <=
+            sum{sum{sum{N*i*j*k*y[i,j,k] + x[i,j],k=1:N; i!=j && j!=k},j=1:N},i=1:N} +
+            sum{sum{x[i,j], j=1:5N; j % i == 3}, i=1:10N; i <= N*z}
+            )
+    end
+end
+
+function test_quad_runtime(N)
+    m = Model()
+    I,J = 1:10N, 1:5N
+    @defVar(m, x[I,J])
+    K = 1:N
+    @defVar(m, y[K,K,K])
+
+    for z in 1:10
+        @addConstraint(m,
+            9*y[1,1,1] - 5*y[N,N,N] -
+            2*sum{ z*x[j,i*N],                j=((z-1)*N+1):z*N, i=3:4} +
+              sum{ i*(9*x[i,j] + 3*x[j,i]),   i=N:2N,            j=N:2N} +
+            x[1,1] + x[10N,5N] * x[2N,1] +
+            1*y[1,1,N] * 2*y[1,N,1] + 3*y[N,1,1] +
+            y[N,N,N] - 2*y[N,N,N] * 3*y[N,N,N]
+             <=
+            sum{sum{sum{N*i*j*k*y[i,j,k] * x[i,j],k=1:N; i!=j && j!=k},j=1:N},i=1:N} +
+            sum{sum{x[i,j], j=1:5N; j % i == 3}, i=1:10N; i <= N*z}
+            )
+    end
+end
+
+
+# Warmup
+println("Test 2 (runtime)")
+test_linear_runtime(1)
+test_quad_runtime(1)
+for N in [20,50,100]
+    println("  Running N=$(N)...")
+    N1_times = {}
+    N2_times = {}
+    for iter in 1:10
+        tic()
+        test_linear_runtime(N)
+        push!(N1_times, toq())
+        tic()
+        test_quad_runtime(N)
+        push!(N2_times, toq())
+    end
+    println("    N=$(N) min $(minimum(N1_times))")
+    println("    N=$(N) min $(minimum(N2_times))")
+end


### PR DESCRIPTION
Ref #346, this adds a runtime version of our ``@gendict`` macro so that
```jl
@defVar(m, x[1:3])
```
and
```jl
T = 1:3
@defVar(m, x[T])
```
produce the same object (that is, ``x::Vector{Variable}``). This implementation is type unstable, which I think is inevitable, given that we produce different types for ``T=1:3`` and ``T=2:3``. In the benchmarks updates I pushed, this lead to about a 4x performance hit in the worst-case, though there may be more serious performance hits in other settings.

This PR takes the current behavior, which has opaque difference in semantics, with something that has the same behavior, but opaque differences in performance. If the performance hit is just 4x, I think this may be a reasonable change (and could get better without all the evaling once we switch to proper ``JuMPArray``s), but I'm not certain.