### PR TITLE
access linear constraint from ConstraintRef

### DIFF
--- a/doc/refexpr.rst
+++ b/doc/refexpr.rst
@@ -121,6 +121,10 @@ infeasibility ray (Farkas proof), if available from the solver.
 
 Dual information is unavailable for MIPs and has not yet been implemented for quadratic constraints.
 
+One may retrieve the corresponding internal ``LinearConstraint`` object from a
+``ConstraintRef{LinearConstraint}`` object ``constr`` by calling ``LinearConstraint(constr)``.
+This functionality is not yet implemented for other classes of constraints.
+
 For users who prefer to generate constraints in an explicit loop, we also
 provide the ``@defConstrRef`` convenience macro, e.g.::
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -505,6 +505,8 @@ end
 
 typealias LinConstrRef ConstraintRef{LinearConstraint}
 
+LinearConstraint(ref::LinConstrRef) = ref.m.linconstr[ref.idx]::LinearConstraint
+
 getLinearIndex(x::ConstraintRef) = x.idx
 
 function getDual(c::ConstraintRef{LinearConstraint})

--- a/test/model.jl
+++ b/test/model.jl
@@ -732,6 +732,14 @@ facts("[model] Test getLinearIndex") do
     end
 end
 
+facts("[model] Test LinearConstraint from ConstraintRef") do
+    m = Model()
+    @defVar(m, x)
+    @addConstraint(m, constr, x == 1)
+    real_constr = LinearConstraint(constr)
+    @fact real_constr.terms --> @LinearConstraint(x == 1).terms
+end
+
 facts("[model] Test getValue on OneIndexedArrays") do
     m = Model()
     @defVar(m, x[i=1:5], start=i)


### PR DESCRIPTION
Instead of a new export as suggested in https://github.com/JuliaOpt/JuMP.jl/issues/462#issuecomment-110096545, just add a new constructor for ``LinearConstraint``. If we want a more generic version, we can do 
```
getConstraint{T}(ref::ConstraintRef{T}) = T(ref)
```
on top of this.

Can be implemented for other constraint types (as needed).

@FabrizioLacalandra, you may be interested in this