### PR TITLE
Printing for user-created Array{Variable}

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -379,8 +379,8 @@ exprToStr(n::Norm) = norm_str(REPLMode, n)
 #------------------------------------------------------------------------
 ## JuMPContainer{Variable}
 #------------------------------------------------------------------------
-Base.print(io::IO, j::Union{Array{Variable},JuMPContainer{Variable}}) = print(io, cont_str(REPLMode,j))
-Base.show( io::IO, j::Union{Array{Variable},JuMPContainer{Variable}}) = print(io, cont_str(REPLMode,j))
+Base.print(io::IO, j::Union{JuMPContainer{Variable}, Array{Variable}}) = print(io, cont_str(REPLMode,j))
+Base.show( io::IO, j::Union{JuMPContainer{Variable}, Array{Variable}}) = print(io, cont_str(REPLMode,j))
 
 Base.writemime(io::IO, ::MIME"text/latex", j::Union{JuMPContainer{Variable},Array{Variable}}) =
     print(io, cont_str(IJuliaMode,j,mathmode=false))
@@ -403,9 +403,9 @@ function cont_str(mode, j, sym::PrintSymbols)
     if !haskey(m.varData, j)
         @assert isa(j, Array{Variable})
         if ndims(j) == 1
-            return string(sprint((io,v) -> Base.show_vector(io, v, "[", "]"), j), "\n")
+            return sprint((io,v) -> Base.show_vector(io, v, "[", "]"), j)
         else
-            return string(sprint((io,X) -> Base.showarray(io, X), j), "\n")
+            return sprint((io,X) -> Base.showarray(io, X), j)
         end
     end
 

--- a/test/print.jl
+++ b/test/print.jl
@@ -556,17 +556,15 @@ facts("[print] User-created Array{Variable}") do
 
     v = [x,y,x]
     A = [x y; y x]
-    io_test(REPLMode,   v, "[x,y,x]\n")
-    io_test(IJuliaMode, v, "[x,y,x]\n")
+    io_test(REPLMode,   v, "[x,y,x]")
+    io_test(IJuliaMode, v, "[x,y,x]")
 
     io_test(REPLMode,   A, """
 2x2 Array{JuMP.Variable,2}:
  x  y
- y  x
-""")
+ y  x""")
     io_test(IJuliaMode, A, """
 2x2 Array{JuMP.Variable,2}:
  x  y
- y  x
-""")
+ y  x""")
 end

--- a/test/print.jl
+++ b/test/print.jl
@@ -441,7 +441,7 @@ facts("[print] changing variable categories") do
     le, ge, fa = repl[:leq], repl[:geq], repl[:for_all]
     inset, dots = repl[:in], repl[:dots]
     infty, union = repl[:infty], repl[:union]
-    
+
     mod = Model()
     @defVar(mod, x[1:3])
     @defVar(mod, y[i=1:3,i:3])
@@ -547,4 +547,26 @@ facts("[print] Variable") do
     @fact    getName(a_v) --> "v[4,5,2,3,2,2,4]"
     io_test(REPLMode,   a_v, "v[4,5,2,3,2,2,4]")
     io_test(IJuliaMode, a_v, "v_{4,5,2,3,2,2,4}")
+end
+
+facts("[print] User-created Array{Variable}") do
+    m = Model()
+    @defVar(m, x)
+    @defVar(m, y)
+
+    v = [x,y,x]
+    A = [x y; y x]
+    io_test(REPLMode,   v, "[x,y,x]\n")
+    io_test(IJuliaMode, v, "[x,y,x]\n")
+
+    io_test(REPLMode,   A, """
+2x2 Array{JuMP.Variable,2}:
+ x  y
+ y  x
+""")
+    io_test(IJuliaMode, A, """
+2x2 Array{JuMP.Variable,2}:
+ x  y
+ y  x
+""")
 end


### PR DESCRIPTION
```jl
using JuMP
m = Model()
@defVar(m, x)
```
Before:
```
julia> Any[[x]]
1-element Array{Any,1}:
Error showing value of type Array{Any,1}:
ERROR:
 in printdata at /Users/huchette/.julia/v0.4/JuMP/src/print.jl:108
 in cont_str at /Users/huchette/.julia/v0.4/JuMP/src/print.jl:399
 in showcompact_lim at show.jl:120
 in sprint at iostream.jl:206
 in alignment at show.jl:959
 in alignment at show.jl:991
 in print_matrix at show.jl:1066
 in print_matrix at show.jl:1058
 in anonymous at replutil.jl:23
 in with_output_limit at /Applications/Julia-0.4.0.app/Contents/Resources/julia/lib/julia/sys.dylib
 in writemime at replutil.jl:23
 in display at REPL.jl:114
 in display at REPL.jl:117
 in display at multimedia.jl:151
 in print_response at REPL.jl:134
 in print_response at REPL.jl:121
 in anonymous at REPL.jl:624
 in run_interface at /Applications/Julia-0.4.0.app/Contents/Resources/julia/lib/julia/sys.dylib
 in run_frontend at /Applications/Julia-0.4.0.app/Contents/Resources/julia/lib/julia/sys.dylib
 in run_repl at /Applications/Julia-0.4.0.app/Contents/Resources/julia/lib/julia/sys.dylib
 in _start at /Applications/Julia-0.4.0.app/Contents/Resources/julia/lib/julia/sys.dylibSYSTEM: show(lasterr) caused an error
```

After:
```
julia> Any[[x]]
1-element Array{Any,1}:
 [x]


```
(looks like an extra newline snuck in there, though.)

I noticed this while creating a an array of arrays of Variables and using that as the index set for a JuMPContainer (don't ask).