### PR TITLE
Fix test and 0.5 breakage

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -39,11 +39,15 @@ function buildrefsets(expr::Expr)
         end
     end
     for s in c.args
-        if isa(s,Expr) && (s.head == :(=) || s.head == :in)
-            idxvar = s.args[1]
-            idxset = esc(s.args[2])
-            push!(idxpairs, IndexPair(s.args[1],s.args[2]))
-        else
+        parse_done = false
+        if isa(s, Expr)
+            parse_done, idxvar, _idxset = tryParseIdxSet(s::Expr)
+            if parse_done
+                idxset = esc(_idxset)
+                push!(idxpairs, IndexPair(idxvar, _idxset))
+            end
+        end
+        if !parse_done
             idxvar = gensym()
             idxset = esc(s)
             push!(idxpairs, IndexPair(nothing,s))

--- a/test/solvers.jl
+++ b/test/solvers.jl
@@ -12,32 +12,30 @@
 # Should be run as part of runtests.jl
 #############################################################################
 
-# Detect solvers
-grb = isdir(Pkg.dir("Gurobi"))
-cpx = isdir(Pkg.dir("CPLEX"))
-mos = isdir(Pkg.dir("Mosek"))
-cbc = isdir(Pkg.dir("Cbc"))
-glp = isdir(Pkg.dir("GLPKMathProgInterface"))
-ipt = isdir(Pkg.dir("Ipopt"))
-nlo = isdir(Pkg.dir("NLopt"))
-kni = isdir(Pkg.dir("KNITRO"))
-eco = isdir(Pkg.dir("ECOS"))
-osl = isdir(Pkg.dir("CoinOptServices"))
-scs = isdir(Pkg.dir("SCS"))
-nlw = isdir(Pkg.dir("AmplNLWriter"))
-# Load them
-if grb; import Gurobi; end
-if cpx; import CPLEX; end
-if mos; import Mosek; end
-if cbc; import Cbc; import Clp; end
-if glp; import GLPKMathProgInterface; end
-if ipt; import Ipopt; end
-if nlo; import NLopt; end
-if kni; import KNITRO; end
-if eco; import ECOS; end
-if osl; import CoinOptServices; end
-if scs; import SCS; end
-if nlw; import AmplNLWriter; end
+function try_import(name::Symbol)
+    try
+        @eval import $name
+        return true
+    catch e
+        return false
+    end
+end
+
+# Load available solvers
+grb = try_import(:Gurobi)
+cpx = try_import(:CPLEX)
+mos = try_import(:Mosek)
+cbc = try_import(:Cbc)
+if cbc; import Clp; end
+glp = try_import(:GLPKMathProgInterface)
+ipt = try_import(:Ipopt)
+nlo = try_import(:NLopt)
+kni = try_import(:KNITRO)
+eco = try_import(:ECOS)
+osl = try_import(:CoinOptServices)
+scs = try_import(:SCS)
+nlw = try_import(:AmplNLWriter)
+
 # Create solver lists
 # LP solvers
 lp_solvers = Any[]


### PR DESCRIPTION
* Fix test to support solvers in `LOAD_PATH`. (Ref https://github.com/JuliaOpt/MathProgBase.jl/pull/89)
* Support the new parsing of `in` (Ref https://github.com/JuliaLang/julia/pull/13078 and https://github.com/dcjones/Compose.jl/pull/164)

    The tests pass locally without the fix for `in` so I suspect it is not covered in the test.
