### PR TITLE
Remove use of Compat in tests

### DIFF
--- a/test/callback.jl
+++ b/test/callback.jl
@@ -11,7 +11,7 @@
 # Testing callbacks
 # Must be run as part of runtests.jl, as it needs a list of solvers.
 #############################################################################
-using JuMP, MathProgBase, FactCheck, Compat
+using JuMP, MathProgBase, FactCheck
 
 facts("[callback] Test lazy constraints") do
 for lazysolver in lazy_solvers

--- a/test/model.jl
+++ b/test/model.jl
@@ -12,7 +12,6 @@
 # Must be run as part of runtests.jl, as it needs a list of solvers.
 #############################################################################
 using JuMP, FactCheck
-using Compat
 
 # If solvers not loaded, load them (i.e running just these tests)
 !isdefined(:lp_solvers) && include("solvers.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,6 @@
 #############################################################################
 
 using JuMP
-using Compat
 using FactCheck
 using Base.Test
 #FactCheck.setstyle(:compact)

--- a/test/solvers.jl
+++ b/test/solvers.jl
@@ -104,7 +104,7 @@ ipt && push!(nlp_solvers, Ipopt.IpoptSolver(print_level=0))
 nlo && push!(nlp_solvers, NLopt.NLoptSolver(algorithm=:LD_SLSQP))
 kni && push!(nlp_solvers, KNITRO.KnitroSolver(objrange=1e16,outlev=0))
 osl && push!(nlp_solvers, CoinOptServices.OsilSolver(CoinOptServices.OSOption("sb","yes",solver="ipopt")))
-nlw && osl && push!(nlp_solvers, AmplNLWriter.BonminNLSolver(@compat Dict("bonmin.nlp_log_level"=>0,"bonmin.bb_log_level"=>0)))
+nlw && osl && push!(nlp_solvers, AmplNLWriter.BonminNLSolver(Dict("bonmin.nlp_log_level"=>0,"bonmin.bb_log_level"=>0)))
 convex_nlp_solvers = copy(nlp_solvers)
 mos && push!(convex_nlp_solvers, Mosek.MosekSolver(LOG=0))
 # Mixed-Integer Nonlinear solvers
@@ -112,7 +112,7 @@ minlp_solvers = Any[]
 kni && push!(minlp_solvers, KNITRO.KnitroSolver(outlev=0))
 osl && push!(minlp_solvers, CoinOptServices.OsilBonminSolver(CoinOptServices.OSOption("sb","yes",category="ipopt")))
 osl && push!(minlp_solvers, CoinOptServices.OsilCouenneSolver())
-nlw && osl && push!(minlp_solvers, AmplNLWriter.BonminNLSolver(@compat Dict("bonmin.nlp_log_level"=>0,"bonmin.bb_log_level"=>0)))
+nlw && osl && push!(minlp_solvers, AmplNLWriter.BonminNLSolver(Dict("bonmin.nlp_log_level"=>0,"bonmin.bb_log_level"=>0)))
 nlw && osl && push!(minlp_solvers, AmplNLWriter.CouenneNLSolver())
 # Semidefinite solvers
 sdp_solvers = Any[]


### PR DESCRIPTION
Unfortunately v0.11.0 of JuMP breaks JuMPeR because of the use of Compat in the `test/solvers.jl` file with no dependency on Compat declared. Worth doing a quick tag?