### PR TITLE
Change AffExpr iteration (#633)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 JuMP release notes
 ==================
 
+Unversioned
+-----------
+
+  * Replaced iteration over ``AffExpr`` with ``Number``-like scalar iteration; previous iteration behavior is now available via ``linearterms(::AffExpr)``.
+
 Version 0.11.1 (December 1, 2015)
 ---------------------------------
 

--- a/doc/refexpr.rst
+++ b/doc/refexpr.rst
@@ -84,6 +84,7 @@ The ``ref`` accepts index sets in the same way as ``@defVar``, and those indices
   This is significantly more efficient than using ``aff += other``.
 * ``sum(affs::Array{AffExpr})`` - efficiently sum an array of affine expressions.
 * ``getValue(expr)`` - evaluate an ``AffExpr`` or ``QuadExpr``, given the current solution values.
+* ``linearterms{C,V}(aff::GenericAffExpr{C,V})`` - provides an iterator over the ``(a_i::C,x_i::V)`` terms in affine expression :math:`\sum_i a_i x_i + b`.
 
 Constraint References
 ^^^^^^^^^^^^^^^^^^^^^

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -40,7 +40,7 @@ export
     getVar,
     getLinearIndex,
     # Expressions and constraints
-    affToStr, quadToStr, exprToStr, conToStr, chgConstrRHS,
+    affToStr, quadToStr, exprToStr, conToStr, chgConstrRHS, linearterms,
 
 # Macros and support functions
     @addConstraint, @addConstraints, @addSDPConstraint,
@@ -298,6 +298,10 @@ abstract JuMPConstraint
 # In JuMP, used only for Variable. Useful primarily for extensions
 abstract AbstractJuMPScalar <: ReverseDiffSparse.Placeholder
 
+Base.start(::AbstractJuMPScalar) = false
+Base.next(x::AbstractJuMPScalar, state) = (x, true)
+Base.done(::AbstractJuMPScalar, state) = state
+Base.isempty(::AbstractJuMPScalar) = false
 
 #############################################################################
 # Variable class

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -19,7 +19,7 @@
 #############################################################################
 # GenericAffExpr
 # ∑ aᵢ xᵢ  +  c
-type GenericAffExpr{CoefType,VarType}
+type GenericAffExpr{CoefType,VarType} <: AbstractJuMPScalar
     vars::Vector{VarType}
     coeffs::Vector{CoefType}
     constant::CoefType
@@ -32,20 +32,16 @@ Base.zero(a::GenericAffExpr) = zero(typeof(a))
 Base.one( a::GenericAffExpr) =  one(typeof(a))
 Base.copy(a::GenericAffExpr) = GenericAffExpr(copy(a.vars),copy(a.coeffs),copy(a.constant))
 
-# Iterator protocol - iterates over tuples (aᵢ,xᵢ)
-Base.start(aff::GenericAffExpr) = 1
-Base.done( aff::GenericAffExpr, state::Int) = state > length(aff.vars)
-Base.next( aff::GenericAffExpr, state::Int) = ((aff.coeffs[state], aff.vars[state]), state+1)
-function Base.in{C,V}(x::V, aff::GenericAffExpr{C,V})
-    acc = zero(C)
-    for (coef,term) in aff
-        if isequal(x, term)
-            acc += coef
-        end
-    end
-    return !(acc == zero(C))
+# Old iterator protocol - iterates over tuples (aᵢ,xᵢ)
+immutable LinearTermIterator{GAE<:GenericAffExpr}
+    aff::GAE
 end
 
+linearterms(aff::GenericAffExpr) = LinearTermIterator(aff)
+
+Base.start(lti::LinearTermIterator) = 1
+Base.done( lti::LinearTermIterator, state::Int) = state > length(lti.aff.vars)
+Base.next( lti::LinearTermIterator, state::Int) = ((lti.aff.coeffs[state], lti.aff.vars[state]), state+1)
 
 # More efficient ways to grow an affine expression
 # Add a single term to an affine expression

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -20,7 +20,7 @@
 #############################################################################
 # GenericQuadExpr
 # ∑qᵢⱼ xᵢⱼ  +  ∑ aᵢ xᵢ  +  c
-type GenericQuadExpr{CoefType,VarType}
+type GenericQuadExpr{CoefType,VarType} <: AbstractJuMPScalar
     qvars1::Vector{VarType}
     qvars2::Vector{VarType}
     qcoeffs::Vector{CoefType}

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -61,7 +61,7 @@ facts("[expr] Test expression iterators") do
 
     a1 = 1*x[1] + 2*x[2]
     k = 1
-    for (coeff,var) in a1
+    for (coeff,var) in linearterms(a1)
         if k == 1
             @fact coeff --> 1
             @fact var --> exactly(x[1])
@@ -73,18 +73,7 @@ facts("[expr] Test expression iterators") do
     end
 
     a2 = zero(AffExpr)
-    for (coeff, var) in a2
+    for (coeff, var) in linearterms(a2)
         @fact coeff --> 0.0  # Shouldn't be called!
     end
-end
-
-# Test ``in(::Variable, AffExpr)``
-facts("[expr] Test in(::Variable, ::AffExpr)") do
-    m = Model()
-    @defVar(m, x[1:3])
-    @defVar(m, y)
-    @fact (x[2] in 2x[2] + x[1]) --> true
-    @fact (x[3] in x[1] + 2x[2]) --> false
-    @fact (y in @defExpr(sum{i*x[i],i=1:3})) --> false
-    @fact (x[2] in x[1] + 2x[2] - x[2] + x[3] - x[2]) --> false
 end


### PR DESCRIPTION
Changes:
* Remove idiosyncratic AffExpr iteration
* Remove in(::Variable, ::AffExpr)
* Make AffExpr, QuadExpr <: AbstractJuMPScalar

The first seemed uncontroversial, but I'm not sure how the other two will go over. I don't think it's possible to "deprecate" iteration if we want to replace the behavior with "number-like" iteration instead.