### PR TITLE
RFC: NLP rewrite using ReverseDiffSparse2

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.4
 MathProgBase 0.4.0 0.5.0-
-ReverseDiffSparse 0.3 0.4
-ArrayViews 0.4.12
+ReverseDiffSparse 0.4 0.5
 Calculus

--- a/doc/probmod.rst
+++ b/doc/probmod.rst
@@ -87,5 +87,5 @@ function and sense will be replaced.
 Modifying nonlinear models
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-See :ref:`Nonlinear performance <nonlinearprobmod>`.
+See :ref:`nonlinear parameters <nonlinearprobmod>`.
 

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -111,13 +111,6 @@ function getValue(a::AffExpr)
     end
     ret
 end
-function getValue(arr::Array{AffExpr})
-    ret = similar(arr, Float64)
-    for I in eachindex(arr)
-        ret[I] = getValue(arr[I])
-    end
-    ret
-end
 
 ##########################################################################
 # GenericRangeConstraint

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -5,6 +5,9 @@
 
 using Base.Meta
 
+issum(s::Symbol) = (s == :sum) || (s == :∑) || (s == :Σ)
+isprod(s::Symbol) = (s == :prod) || (s == :∏)
+
 include("parseExpr_staged.jl")
 
 ###############################################################################
@@ -954,7 +957,6 @@ macro addNLConstraint(m, x, extra...)
         code = quote
             c = NonlinearConstraint(@processNLExpr($(esc(lhs))), $lb, $ub)
             push!($m.nlpdata.nlconstr, c)
-            push!($m.nlpdata.nlconstrlist, c.terms)
             $(refcall) = ConstraintRef{NonlinearConstraint}($m, length($m.nlpdata.nlconstr))
         end
     elseif length(x.args) == 5
@@ -972,7 +974,6 @@ macro addNLConstraint(m, x, extra...)
             end
             c = NonlinearConstraint(@processNLExpr($(esc(x.args[3]))), $(esc(lb)), $(esc(ub)))
             push!($m.nlpdata.nlconstr, c)
-            push!($m.nlpdata.nlconstrlist, c.terms)
             $(refcall) = ConstraintRef{NonlinearConstraint}($m, length($m.nlpdata.nlconstr))
         end
     else
@@ -992,17 +993,59 @@ macro addNLConstraint(m, x, extra...)
     return assert_validmodel(m, code)
 end
 
-macro defNLExpr(x, extra...)
-    # Two formats:
-    # - @defNLExpr(a*x <= 5)
-    # - @defNLExpr(myref[a=1:5], sin(x^a))
-    length(extra) > 1 && error("in @defNLExpr: too many arguments.")
-    # Canonicalize the arguments
-    c = length(extra) == 1 ? x        : nothing
-    x = length(extra) == 1 ? extra[1] : x
+macro defNLExpr(args...)
+    if length(args) <= 2
+        s = IOBuffer()
+        print(s,args[1])
+        if length(args) == 2
+            print(s,",")
+            print(s,args[2])
+        end
+        msg = """
+        in @defNLExpr($(takebuf_string(s))): three arguments are required.
+        Note that the syntax of @defNLExpr has recently changed:
+        The first argument should be the model to which the expression is attached.
+        The second is the name of the expression (or collection of expressions).
+        The third is the expression itself.
+        Example:
+        @defNLExpr(m, my_expr, x^2/y)
+        @defNLExpr(m, my_expr_collection[i=1:2], sin(z[i])^2)
+        Support for the old syntax (with the model omitted) will be removed in an upcoming release.
+        """
+        Base.warn(msg)
+        m = :(__last_model[1])
+        if length(args) == 2
+            c = args[1]
+            x = args[2]
+        else
+            c = nothing
+            x = args[1]
+        end
+    else
+        @assert length(args) == 3
+        m, c, x = args
+        m = esc(m)
+    end
 
-    refcall, idxvars, idxsets, idxpairs = buildrefsets(c)
-    varname = isexpr(refcall,:ref) ? refcall.args[1] : refcall
-    macrocall = Expr(:macrocall, symbol("@parametricExpr"), [esc(v) for v in idxvars]..., esc(x))
-    return :($(varname) = $macrocall)
+    refcall, idxvars, idxsets, idxpairs, condition = buildrefsets(c)
+    code = quote
+        $(refcall) = NonlinearExpression($m, @processNLExpr($(esc(x))))
+    end
+    return assert_validmodel(m, getloopedcode(c, code, condition, idxvars, idxsets, idxpairs, :NonlinearExpression))
+end
+
+# syntax is @defNLParam(m, p[i=1] == 2i)
+macro defNLParam(m, ex)
+    m = esc(m)
+    @assert isexpr(ex, :comparison)
+    @assert length(ex.args) == 3
+    @assert ex.args[2] == :(==)
+    c = ex.args[1]
+    x = ex.args[3]
+
+    refcall, idxvars, idxsets, idxpairs, condition = buildrefsets(c)
+    code = quote
+        $(refcall) = newparameter($m, $(esc(x)))
+    end
+    return assert_validmodel(m, getloopedcode(c, code, condition, idxvars, idxsets, idxpairs, :NonlinearParameter))
 end

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -880,6 +880,7 @@ function _buildInternalModel_nlp(m::Model, traits)
     if m.internalModelLoaded
         @assert isa(nldata.evaluator, JuMPNLPEvaluator)
         d = nldata.evaluator
+        fill!(d.last_x, NaN)
         if length(nldata.nlparamvalues) == 0 && !ENABLE_NLP_RESOLVE[1]
             # no parameters and haven't explicitly allowed resolves
             # error to prevent potentially incorrect answers

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -3,17 +3,44 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-typealias NonlinearConstraint GenericRangeConstraint{ReverseDiffSparse.SymbolicOutput}
+include("nlpmacros.jl")
+
+import DualNumbers: Dual, epsilon
+
+type NonlinearExprData
+    nd::Vector{NodeData}
+    const_values::Vector{Float64}
+end
+
+typealias NonlinearConstraint GenericRangeConstraint{NonlinearExprData}
 
 type NLPData
     nlobj
     nlconstr::Vector{NonlinearConstraint}
-    nlconstrlist::ReverseDiffSparse.ExprList
+    nlexpr::Vector{NonlinearExprData}
     nlconstrDuals::Vector{Float64}
+    nlparamvalues::Vector{Float64}
     evaluator
 end
 
-NLPData() = NLPData(nothing, NonlinearConstraint[], ExprList(), Float64[], nothing)
+function NonlinearExpression(m::Model,ex::NonlinearExprData)
+    initNLP(m)
+    nldata::NLPData = m.nlpdata
+    push!(nldata.nlexpr, ex)
+    return NonlinearExpression(m, length(nldata.nlexpr))
+end
+
+function newparameter(m::Model,value::Number)
+    initNLP(m)
+    nldata::NLPData = m.nlpdata
+    push!(nldata.nlparamvalues, value)
+    return NonlinearParameter(m, length(nldata.nlparamvalues))
+end
+
+getValue(p::NonlinearParameter) = p.m.nlpdata.nlparamvalues[p.index]::Float64
+setValue(p::NonlinearParameter,v::Number) = (p.m.nlpdata.nlparamvalues[p.index] = v)
+
+NLPData() = NLPData(nothing, NonlinearConstraint[], NonlinearExprData[], Float64[], Float64[], nothing)
 
 Base.copy(::NLPData) = error("Copying nonlinear problems not yet implemented")
 
@@ -32,20 +59,54 @@ function getDual(c::ConstraintRef{NonlinearConstraint})
     return nldata.nlconstrDuals[c.idx]
 end
 
+type FunctionStorage
+    nd::Vector{NodeData}
+    adj::SparseMatrixCSC{Bool,Int}
+    const_values::Vector{Float64}
+    forward_storage::Vector{Float64}
+    reverse_storage::Vector{Float64}
+    grad_sparsity::Vector{Int}
+    hess_I::Vector{Int} # nonzero pattern of hessian
+    hess_J::Vector{Int}
+    rinfo::Coloring.RecoveryInfo # coloring info for hessians
+    seed_matrix::Matrix{Float64}
+    linearity::Linearity
+    dependent_subexpressions::Vector{Int} # subexpressions which this function depends on, ordered for forward pass
+end
+
+type SubexpressionStorage
+    nd::Vector{NodeData}
+    adj::SparseMatrixCSC{Bool,Int}
+    const_values::Vector{Float64}
+    forward_storage::Vector{Float64}
+    reverse_storage::Vector{Float64}
+    forward_hessian_storage::Vector{Dual{Float64}}
+    reverse_hessian_storage::Vector{Dual{Float64}}
+end
+
 type JuMPNLPEvaluator <: MathProgBase.AbstractNLPEvaluator
     m::Model
     A::SparseMatrixCSC{Float64,Int} # linear constraint matrix
+    parameter_values::Vector{Float64}
     has_nlobj::Bool
     linobj::Vector{Float64}
-    eval_f_nl::Function
-    eval_fgrad_nl::Function
-    eval_h_nl::Function
-    nnz_hess_obj::Int
-    jac_I::Vector{Int}
-    jac_J::Vector{Int}
-    hess_I::Vector{Int}
-    hess_J::Vector{Int}
-    requested_hessian::Bool
+    objective::FunctionStorage
+    constraints::Vector{FunctionStorage}
+    subexpressions::Vector{SubexpressionStorage}
+    subexpression_order::Vector{Int}
+    subexpression_forward_values::Vector{Float64}
+    subexpression_reverse_values::Vector{Float64}
+    subexpressions_as_julia_expressions::Vector{Any}
+    last_x::Vector{Float64}
+    jac_storage::Vector{Float64} # temporary storage for computing jacobians
+    # storage for computing hessians
+    want_hess::Bool
+    forward_storage_hess::Vector{Dual{Float64}} # length is of the longest expression
+    reverse_storage_hess::Vector{Dual{Float64}} # length is of the longest expression
+    forward_input_vector::Vector{Dual{Float64}} # length is number of variables
+    reverse_output_vector::Vector{Dual{Float64}}# length is number of variables
+    subexpression_hessian_forward_values::Vector{Dual{Float64}} # length is number of subexpressions
+    subexpression_hessian_reverse_values::Vector{Dual{Float64}} # length is number of subexpressions
     # timers
     eval_f_timer::Float64
     eval_g_timer::Float64
@@ -54,7 +115,13 @@ type JuMPNLPEvaluator <: MathProgBase.AbstractNLPEvaluator
     eval_hesslag_timer::Float64
     function JuMPNLPEvaluator(m::Model)
         d = new(m)
+        numVar = m.numCols
         d.A = prepConstrMatrix(m)
+        d.constraints = FunctionStorage[]
+        d.last_x = fill(NaN, numVar)
+        d.jac_storage = Array(Float64,numVar)
+        d.forward_input_vector = Array(Dual{Float64},numVar)
+        d.reverse_output_vector = Array(Dual{Float64},numVar)
         d.eval_f_timer = 0
         d.eval_g_timer = 0
         d.eval_grad_f_timer = 0
@@ -64,7 +131,58 @@ type JuMPNLPEvaluator <: MathProgBase.AbstractNLPEvaluator
     end
 end
 
-@Base.deprecate JuMPNLPEvaluator(m::Model,A) JuMPNLPEvaluator(m)
+function FunctionStorage(nld::NonlinearExprData,numVar, want_hess::Bool, subexpr::Vector{Vector{NodeData}}, dependent_subexpressions, subexpression_linearity, subexpression_edgelist, subexpression_variables)
+
+    nd = nld.nd
+    const_values = nld.const_values
+    adj = adjmat(nd)
+    forward_storage = zeros(length(nd))
+    reverse_storage = zeros(length(nd))
+    grad_sparsity = compute_gradient_sparsity(nd)
+
+    for k in dependent_subexpressions
+        union!(grad_sparsity, compute_gradient_sparsity(subexpr[k]))
+    end
+
+    if want_hess
+        # compute hessian sparsity
+        linearity = classify_linearity(nd, adj, subexpression_linearity)
+        edgelist = compute_hessian_sparsity(nd, adj, linearity, subexpression_edgelist, subexpression_variables)
+        hess_I, hess_J, rinfo = Coloring.hessian_color_preprocess(edgelist, numVar)
+        seed_matrix = Coloring.seed_matrix(rinfo)
+        if linearity[1] == NONLINEAR
+            @assert length(hess_I) > 0
+        end
+    else
+        hess_I = hess_J = Int[]
+        rinfo = Coloring.RecoveryInfo()
+        seed_matrix = Array(Float64,0,0)
+        linearity = [NONLINEAR]
+    end
+
+    return FunctionStorage(nd, adj, const_values, forward_storage, reverse_storage, sort(collect(grad_sparsity)), hess_I, hess_J, rinfo, seed_matrix, linearity[1],dependent_subexpressions)
+
+end
+
+function SubexpressionStorage(nld::NonlinearExprData,numVar, want_hess_storage::Bool)
+
+    nd = nld.nd
+    const_values = nld.const_values
+    adj = adjmat(nd)
+    forward_storage = zeros(length(nd))
+    reverse_storage = zeros(length(nd))
+    if want_hess_storage # for Hess or HessVec
+        forward_hessian_storage = zeros(Dual{Float64},length(nd))
+        reverse_hessian_storage = zeros(Dual{Float64},length(nd))
+    else
+        forward_hessian_storage = Array(Dual{Float64},0)
+        reverse_hessian_storage = Array(Dual{Float64},0)
+    end
+
+
+    return SubexpressionStorage(nd, adj, const_values, forward_storage, reverse_storage, forward_hessian_storage, reverse_hessian_storage)
+
+end
 
 function MathProgBase.initialize(d::JuMPNLPEvaluator, requested_features::Vector{Symbol})
     for feat in requested_features
@@ -83,147 +201,87 @@ function MathProgBase.initialize(d::JuMPNLPEvaluator, requested_features::Vector
     initNLP(d.m) #in case the problem is purely linear/quadratic thus far
     nldata::NLPData = d.m.nlpdata
 
-    if :ExprGraph in requested_features
-        prep_expression_output(nldata.nlconstrlist)
-        if length(requested_features) == 1 # don't need to do anything else
-            return
-        end
-    end
-
-    need_hessian = (:Hess in requested_features)
-    d.requested_hessian = need_hessian
-
-    d.has_nlobj = isa(nldata.nlobj, ReverseDiffSparse.SymbolicOutput)
-    if d.has_nlobj
-        @assert length(d.m.obj.qvars1) == 0 && length(d.m.obj.aff.vars) == 0
-    end
+    d.parameter_values = nldata.nlparamvalues
 
     tic()
 
     d.linobj, linrowlb, linrowub = prepProblemBounds(d.m)
+    numVar = length(d.linobj)
 
-    A = d.A
+    d.want_hess = (:Hess in requested_features)
+    want_hess_storage = (:HessVec in requested_features) || d.want_hess
 
-    n_nlconstr = length(nldata.nlconstr)
-
-    constrhessI, constrhessJ = prep_sparse_hessians(nldata.nlconstrlist, d.m.numCols, hessvec_only = !need_hessian)
-    nljacI, nljacJ = jac_nz(nldata.nlconstrlist) # nonlinear jacobian components
-    nnz_jac::Int = nnz(A) + length(nljacI)
-    nnz_hess = length(constrhessI)
-
-    for c in d.m.quadconstr
-        nnz_jac += 2*length(c.terms.qvars1)+length(c.terms.aff.vars)
-        nnz_hess += length(c.terms.qvars1)
+    d.has_nlobj = isa(nldata.nlobj, NonlinearExprData)
+    max_expr_length = 0
+    main_expressions = Array(Vector{NodeData},0)
+    subexpr = Array(Vector{NodeData},0)
+    for nlexpr in nldata.nlexpr
+        push!(subexpr, nlexpr.nd)
     end
+    if d.has_nlobj
+        push!(main_expressions,nldata.nlobj.nd)
+    end
+    for nlconstr in nldata.nlconstr
+        push!(main_expressions,nlconstr.terms.nd)
+    end
+    d.subexpression_order, individual_order = order_subexpressions(main_expressions,subexpr)
+    if :ExprGraph in requested_features
+        d.subexpressions_as_julia_expressions = Array(Any,length(subexpr))
+        for k in d.subexpression_order
+            ex = nldata.nlexpr[k]
+            adj = adjmat(ex.nd)
+            d.subexpressions_as_julia_expressions[k] = tapeToExpr(1, ex.nd, adj, ex.const_values, d.parameter_values, d.subexpressions_as_julia_expressions)
+        end
+    end
+
+    subexpression_linearity = Array(Linearity, length(nldata.nlexpr))
+    subexpression_variables = Array(Set{Int}, length(nldata.nlexpr))
+    subexpression_edgelist = Array(Set{Tuple{Int,Int}}, length(nldata.nlexpr))
+    d.subexpressions = Array(SubexpressionStorage, length(nldata.nlexpr))
+    for k in d.subexpression_order # only load expressions which actually are used
+        d.subexpressions[k] = SubexpressionStorage(nldata.nlexpr[k], numVar, want_hess_storage)
+        subex = d.subexpressions[k]
+        if d.want_hess
+            linearity = classify_linearity(subex.nd, subex.adj, subexpression_linearity)
+            subexpression_linearity[k] = linearity[1]
+            vars = compute_gradient_sparsity(d.subexpressions[k].nd)
+            # union with all dependent expressions
+            for idx in list_subexpressions(d.subexpressions[k].nd)
+                union!(vars, subexpression_variables[idx])
+            end
+            subexpression_variables[k] = vars
+            edgelist = compute_hessian_sparsity(subex.nd, subex.adj, linearity,subexpression_edgelist, subexpression_variables)
+            subexpression_edgelist[k] = edgelist
+        end
+
+    end
+
 
     if d.has_nlobj
-        d.eval_fgrad_nl = genfgrad_simple(nldata.nlobj)
-        d.eval_f_nl = genfval_simple(nldata.nlobj)
+        @assert length(d.m.obj.qvars1) == 0 && length(d.m.obj.aff.vars) == 0
+        d.objective = FunctionStorage(nldata.nlobj, numVar, d.want_hess, subexpr, individual_order[1], subexpression_linearity, subexpression_edgelist, subexpression_variables)
+        max_expr_length = max(max_expr_length, length(d.objective.nd))
     end
 
-    # Jacobian structure
-    jac_I = zeros(Int,nnz_jac)
-    jac_J = zeros(Int,nnz_jac)
-    let
-        idx = 1
-        for col = 1:size(A,2)
-            for pos = A.colptr[col]:(A.colptr[col+1]-1)
-                jac_I[idx] = A.rowval[pos]
-                jac_J[idx] = col
-                idx += 1
-            end
-        end
-        rowoffset = size(A,1)+1
-        for c::QuadConstraint in d.m.quadconstr
-            aff = c.terms.aff
-            for k in 1:length(aff.vars)
-                jac_I[idx] = rowoffset
-                jac_J[idx] = aff.vars[k].col
-                idx += 1
-            end
-            for k in 1:length(c.terms.qvars1)
-                jac_I[idx] = rowoffset
-                jac_J[idx] = c.terms.qvars1[k].col
-                jac_I[idx+1] = rowoffset
-                jac_J[idx+1] = c.terms.qvars2[k].col
-                idx += 2
-            end
-            rowoffset += 1
-        end
-        for k in 1:length(nljacI)
-            jac_I[idx] = nljacI[k]+rowoffset-1
-            jac_J[idx] = nljacJ[k]
-            idx += 1
-        end
-        @assert idx-1 == nnz_jac
-    end
-    d.jac_I = jac_I
-    d.jac_J = jac_J
-
-    if need_hessian
-        if d.has_nlobj
-            hI, hJ, d.eval_h_nl = gen_hessian_sparse_color_parametric(nldata.nlobj, d.m.numCols)
-            nnz_hess += length(hI)
-        else
-            hI = []
-            hJ = []
-            d.eval_h_nl = (x,y,z) -> nothing
-            nnz_hess += length(d.m.obj.qvars1)
-        end
-        d.nnz_hess_obj = length(hI)
-
-        hess_I = zeros(Int,nnz_hess)
-        hess_J = zeros(Int,nnz_hess)
-
-        qobj::QuadExpr = d.m.obj
-        for i in 1:length(hI)
-            # not guaranteed to be lower-triangular
-            ix1 = nldata.nlobj.mapfromcanonical[hI[i]]
-            ix2 = nldata.nlobj.mapfromcanonical[hJ[i]]
-            if ix2 > ix1
-                ix1, ix2 = ix2, ix1
-            end
-            hess_I[i] = ix1
-            hess_J[i] = ix2
-        end
-        idx = length(hI)+1
-        for k in 1:length(qobj.qvars1)
-            qidx1 = qobj.qvars1[k].col
-            qidx2 = qobj.qvars2[k].col
-            if qidx2 > qidx1
-                qidx1, qidx2 = qidx2, qidx1
-            end
-            hess_I[idx] = qidx1
-            hess_J[idx] = qidx2
-            idx += 1
-        end
-        # quadratic constraints
-        for c::QuadConstraint in d.m.quadconstr
-            for k in 1:length(c.terms.qvars1)
-                qidx1 = c.terms.qvars1[k].col
-                qidx2 = c.terms.qvars2[k].col
-                if qidx2 > qidx1
-                    qidx1, qidx2 = qidx2, qidx1
-                end
-                hess_I[idx] = qidx1
-                hess_J[idx] = qidx2
-                idx += 1
-            end
-        end
-
-        hess_I[idx:end] = constrhessI
-        hess_J[idx:end] = constrhessJ
-        d.hess_I = hess_I
-        d.hess_J = hess_J
+    for k in 1:length(nldata.nlconstr)
+        nlconstr = nldata.nlconstr[k]
+        idx = (d.has_nlobj) ? k+1 : k
+        push!(d.constraints, FunctionStorage(nlconstr.terms, numVar, d.want_hess, subexpr, individual_order[idx], subexpression_linearity, subexpression_edgelist, subexpression_variables))
+        max_expr_length = max(max_expr_length, length(d.constraints[end].nd))
     end
 
-    numconstr = length(d.m.linconstr)+length(d.m.quadconstr)+n_nlconstr
-    # call functions once to pre-compile
-    MathProgBase.eval_f(d, d.m.colVal)
-    MathProgBase.eval_grad_f(d, Array(Float64,d.m.numCols), d.m.colVal)
-    MathProgBase.eval_g(d, Array(Float64,numconstr), d.m.colVal)
-    MathProgBase.eval_jac_g(d, Array(Float64,nnz_jac), d.m.colVal)
-    need_hessian && MathProgBase.eval_hesslag(d, Array(Float64,nnz_hess), d.m.colVal, 1.0, ones(numconstr))
+    if d.want_hess || want_hess_storage # storage for Hess or HessVec
+        d.forward_storage_hess = Array(Dual{Float64},max_expr_length)
+        d.reverse_storage_hess = Array(Dual{Float64},max_expr_length)
+        d.subexpression_hessian_forward_values = Array(Dual{Float64},length(d.subexpressions))
+        d.subexpression_hessian_reverse_values = Array(Dual{Float64},length(d.subexpressions))
+    end
+
+
+    d.subexpression_forward_values = Array(Float64, length(d.subexpressions))
+    d.subexpression_reverse_values = Array(Float64, length(d.subexpressions))
+
+
 
     tprep = toq()
     #println("Prep time: $tprep")
@@ -240,25 +298,59 @@ end
 
 MathProgBase.features_available(d::JuMPNLPEvaluator) = [:Grad, :Jac, :Hess, :HessVec, :ExprGraph]
 
+function forward_eval_all(d::JuMPNLPEvaluator,x)
+    # do a forward pass on all expressions at x
+    subexpr_values = d.subexpression_forward_values
+    for k in d.subexpression_order
+        ex = d.subexpressions[k]
+        subexpr_values[k] = forward_eval(ex.forward_storage,ex.nd,ex.adj,ex.const_values,d.parameter_values,x,subexpr_values)
+    end
+    if d.has_nlobj
+        ex = d.objective
+        forward_eval(ex.forward_storage,ex.nd,ex.adj,ex.const_values,d.parameter_values,x,subexpr_values)
+    end
+    for ex in d.constraints
+        forward_eval(ex.forward_storage,ex.nd,ex.adj,ex.const_values,d.parameter_values,x,subexpr_values)
+    end
+    copy!(d.last_x,x)
+end
+
 function MathProgBase.eval_f(d::JuMPNLPEvaluator, x)
     tic()
+    if d.last_x != x
+        forward_eval_all(d,x)
+    end
+    val = zero(eltype(x))
     if d.has_nlobj
-        v = d.eval_f_nl(x)::Float64
+        val = d.objective.forward_storage[1]
     else
         qobj = d.m.obj::QuadExpr
-        v = dot(x,d.linobj) + qobj.aff.constant
+        val = dot(x,d.linobj) + qobj.aff.constant
         for k in 1:length(qobj.qvars1)
-            v += qobj.qcoeffs[k]*x[qobj.qvars1[k].col]*x[qobj.qvars2[k].col]
+            val += qobj.qcoeffs[k]*x[qobj.qvars1[k].col]*x[qobj.qvars2[k].col]
         end
     end
     d.eval_f_timer += toq()
-    return v
+    return val
 end
 
 function MathProgBase.eval_grad_f(d::JuMPNLPEvaluator, g, x)
     tic()
+    if d.last_x != x
+        forward_eval_all(d,x)
+    end
     if d.has_nlobj
-        d.eval_fgrad_nl(x,g)
+        fill!(g,0.0)
+        ex = d.objective
+        subexpr_reverse_values = d.subexpression_reverse_values
+        subexpr_reverse_values[ex.dependent_subexpressions] = 0.0
+        reverse_eval(g,ex.reverse_storage,ex.forward_storage,ex.nd,ex.adj,subexpr_reverse_values,1.0)
+        for i in length(ex.dependent_subexpressions):-1:1
+            k = ex.dependent_subexpressions[i]
+            subexpr = d.subexpressions[k]
+            reverse_eval(g,subexpr.reverse_storage,subexpr.forward_storage,subexpr.nd,subexpr.adj,subexpr_reverse_values,subexpr_reverse_values[k])
+
+        end
     else
         copy!(g,d.linobj)
         qobj::QuadExpr = d.m.obj
@@ -274,10 +366,13 @@ end
 
 function MathProgBase.eval_g(d::JuMPNLPEvaluator, g, x)
     tic()
+    if d.last_x != x
+        forward_eval_all(d,x)
+    end
     A = d.A
     for i in 1:size(A,1); g[i] = 0.0; end
-    #fill!(subarr(g,1:size(A,1)), 0.0)
-    A_mul_B!(subarr(g,1:size(A,1)),A,x)
+    #fill!(sub(g,1:size(A,1)), 0.0)
+    A_mul_B!(sub(g,1:size(A,1)),A,x)
     idx = size(A,1)+1
     quadconstr = d.m.quadconstr::Vector{QuadConstraint}
     for c::QuadConstraint in quadconstr
@@ -292,7 +387,10 @@ function MathProgBase.eval_g(d::JuMPNLPEvaluator, g, x)
         g[idx] = v
         idx += 1
     end
-    eval_g!(subarr(g,idx:length(g)), (d.m.nlpdata::NLPData).nlconstrlist, x)
+    for ex in d.constraints
+        g[idx] = ex.forward_storage[1]
+        idx += 1
+    end
 
     d.eval_g_timer += toq()
     #print("x = ");show(x);println()
@@ -302,11 +400,14 @@ end
 
 function MathProgBase.eval_jac_g(d::JuMPNLPEvaluator, J, x)
     tic()
+    if d.last_x != x
+        forward_eval_all(d,x)
+    end
     fill!(J,0.0)
     idx = 1
     A = d.A
     for col = 1:size(A,2)
-        for pos = A.colptr[col]:(A.colptr[col+1]-1)
+        for pos = nzrange(A,col)
             J[idx] = A.nzval[pos]
             idx += 1
         end
@@ -328,7 +429,25 @@ function MathProgBase.eval_jac_g(d::JuMPNLPEvaluator, J, x)
             idx += 2
         end
     end
-    eval_jac_g!(subarr(J,idx:length(J)), (d.m.nlpdata::NLPData).nlconstrlist, x)
+    grad_storage = d.jac_storage
+    subexpr_reverse_values = d.subexpression_reverse_values
+    for ex in d.constraints
+        nzidx = ex.grad_sparsity
+        grad_storage[nzidx] = 0.0
+        subexpr_reverse_values[ex.dependent_subexpressions] = 0.0
+
+        reverse_eval(grad_storage,ex.reverse_storage,ex.forward_storage,ex.nd,ex.adj,subexpr_reverse_values,1.0)
+        for i in length(ex.dependent_subexpressions):-1:1
+            k = ex.dependent_subexpressions[i]
+            subexpr = d.subexpressions[k]
+            reverse_eval(grad_storage,subexpr.reverse_storage,subexpr.forward_storage,subexpr.nd,subexpr.adj,subexpr_reverse_values,subexpr_reverse_values[k])
+        end
+
+        for k in 1:length(nzidx)
+            J[idx+k-1] = grad_storage[nzidx[k]]
+        end
+        idx += length(nzidx)
+    end
 
     d.eval_jac_g_timer += toq()
     #print("x = ");show(x);println()
@@ -336,7 +455,7 @@ function MathProgBase.eval_jac_g(d::JuMPNLPEvaluator, J, x)
     return
 end
 
-import DualNumbers: Dual, epsilon
+
 
 function MathProgBase.eval_hesslag_prod(
     d::JuMPNLPEvaluator,
@@ -348,19 +467,21 @@ function MathProgBase.eval_hesslag_prod(
 
     nldata = d.m.nlpdata::NLPData
 
-    # evaluate directional derivative of the gradient
-    dualvec = reinterpret(Dual{Float64}, nldata.nlconstrlist.dualvec)
-    dualout = reinterpret(Dual{Float64}, nldata.nlconstrlist.dualout)
-    @assert length(dualvec) >= length(x)
-    for i in 1:length(x)
-        dualvec[i] = Dual(x[i], v[i])
-        dualout[i] = zero(Dual{Float64})
-    end
-    MathProgBase.eval_grad_f(d, dualout, dualvec)
-    for i in 1:length(x)
-        h[i] = σ*epsilon(dualout[i])
+    # quadratic objective
+    qobj::QuadExpr = d.m.obj
+    for k in 1:length(qobj.qvars1)
+        col1 = qobj.qvars1[k].col
+        col2 = qobj.qvars2[k].col
+        coef = qobj.qcoeffs[k]
+        if col1 == col2
+            h[col1] += σ*2*coef*v[col1]
+        else
+            h[col1] += σ*coef*v[col2]
+            h[col2] += σ*coef*v[col1]
+        end
     end
 
+    # quadratic constraints
     row = size(d.A,1)+1
     quadconstr = d.m.quadconstr::Vector{QuadConstraint}
     for c in quadconstr
@@ -379,7 +500,45 @@ function MathProgBase.eval_hesslag_prod(
         row += 1
     end
 
-    ReverseDiffSparse.eval_hessvec!(h, v, nldata.nlconstrlist, x, subarr(μ,row:length(μ)))
+    for i in 1:length(x)
+        d.forward_input_vector[i] = Dual(x[i],v[i])
+    end
+
+    # forward evaluate all subexpressions once
+    subexpr_forward_values = d.subexpression_hessian_forward_values
+    subexpr_reverse_values = d.subexpression_hessian_reverse_values
+    reverse_output_vector = d.reverse_output_vector
+    for expridx in d.subexpression_order
+        subexpr = d.subexpressions[expridx]
+        subexpr_forward_values[expridx] = forward_eval(subexpr.forward_hessian_storage, subexpr.nd, subexpr.adj, subexpr.const_values, d.parameter_values, forward_input_vector,subexpr_forward_values)
+    end
+    # we only need to do one reverse pass through the subexpressions as well
+    fill!(subexpr_reverse_values,zero(Dual{Float64}))
+    fill!(reverse_output_vector,zero(Dual{Float64}))
+    if d.has_nlobj
+        ex = d.objective
+        forward_eval(d.forward_storage_hess,ex.nd,ex.adj,ex.const_values,d.parameter_values,d.forward_input_vector,subexpr_forward_values)
+        reverse_eval(reverse_output_vector,d.reverse_storage_hess,d.forward_storage_hess,ex.nd,ex.adj,subexpr_reverse_values, Dual(σ)) # note scaled by σ
+    end
+
+
+    for i in 1:length(d.constraints)
+        ex = d.constraints[i]
+        l = μ[row]
+        forward_eval(d.forward_storage_hess,ex.nd,ex.adj,ex.const_values,d.parameter_values,d.forward_input_vector,subexpr_forward_values)
+        reverse_eval(reverse_output_vector,d.reverse_storage_hess,d.forward_storage_hess,ex.nd,ex.adj,subexpr_reverse_values, Dual(l))
+        row += 1
+    end
+
+    for i in length(ex.dependent_subexpressions):-1:1
+        expridx = ex.dependent_subexpressions[i]
+        subexpr = d.subexpressions[expridx]
+        reverse_eval(reverse_output_vector,subexpr.reverse_hessian_storage,subexpr.forward_hessian_storage,subexpr.nd,subexpr.adj,subexpr.const_values,subexpr_reverse_values,subexpr_reverse_values[expridx])
+    end
+
+    for i in 1:length(x)
+        h[i] += epsilon(reverse_output_vector[i])
+    end
 
 end
 
@@ -393,21 +552,19 @@ function MathProgBase.eval_hesslag(
     qobj = d.m.obj::QuadExpr
     nldata = d.m.nlpdata::NLPData
 
-    d.requested_hessian || error("Hessian computations were not requested on the call to MathProgBase.initialize.")
+    d.want_hess || error("Hessian computations were not requested on the call to MathProgBase.initialize.")
 
     tic()
-    d.eval_h_nl(x, subarr(H, 1:d.nnz_hess_obj), nldata.nlobj)
-    for i in 1:d.nnz_hess_obj; H[i] *= obj_factor; end
-    #scale!(subarr(H, 1:length(hI)), obj_factor)
+
     # quadratic objective
-    idx = 1+d.nnz_hess_obj
+    nzcount = 1
     for k in 1:length(qobj.qvars1)
         if qobj.qvars1[k].col == qobj.qvars2[k].col
-            H[idx] = obj_factor*2*qobj.qcoeffs[k]
+            H[nzcount] = obj_factor*2*qobj.qcoeffs[k]
         else
-            H[idx] = obj_factor*qobj.qcoeffs[k]
+            H[nzcount] = obj_factor*qobj.qcoeffs[k]
         end
-        idx += 1
+        nzcount += 1
     end
     # quadratic constraints
     quadconstr = d.m.quadconstr::Vector{QuadConstraint}
@@ -416,30 +573,181 @@ function MathProgBase.eval_hesslag(
         l = lambda[length(d.m.linconstr)+i]
         for k in 1:length(c.terms.qvars1)
             if c.terms.qvars1[k].col == c.terms.qvars2[k].col
-                H[idx] = l*2*c.terms.qcoeffs[k]
+                H[nzcount] = l*2*c.terms.qcoeffs[k]
             else
-                H[idx] = l*c.terms.qcoeffs[k]
+                H[nzcount] = l*c.terms.qcoeffs[k]
             end
-            idx += 1
+            nzcount += 1
         end
     end
 
-    eval_hess!(subarr(H, idx:length(H)), nldata.nlconstrlist, x, subarr(lambda, (length(d.m.linconstr::Vector{LinearConstraint})+length(quadconstr)+1):length(lambda)))
+    for i in 1:length(x)
+        d.forward_input_vector[i] = Dual(x[i],0.0)
+    end
+    recovery_tmp_storage = reinterpret(Float64, d.reverse_output_vector)
+    nzcount -= 1
+
+    if d.has_nlobj
+        ex = d.objective
+        nzthis = hessian_slice(d, ex, x, H, obj_factor, nzcount, recovery_tmp_storage)
+        nzcount += nzthis
+    end
+
+    for i in 1:length(d.constraints)
+        ex = d.constraints[i]
+        nzthis = hessian_slice(d, ex, x, H, lambda[i+length(quadconstr)+length(d.m.linconstr)], nzcount, recovery_tmp_storage)
+        nzcount += nzthis
+    end
+
     d.eval_hesslag_timer += toq()
     return
 
 end
 
-MathProgBase.isobjlinear(d::JuMPNLPEvaluator) = !(isa(d.m.nlpdata.nlobj, ReverseDiffSparse.SymbolicOutput)) && (length(d.m.obj.qvars1) == 0)
+function hessian_slice(d, ex, x, H, scale, nzcount, recovery_tmp_storage)
+
+    nzthis = length(ex.hess_I)
+    if ex.linearity == LINEAR
+        @assert nzthis == 0
+        return 0
+    end
+    R = ex.seed_matrix
+    Coloring.prepare_seed_matrix!(R,ex.rinfo)
+    local_to_global_idx = ex.rinfo.local_indices
+    reverse_output_vector = d.reverse_output_vector
+    forward_input_vector = d.forward_input_vector
+    subexpr_forward_values = d.subexpression_hessian_forward_values
+    subexpr_reverse_values = d.subexpression_hessian_reverse_values
+
+    # compute hessian-vector products
+    num_products = size(R,2) # number of hessian-vector products
+    @assert size(R,1) == length(local_to_global_idx)
+    numVar = length(x)
+
+    for k in 1:num_products
+
+        for r in 1:length(local_to_global_idx)
+            # set up directional derivatives
+            @inbounds idx = local_to_global_idx[r]
+            @inbounds forward_input_vector[idx] = Dual(x[idx],R[r,k])
+            @inbounds reverse_output_vector[idx] = zero(Dual{Float64})
+        end
+
+        # do a forward pass
+        for expridx in ex.dependent_subexpressions
+            subexpr = d.subexpressions[expridx]
+            subexpr_forward_values[expridx] = forward_eval(subexpr.forward_hessian_storage, subexpr.nd, subexpr.adj, subexpr.const_values, d.parameter_values, forward_input_vector,subexpr_forward_values)
+        end
+        forward_eval(d.forward_storage_hess,ex.nd,ex.adj,ex.const_values,d.parameter_values, forward_input_vector,subexpr_forward_values)
+
+        # do a reverse pass
+        subexpr_reverse_values[ex.dependent_subexpressions] = zero(Dual{Float64})
+        reverse_eval(reverse_output_vector,d.reverse_storage_hess,d.forward_storage_hess,ex.nd,ex.adj,subexpr_reverse_values, Dual(1.0))
+        for i in length(ex.dependent_subexpressions):-1:1
+            expridx = ex.dependent_subexpressions[i]
+            subexpr = d.subexpressions[expridx]
+            reverse_eval(reverse_output_vector,subexpr.reverse_hessian_storage,subexpr.forward_hessian_storage,subexpr.nd,subexpr.adj,subexpr_reverse_values,subexpr_reverse_values[expridx])
+        end
+
+
+        # collect directional derivatives
+        for r in 1:length(local_to_global_idx)
+            idx = local_to_global_idx[r]
+            R[r,k] = epsilon(reverse_output_vector[idx])
+        end
+
+    end
+
+    #hessmat_eval!(seed, d.reverse_storage_hess, d.forward_storage_hess, ex.nd, ex.adj, ex.const_values, x, d.reverse_output_vector, d.forward_input_vector, ex.rinfo.local_indices)
+    # Output is in R, now recover
+
+    output_slice = sub(H, (nzcount+1):(nzcount+nzthis))
+    Coloring.recover_from_matmat!(output_slice, R, ex.rinfo, recovery_tmp_storage)
+    scale!(output_slice, scale)
+    return nzthis
+
+end
+
+MathProgBase.isobjlinear(d::JuMPNLPEvaluator) = !d.has_nlobj && (length(d.m.obj.qvars1) == 0)
 # interpret quadratic to include purely linear
-MathProgBase.isobjquadratic(d::JuMPNLPEvaluator) = !(isa(d.m.nlpdata.nlobj, ReverseDiffSparse.SymbolicOutput))
+MathProgBase.isobjquadratic(d::JuMPNLPEvaluator) = !d.has_nlobj
 
 MathProgBase.isconstrlinear(d::JuMPNLPEvaluator, i::Integer) = (i <= length(d.m.linconstr))
 
-MathProgBase.jac_structure(d::JuMPNLPEvaluator) = d.jac_I, d.jac_J
+function MathProgBase.jac_structure(d::JuMPNLPEvaluator)
+    # Jacobian structure
+    jac_I = Int[]
+    jac_J = Int[]
+    A = d.A
+    for col = 1:size(A,2)
+        for pos = nzrange(A,col)
+            push!(jac_I, A.rowval[pos])
+            push!(jac_J, col)
+        end
+    end
+    rowoffset = size(A,1)+1
+    for c::QuadConstraint in d.m.quadconstr
+        aff = c.terms.aff
+        for k in 1:length(aff.vars)
+            push!(jac_I, rowoffset)
+            push!(jac_J, aff.vars[k].col)
+        end
+        for k in 1:length(c.terms.qvars1)
+            push!(jac_I, rowoffset)
+            push!(jac_I, rowoffset)
+            push!(jac_J, c.terms.qvars1[k].col)
+            push!(jac_J, c.terms.qvars2[k].col)
+        end
+        rowoffset += 1
+    end
+    for ex in d.constraints
+        idx = ex.grad_sparsity
+        for i in 1:length(idx)
+            push!(jac_I, rowoffset)
+            push!(jac_J, idx[i])
+        end
+        rowoffset += 1
+    end
+    return jac_I, jac_J
+end
 function MathProgBase.hesslag_structure(d::JuMPNLPEvaluator)
-    d.requested_hessian || error("Hessian computations were not requested on the call to MathProgBase.initialize.")
-    return d.hess_I, d.hess_J
+    d.want_hess || error("Hessian computations were not requested on the call to MathProgBase.initialize.")
+    hess_I = Int[]
+    hess_J = Int[]
+
+    qobj::QuadExpr = d.m.obj
+    for k in 1:length(qobj.qvars1)
+        qidx1 = qobj.qvars1[k].col
+        qidx2 = qobj.qvars2[k].col
+        if qidx2 > qidx1
+            qidx1, qidx2 = qidx2, qidx1
+        end
+        push!(hess_I, qidx1)
+        push!(hess_J, qidx2)
+    end
+    # quadratic constraints
+    for c::QuadConstraint in d.m.quadconstr
+        for k in 1:length(c.terms.qvars1)
+            qidx1 = c.terms.qvars1[k].col
+            qidx2 = c.terms.qvars2[k].col
+            if qidx2 > qidx1
+                qidx1, qidx2 = qidx2, qidx1
+            end
+            push!(hess_I, qidx1)
+            push!(hess_J, qidx2)
+        end
+    end
+
+    if d.has_nlobj
+        append!(hess_I, d.objective.hess_I)
+        append!(hess_J, d.objective.hess_J)
+    end
+    for ex in d.constraints
+        append!(hess_I, ex.hess_I)
+        append!(hess_J, ex.hess_J)
+    end
+
+    return hess_I, hess_J
 end
 
 # currently don't merge duplicates (this isn't required by MPB standard)
@@ -463,9 +771,63 @@ function quadToExpr(q::QuadExpr,constant::Bool)
     return ex
 end
 
+# we splat in the subexpressions (for now)
+function tapeToExpr(k, nd::Vector{NodeData}, adj, const_values, parameter_values, subexpressions::Vector{Any})
+
+    children_arr = rowvals(adj)
+
+    nod = nd[k]
+    if nod.nodetype == VARIABLE
+        return Expr(:ref,:x,nod.index)
+    elseif nod.nodetype == VALUE
+        return const_values[nod.index]
+    elseif nod.nodetype == SUBEXPRESSION
+        return subexpressions[nod.index]
+    elseif nod.nodetype == PARAMETER
+        return parameter_values[nod.index]
+    elseif nod.nodetype == CALL
+        op = nod.index
+        opsymbol = operators[op]
+        children_idx = nzrange(adj,k)
+        ex = Expr(:call,opsymbol)
+        for cidx in children_idx
+            push!(ex.args, tapeToExpr(children_arr[cidx], nd, adj, const_values, parameter_values, subexpressions))
+        end
+        return ex
+    elseif nod.nodetype == CALLUNIVAR
+        op = nod.index
+        opsymbol = univariate_operators[op]
+        cidx = first(nzrange(adj,k))
+        return Expr(:call,opsymbol,tapeToExpr(children_arr[cidx], nd, adj, const_values, parameter_values, subexpressions))
+    elseif nod.nodetype == COMPARISON
+        op = nod.index
+        opsymbol = comparison_operators[op]
+        children_idx = nzrange(adj,k)
+        ex = Expr(:comparison)
+        for cidx in children_idx
+            push!(ex.args, tapeToExpr(children_arr[cidx], nd, adj, const_values, parameter_values, subexpressions))
+            push!(ex.args, opsymbol)
+        end
+        pop!(ex.args)
+        return ex
+    elseif nod.nodetype == LOGIC
+        op = nod.index
+        opsymbol = logic_operators[op]
+        children_idx = nzrange(adj,k)
+        lhs = tapeToExpr(children_arr[first(children_idx)], nd, adj, const_values, parameter_values, subexpressions)
+        rhs = tapeToExpr(children_arr[last(children_idx)], nd, adj, const_values, parameter_values, subexpressions)
+        return Expr(opsymbol, lhs, rhs)
+    end
+    error()
+
+
+end
+
+
 function MathProgBase.obj_expr(d::JuMPNLPEvaluator)
-    if isa(d.m.nlpdata.nlobj, ReverseDiffSparse.SymbolicOutput)
-        return ReverseDiffSparse.to_flat_expr(d.m.nlpdata.nlobj)
+    if d.has_nlobj
+        ex = d.objective
+        return tapeToExpr(1, ex.nd, ex.adj, ex.const_values, d.parameter_values, d.subexpressions_as_julia_expressions)
     else
         return quadToExpr(d.m.obj, true)
     end
@@ -488,15 +850,25 @@ function MathProgBase.constr_expr(d::JuMPNLPEvaluator,i::Integer)
         return Expr(:comparison, quadToExpr(qconstr.terms, true), qconstr.sense, 0)
     else
         i -= nlin + nquad
-        ex = ReverseDiffSparse.to_flat_expr(d.m.nlpdata.nlconstrlist, i)
+        ex = d.constraints[i]
+        julia_expr = tapeToExpr(1, ex.nd, ex.adj, ex.const_values, d.parameter_values, d.subexpressions_as_julia_expressions)
         constr = d.m.nlpdata.nlconstr[i]
         if sense(constr) == :range
-            return Expr(:comparison, constr.lb, :(<=), ex, :(<=), constr.ub)
+            return Expr(:comparison, constr.lb, :(<=), julia_expr, :(<=), constr.ub)
         else
-            return Expr(:comparison, ex, sense(constr), rhs(constr))
+            return Expr(:comparison, julia_expr, sense(constr), rhs(constr))
         end
     end
 end
+
+const ENABLE_NLP_RESOLVE = Array(Bool,1)
+function EnableNLPResolve()
+    ENABLE_NLP_RESOLVE[1] = true
+end
+function DisableNLPResolve()
+    ENABLE_NLP_RESOLVE[1] = false
+end
+export EnableNLPResolve, DisableNLPResolve
 
 
 function _buildInternalModel_nlp(m::Model, traits)
@@ -507,6 +879,36 @@ function _buildInternalModel_nlp(m::Model, traits)
     if m.internalModelLoaded
         @assert isa(nldata.evaluator, JuMPNLPEvaluator)
         d = nldata.evaluator
+        if length(nldata.nlparamvalues) == 0 && !ENABLE_NLP_RESOLVE[1]
+            # no parameters and haven't explicitly allowed resolves
+            # error to prevent potentially incorrect answers
+            msg = """
+            There was a recent **breaking** change in behavior
+            for solving sequences of nonlinear models.
+            Previously, users were allowed to modify the data in the model
+            by modifying the values stored in their own data arrays.
+            For example:
+
+            data = [1.0]
+            @addNLConstraint(m, data[1]*x <= 1)
+            solve(m)
+            data[1] = 2.0
+            solve(m) # coefficient is updated
+
+            However, this behavior **no longer works**. Instead,
+            nonlinear parameters defined with @defNLParam should be used.
+            See the latest JuMP documentation for more information.
+            It is possible that this model was exploiting the previous behavior,
+            and out of extreme caution we have temporarily introduced
+            this error message.
+            If you are sure that you are solving the correct model,
+            then call `EnableNLPResolve()` at the top of this file to disable
+            this error message.
+            To return to the last version of JuMP which supported the
+            old behavior, run `Pkg.pin("JuMP",v"0.11.1")`.
+            """
+            error(msg)
+        end
     else
         d = JuMPNLPEvaluator(m)
         nldata.evaluator = d
@@ -574,25 +976,40 @@ function solvenlp(m::Model, traits; suppress_warnings=false)
 
 end
 
+
 # getValue for nonlinear subexpressions
-function getValue(x::Union{ReverseDiffSparse.ParametricExpressionWithParams,ReverseDiffSparse.ParametricExpression{0}})
-    # messy check to extract model object
-    found = false
-    m = nothing
-    for item in ReverseDiffSparse.expression_data(x)
-        if isa(item, JuMPContainer)
-            found = true
-            m = getmeta(item, :model)
-            break
-        elseif isa(item, Array{Variable}) && !isempty(item)
-            found = true
-            m = first(item).m
-        elseif isa(item, Variable)
-            found = true
-            m = item.m
-            break
-        end
+function getValue(x::NonlinearExpression)
+    m = x.m
+    # recompute EVERYTHING here
+    # could be smarter and cache
+
+    nldata::NLPData = m.nlpdata
+    subexpr = Array(Vector{NodeData},0)
+    for nlexpr in nldata.nlexpr
+        push!(subexpr, nlexpr.nd)
     end
-    found || error("Unable to determine which model this expression belongs to. Are there any variables present?")
-    return ReverseDiffSparse.getvalue(x, m.colVal)
+
+    this_subexpr = nldata.nlexpr[x.index]
+
+    max_len = length(this_subexpr.nd)
+
+    subexpression_order, individual_order = order_subexpressions(Vector{NodeData}[this_subexpr.nd],subexpr)
+
+    subexpr_values = Array(Float64, length(subexpr))
+
+    for k in subexpression_order
+        max_len = max(max_len, length(nldata.nlexpr[k].nd))
+    end
+
+    forward_storage = Array(Float64, max_len)
+
+    for k in subexpression_order # compute value of dependent subexpressions
+        ex = nldata.nlexpr[k]
+        adj = adjmat(ex.nd)
+        subexpr_values[k] = forward_eval(forward_storage,ex.nd,adj,ex.const_values,nldata.nlparamvalues,m.colVal,subexpr_values)
+    end
+
+    adj = adjmat(this_subexpr.nd)
+
+    return forward_eval(forward_storage,this_subexpr.nd,adj,this_subexpr.const_values,nldata.nlparamvalues,m.colVal,subexpr_values)
 end

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -38,6 +38,7 @@ function newparameter(m::Model,value::Number)
 end
 
 getValue(p::NonlinearParameter) = p.m.nlpdata.nlparamvalues[p.index]::Float64
+
 setValue(p::NonlinearParameter,v::Number) = (p.m.nlpdata.nlparamvalues[p.index] = v)
 
 NLPData() = NLPData(nothing, NonlinearConstraint[], NonlinearExprData[], Float64[], Float64[], nothing)
@@ -975,7 +976,6 @@ function solvenlp(m::Model, traits; suppress_warnings=false)
     return stat::Symbol
 
 end
-
 
 # getValue for nonlinear subexpressions
 function getValue(x::NonlinearExpression)

--- a/src/nlpmacros.jl
+++ b/src/nlpmacros.jl
@@ -1,0 +1,171 @@
+#  Copyright 2015, Iain Dunning, Joey Huchette, Miles Lubin, and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+
+
+# generates code which converts an expression into a NodeData array (tape)
+# parent is the index of the parent expression
+# whichchild is the index of this node in the parent expression
+# values is the name of the list of constants which appear in the expression
+function parseNLExpr(x, tapevar, parent, whichchild, values)
+
+    if isexpr(x, :call)
+        if length(x.args) == 2 # univariate
+            code = :(let; end)
+            block = code.args[1]
+            @assert isexpr(block, :block)
+            operatorid = univariate_operator_to_id[x.args[1]]
+            push!(block.args, :(push!($tapevar, NodeData(CALLUNIVAR, $operatorid, $parent, $whichchild))))
+            parentvar = gensym()
+            push!(block.args, :($parentvar = length($tapevar)))
+            push!(block.args, parseNLExpr(x.args[2], tapevar, parentvar, 1, values))
+            return code
+        else
+            code = :(let; end)
+            block = code.args[1]
+            @assert isexpr(block, :block)
+            operatorid = operator_to_id[x.args[1]]
+            parentvar = gensym()
+            push!(block.args, :(push!($tapevar, NodeData(CALL, $operatorid, $parent, $whichchild))))
+            push!(block.args, :($parentvar = length($tapevar)))
+            for i in 1:length(x.args)-1
+                push!(block.args, parseNLExpr(x.args[i+1], tapevar, parentvar, i, values))
+            end
+            return code
+        end
+    end
+    if isexpr(x, :comparison)
+        code = :(let; end)
+        block = code.args[1]
+        op = x.args[2]
+        operatorid = comparison_operator_to_id[op]
+        for k in 2:2:length(x.args)-1
+            @assert x.args[k] == op # don't handle a <= b >= c
+        end
+        parentvar = gensym()
+        push!(block.args, :(push!($tapevar, NodeData(COMPARISON, $operatorid, $parent, $whichchild))))
+        push!(block.args, :($parentvar = length($tapevar)))
+        for k in 1:2:length(x.args)
+            push!(block.args, parseNLExpr(x.args[k], tapevar, parentvar, div(k+1,2), values))
+        end
+        return code
+    end
+    if isexpr(x, :&&) || isexpr(x, :||)
+        code = :(let; end)
+        block = code.args[1]
+        op = x.head
+        operatorid = logic_operator_to_id[op]
+        parentvar = gensym()
+        push!(block.args, :(push!($tapevar, NodeData(LOGIC, $operatorid, $parent, $whichchild))))
+        push!(block.args, :($parentvar = length($tapevar)))
+        push!(block.args, parseNLExpr(x.args[1], tapevar, parentvar, 1, values))
+        push!(block.args, parseNLExpr(x.args[2], tapevar, parentvar, 2, values))
+        return code
+    end
+    if isexpr(x, :curly)
+        header = x.args[1]
+        if length(x.args) < 3
+            error("Need at least two arguments for $header")
+        end
+        if issum(header)
+            operatorid = operator_to_id[:+]
+        elseif isprod(header)
+            operatorid = operator_to_id[:*]
+        else
+            error("Unrecognized expression $header{...}")
+        end
+        codeblock = :(let; end)
+        block = codeblock.args[1]
+        push!(block.args, :(push!($tapevar, NodeData(CALL, $operatorid, $parent, $whichchild))))
+        parentvar = gensym()
+        push!(block.args, :($parentvar = length($tapevar)))
+        childcountervar = gensym()
+        push!(block.args, :($childcountervar = 1))
+        
+        # we have a filter condition
+        if isexpr(x.args[2],:parameters)
+            cond = x.args[2]
+            if length(cond.args) != 1
+                error("No commas after semicolon allowed in $header{} expression, use && for multiple conditions")
+            end
+            # generate inner loop code first and then wrap in for loops
+            innercode = parseNLExpr(x.args[3], tapevar, parentvar, childcountervar, values)
+            code = quote
+                if $(esc(cond.args[1]))
+                    $childcountervar += 1
+                    $innercode
+                end
+            end
+            for level in length(x.args):-1:4
+                _idxvar, idxset = parseIdxSet(x.args[level]::Expr)
+                idxvar = esc(_idxvar)
+                code = :(let
+                    $(localvar(idxvar))
+                    for $idxvar in $(esc(idxset))
+                        $code
+                    end
+                end)
+            end
+            push!(block.args, code)
+        else # no condition
+            innercode = parseNLExpr(x.args[2], tapevar, parentvar, childcountervar, values)
+            code = quote
+                $childcountervar += 1
+                $innercode
+            end
+            for level in length(x.args):-1:3
+                _idxvar, idxset = parseIdxSet(x.args[level]::Expr)
+                idxvar = esc(_idxvar)
+                code = :(let
+                    $(localvar(idxvar))
+                    for $idxvar in $(esc(idxset))
+                        $code
+                    end
+                end)
+            end
+            push!(block.args, code)
+        end
+        return codeblock
+    end
+    # at the lowest level?
+    return :( parseNLExpr_runtime($(esc(x)), $tapevar, $parent, $whichchild, $values) )
+
+end
+
+function parseNLExpr_runtime(x::Number, tape, parent, whichchild, values)
+    push!(values, x)
+    push!(tape, NodeData(VALUE, length(values), parent, whichchild))
+    nothing
+end
+
+# Temporary hack for deprecation of @defNLExpr syntax
+const __last_model = Array(Model,1)
+
+function parseNLExpr_runtime(x::Variable, tape, parent, whichchild, values)
+    __last_model[1] = x.m
+    push!(tape, NodeData(VARIABLE, x.col, parent, whichchild))
+    nothing
+end
+
+function parseNLExpr_runtime(x::NonlinearExpression, tape, parent, whichchild, values)
+    push!(tape, NodeData(SUBEXPRESSION, x.index, parent, whichchild))
+    nothing
+end
+
+function parseNLExpr_runtime(x::NonlinearParameter, tape, parent, whichchild, values)
+    push!(tape, NodeData(PARAMETER, x.index, parent, whichchild))
+    nothing
+end
+
+macro processNLExpr(ex)
+    parsed = parseNLExpr(ex, :tape, -1, -1, :values)
+    quote
+        tape = NodeData[]
+        values = Float64[]
+        $parsed
+        NonlinearExprData(tape, values)
+    end
+end

--- a/src/parseExpr_staged.jl
+++ b/src/parseExpr_staged.jl
@@ -257,9 +257,10 @@ function addToExpression{C,V}(ex::GenericQuadExpr{C,V}, c::GenericAffExpr{C,V}, 
     ex
 end
 
-# Catch nonlinear expressions being used in addConstraint, etc.
-typealias _NLExpr ReverseDiffSparse.ParametricExpression
-_nlexprerr() = error("""Cannot use nonlinear expression in @addConstraint or @setObjective.
+# Catch nonlinear expressions and parameters being used in addConstraint, etc.
+
+typealias _NLExpr Union{NonlinearExpression,NonlinearParameter}
+_nlexprerr() = error("""Cannot use nonlinear expression or parameter in @addConstraint or @setObjective.
                         Use @addNLConstraint or @setNLObjective instead.""")
 # Following three definitions avoid ambiguity warnings
 addToExpression{C,V<:_NLExpr}(expr::GenericQuadExpr{C,V}, c::GenericAffExpr{C,V}, x::V) = _nlexprerr()
@@ -297,7 +298,7 @@ function parseCurly(x::Expr, aff::Symbol, lcoeffs, rcoeffs, newaff=gensym())
     if length(x.args) < 3
         error("Need at least two arguments for $header")
     end
-    if header ∈ [:sum, :∑, :Σ]
+    if issum(header)
         parseSum(x, aff, lcoeffs, rcoeffs, newaff)
     elseif header ∈ [:norm1, :norm2, :norminf, :norm∞]
         parseNorm(header, x, aff, lcoeffs, rcoeffs, newaff)

--- a/src/print.jl
+++ b/src/print.jl
@@ -118,7 +118,7 @@ end
 
 function Base.show(io::IO, m::Model)
     plural(n) = (n==1 ? "" : "s")
-    print(io, m.objSense == :Max ? "Maximization" : ((m.objSense == :Min && (!isempty(m.obj) || (m.nlpdata !== nothing && isa(m.nlpdata.nlobj, ReverseDiffSparse.SymbolicOutput)))) ? "Minimization" : "Feasibility"))
+    print(io, m.objSense == :Max ? "Maximization" : ((m.objSense == :Min && (!isempty(m.obj) || (m.nlpdata !== nothing && isa(m.nlpdata.nlobj, NonlinearExprData)))) ? "Minimization" : "Feasibility"))
     println(io, " problem with:")
     nlin = length(m.linconstr)
     println(io, " * $(nlin) linear constraint$(plural(nlin))")

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -224,10 +224,13 @@ facts("[macros] @addNLConstraints") do
     end)
 
     @fact length(m.nlpdata.nlconstr) --> 4
-    @fact "$(ReverseDiffSparse.base_expression(m.nlpdata.nlconstr[1].terms))" --> "y[i] - 0"
-    @fact "$(ReverseDiffSparse.base_expression(m.nlpdata.nlconstr[2].terms))" --> "y[i] - 0"
-    @fact "$(ReverseDiffSparse.base_expression(m.nlpdata.nlconstr[3].terms))" --> "y[i] - 0"
-    @fact "$(ReverseDiffSparse.base_expression(m.nlpdata.nlconstr[4].terms))" --> "(x + y[1] * y[2] * y[3]) - 0.5"
+    d = JuMPNLPEvaluator(m)
+    MathProgBase.initialize(d, [:ExprGraph])
+
+    @fact MathProgBase.constr_expr(d,1) --> :(x[2] - 0.0 == 0.0)
+    @fact MathProgBase.constr_expr(d,2) --> :(x[3] - 0.0 == 0.0)
+    @fact MathProgBase.constr_expr(d,3) --> :(x[4] - 0.0 == 0.0)
+    @fact MathProgBase.constr_expr(d,4) --> :((x[1] + x[2] * x[3] * x[4]) - 0.5 <= 0.0)
 
 end
 

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -341,6 +341,18 @@ context("With solver $(typeof(nlp_solver))") do
     @fact getValue(zexpr[1]) --> roughly(-(1/4)*log(1/4), 1e-4)
 end; end; end
 
+facts("[nonlinear] Test derivatives of x^4, x < 0") do
+for nlp_solver in convex_nlp_solvers
+context("With solver $(typeof(nlp_solver))") do
+    m = Model(solver=nlp_solver)
+    @defVar(m, x >= -1, start = -0.5)
+    @setNLObjective(m, Min, x^4)
+    status = solve(m)
+
+    @fact status --> :Optimal
+    @fact getValue(x) --> roughly(0.0, 1e-2)
+end; end; end
+
 facts("[nonlinear] Test nonlinear duals") do
 for nlp_solver in nlp_solvers
 applicable(MathProgBase.getconstrduals, MathProgBase.NonlinearModel(nlp_solver)) || continue

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -84,11 +84,13 @@ context("With solver $(typeof(nlp_solver))") do
     @defVar(m, y ≥ 0)
     @setObjective(m, Min, y)
     @addNLConstraint(m, y ≥ x^2)
+    EnableNLPResolve()
     for α in 1:4
         setValue(x, α)
         solve(m)
         @fact getValue(y) --> roughly(α^2, 1e-6)
     end
+    DisableNLPResolve()
 end; end; end
 
 facts("[nonlinear] Test QP solve through NL pathway") do
@@ -99,21 +101,23 @@ context("With solver $(typeof(nlp_solver))") do
     m = Model(solver=nlp_solver)
     @defVar(m, 0.5 <= x <=  2)
     @defVar(m, 0.0 <= y <= 30)
+    @defNLParam(m, param == 1.0)
     @setObjective(m, Min, (x+y)^2)
-    param = [1.0]
-    @addNLConstraint(m, x + y >= param[1])
+    @addNLConstraint(m, x + y >= param)
     status = solve(m)
 
     @fact status --> :Optimal
     @fact m.objVal --> roughly(1.0, 1e-6)
+    @defNLExpr(m, lhs, x+y)
     @fact getValue(x)+getValue(y) --> roughly(1.0, 1e-6)
+    @fact getValue(lhs) --> roughly(1.0, 1e-6)
 
-    # sneaky problem modification
-    param[1] = 10
+    setValue(param,10)
     @fact m.internalModelLoaded --> true
     status = solve(m)
     @fact m.objVal --> roughly(10.0^2, 1e-6)
     @fact getValue(x)+getValue(y) --> roughly(10.0, 1e-6)
+    @fact getValue(lhs) --> roughly(10.0, 1e-6)
 
 end; end; end
 
@@ -240,13 +244,17 @@ context("With solver $(typeof(nlp_solver))") do
     @defVar(m, -2 <= x <= 2); setValue(x, -1.8)
     @defVar(m, -2 <= y <= 2); setValue(y,  1.5)
     @setNLObjective(m, Max, y - x)
-    @defNLExpr(quadexpr, x + x^2 + x*y + y^2)
+    @defNLExpr(m, quadexpr, x + x^2 + x*y + y^2)
     @addNLConstraint(m, quadexpr <= 1)
 
     @fact solve(m) --> :Optimal
     @fact getObjectiveValue(m) --> roughly(1+4/sqrt(3), 1e-6)
     @fact getValue(x) + getValue(y) --> roughly(-1/3, 1e-3)
     @fact getValue(quadexpr) --> roughly(1, 1e-5)
+    @defNLExpr(quadexpr2, x + x^2 + x*y + y^2)
+    @fact getValue(quadexpr2) --> roughly(1, 1e-5)
+    quadexpr3 = @defNLExpr(x + x^2 + x*y + y^2)
+    @fact getValue(quadexpr3) --> roughly(1, 1e-5)
 end; end; end
 
 
@@ -284,7 +292,7 @@ context("With solver $(typeof(nlp_solver))") do
     m = Model(solver=nlp_solver)
     N = 3
     @defVar(m, x[1:N] >= 0, start = 1)
-    @defNLExpr(entropy[i=1:N], -x[i]*log(x[i]))
+    @defNLExpr(m, entropy[i=1:N], -x[i]*log(x[i]))
     @setNLObjective(m, Max, sum{entropy[i], i = 1:N})
     @addConstraint(m, sum(x) == 1)
 
@@ -299,7 +307,7 @@ context("With solver $(typeof(nlp_solver))") do
     idx = [1,2,3,4]
     @defVar(m, x[idx] >= 0, start = 1)
     @defVar(m, z[1:4], start = 0)
-    @defNLExpr(entropy[i=idx], -x[i]*log(x[i]))
+    @defNLExpr(m, entropy[i=idx], -x[i]*log(x[i]))
     @setNLObjective(m, Max, sum{z[i], i = 1:2} + sum{z[i]/2, i=3:4})
     @addNLConstraint(m, z_constr1[i=1], z[i] <= entropy[i])
     @addNLConstraint(m, z_constr1[i=2], z[i] <= entropy[i]) # duplicate expressions
@@ -309,7 +317,7 @@ context("With solver $(typeof(nlp_solver))") do
     @fact solve(m) --> :Optimal
     @fact norm([getValue(x[i]) for i in idx] - [1/4,1/4,1/4,1/4]) --> roughly(0.0, 1e-4)
     @fact getValue(entropy[1]) --> roughly(-(1/4)*log(1/4), 1e-4)
-    @defNLExpr(zexpr[i=1:4], z[i])
+    @defNLExpr(m, zexpr[i=1:4], z[i])
     @fact getValue(zexpr[1]) --> roughly(-(1/4)*log(1/4), 1e-4)
 end; end; end
 
@@ -471,7 +479,7 @@ facts("[nonlinear] Hessians through MPB") do
     @defVar(m, b, start = 2)
     @defVar(m, c, start = 3)
 
-    @defNLExpr(foo, a * b + c^2)
+    @defNLExpr(m, foo, a * b + c^2)
 
     @setNLObjective(m, Min, foo)
     d = JuMPNLPEvaluator(m)
@@ -501,4 +509,18 @@ facts("[nonlinear] Hess-vec through MPB") do
     MathProgBase.eval_hesslag_prod(d, h, m.colVal, v, 1.0, [2.0,3.0])
     correct = [3.0 1.0 0.0; 1.0 0.0 2.0; 0.0 2.0 2.0]*v
     @fact h --> roughly(correct)
+end
+
+if length(convex_nlp_solvers) > 0
+    facts("[nonlinear] Error on NLP resolve") do
+        m = Model(solver=convex_nlp_solvers[1])
+        @defVar(m, x, start = 1)
+        @setNLObjective(m, Min, x^2)
+        solve(m)
+        setValue(x, 2)
+        @fact_throws ErrorException solve(m)
+        EnableNLPResolve()
+        status = solve(m)
+        @fact status --> :Optimal
+    end
 end

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -159,6 +159,23 @@ context("With solver $(typeof(nlp_solver))") do
     @fact getValue(x) + getValue(y) --> roughly(-1/3, 1e-3)
 end; end; end
 
+facts("[nonlinear] Test resolve with parameter") do
+for nlp_solver in convex_nlp_solvers
+context("With solver $(typeof(nlp_solver))") do
+    m = Model(solver=nlp_solver)
+    @defVar(m, z)
+    @defNLParam(m, x == 1.0)
+    @setNLObjective(m, Min, (z-x)^2)
+    status = solve(m)
+    @fact status --> :Optimal
+    @fact getValue(z) --> roughly(1.0, 1e-3)
+
+    setValue(x, 5.0)
+    status = solve(m)
+    @fact status --> :Optimal
+    @fact getValue(z) --> roughly(5.0, 1e-3)
+end; end; end
+
 facts("[nonlinear] Test two-sided nonlinear constraints") do
 for nlp_solver in convex_nlp_solvers
 context("With solver $(typeof(nlp_solver))") do

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -13,6 +13,26 @@
 #############################################################################
 using JuMP, FactCheck
 
+facts("[nonlinear] Test getValue on arrays") do
+    m = Model()
+    @defVar(m, x, start = π/2)
+    @defNLExpr(m, f1, sin(x))
+    @defNLExpr(m, f2, sin(2x))
+    @defNLExpr(m, f3[i=1:2], sin(i*x))
+
+    @fact getValue(f1) --> roughly(1, 1e-5)
+    @fact getValue(f2) --> roughly(0, 1e-5)
+
+    @fact getValue([f1, f2]) --> getValue(f3)
+
+    v = [1.0, 2.0]
+    @defNLParam(m, vparam[i=1:2] == v[i])
+    @fact getValue(vparam) --> v
+    v[1] = 3.0
+    setValue(vparam, v)
+    @fact getValue(vparam) --> v
+end
+
 facts("[nonlinear] Test HS071 solves correctly") do
 for nlp_solver in nlp_solvers
 context("With solver $(typeof(nlp_solver))") do


### PR DESCRIPTION
The long awaited NLP rewrite is now a ~~WIP~~ RFC. ~~The net 200 line addition is pretty good considering that it replaces the 400+ lines of expression parsing in ReverseDiffSparse.~~

Still to do:
- [x] Nonlinear subexpressions
- [x] Replace ReverseDiffSparse with ReverseDiffSparse2 and tag
- [x] Re-implement hessian-vector products
- [x] Re-implement expression graph output
- [x] Parameters
- [x] Error message on NLP resolve
- [x] Switch to ``NaNMath``
- [x] Deprecation warning for change in ``@defNLExpr`` (*missing backtraces*)
- [x] Support for ``ifelse``
- [x] Support for ``abs``
- [x] ``getValue`` for expressions
- [x] Add unit test for pow domain error
- [x] Docs

CC @anriseth ~~(don't bother testing until subexpressions are working)~~

Closes #614 
Closes #571
Closes #585
Closes #414
Closes #567 
Closes #474 
Closes #304 