### PR TITLE
Fix off-by-one indexing error in rotated-second-order cone code (#659)

### DIFF
--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -859,7 +859,7 @@ function conicconstraintdata(m::Model)
         rng = (c+1):(c+n)
         append!(I, rng)
         append!(J, copy(cone))
-        append!(V, [-1.0; -1.0; ones(n-2)])
+        append!(V, [-1/sqrt(2); -1/sqrt(2); ones(n-2)])
         push!(con_cones, (:SOCRotated,rng))
         b[rng] = 0
         c += n

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -657,6 +657,7 @@ function conicconstraintdata(m::Model)
                 if q.qcoeffs[i] == -1
                     neg_diag_idx == off_diag_idx == 0 || error("Invalid rotated SOC constraint $qconstr")
                     off_diag_idx = i
+                    nz += 1
                 end
             end
         end
@@ -670,7 +671,7 @@ function conicconstraintdata(m::Model)
                 cone[r] = q.qvars1[i].col
             end
             push!(soc_cones, cone)
-        elseif n_pos_on_diag == nz-1 && off_diag_idx > 0
+        elseif n_pos_on_diag == nz-2 && off_diag_idx > 0
             cone[1] = q.qvars1[off_diag_idx].col
             cone[2] = q.qvars2[off_diag_idx].col
             r = 2

--- a/test/qcqpmodel.jl
+++ b/test/qcqpmodel.jl
@@ -371,7 +371,7 @@ context("With solver $(typeof(solver))") do
     @addConstraint(mod, v^2 <= u * x[1])
 
     @fact solve(mod) --> :Optimal
-    @fact getValue(x) --> roughly([1,0,0,0,0], 1e-4)
+    @fact getValue(x) --> roughly([1,0,0,0,0], 1e-2)
     @fact getValue(u) --> roughly(5, 1e-4)
     @fact getValue(v) --> roughly(sqrt(5), 1e-6)
 end; end; end

--- a/test/qcqpmodel.jl
+++ b/test/qcqpmodel.jl
@@ -357,7 +357,7 @@ context("With solver $(typeof(solver))") do
 end; end; end
 
 facts("[qcqpmodel] Rotated second-order cones") do
-for solver in soc_solvers
+for solver in rsoc_solvers
 context("With solver $(typeof(solver))") do
     mod = Model(solver=solver)
 
@@ -371,7 +371,7 @@ context("With solver $(typeof(solver))") do
     @addConstraint(mod, v^2 <= u * x[1])
 
     @fact solve(mod) --> :Optimal
-    @fact getValue(x) --> roughly([1,0,0,0,0], 1e-6)
-    @fact getValue(u) --> roughly(5, 1e-6)
+    @fact getValue(x) --> roughly([1,0,0,0,0], 1e-4)
+    @fact getValue(u) --> roughly(5, 1e-4)
     @fact getValue(v) --> roughly(sqrt(5), 1e-6)
 end; end; end

--- a/test/qcqpmodel.jl
+++ b/test/qcqpmodel.jl
@@ -355,3 +355,23 @@ context("With solver $(typeof(solver))") do
     @fact solve(modQ) --> :Optimal
     @fact getObjectiveValue(modQ) --> roughly(-0.75, 1e-6)
 end; end; end
+
+facts("[qcqpmodel] Rotated second-order cones") do
+for solver in soc_solvers
+context("With solver $(typeof(solver))") do
+    mod = Model(solver=solver)
+
+    @defVar(mod, x[1:5] >= 0)
+    @defVar(mod, 0 <= u <= 5)
+    @defVar(mod, v)
+
+    @setObjective(mod, Max, v)
+
+    @addConstraint(mod, norm(x[:]) <= 1)
+    @addConstraint(mod, v^2 <= u * x[1])
+
+    @fact solve(mod) --> :Optimal
+    @fact getValue(x) --> roughly([1,0,0,0,0], 1e-6)
+    @fact getValue(u) --> roughly(5, 1e-6)
+    @fact getValue(v) --> roughly(sqrt(5), 1e-6)
+end; end; end

--- a/test/solvers.jl
+++ b/test/solvers.jl
@@ -103,6 +103,8 @@ eco && push!(soc_solvers, ECOS.ECOSSolver(verbose=false))
 scs && push!(soc_solvers, SCS.SCSSolver(eps=1e-6,verbose=0))
 osl && push!(quad_mip_solvers, CoinOptServices.OsilBonminSolver(CoinOptServices.OSOption("sb","yes",category="ipopt")))
 osl && push!(quad_mip_solvers, CoinOptServices.OsilCouenneSolver())
+rsoc_solvers = Any[]
+mos && push!(rsoc_solvers, Mosek.MosekSolver(LOG=0))
 # Nonlinear solvers
 nlp_solvers = Any[]
 ipt && push!(nlp_solvers, Ipopt.IpoptSolver(print_level=0))


### PR DESCRIPTION
This needs rSOC support in MPB (https://github.com/JuliaOpt/MathProgBase.jl/blob/2f85f363cbb4ea24997706f9d2c04f77b7fb808e/src/SolverInterface/lpqp_to_conic.jl#L38) to actually work, I think.