### PR TITLE
Implement hessian chunks

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
 MathProgBase 0.4.0 0.5.0-
-ReverseDiffSparse 0.4 0.5
+ReverseDiffSparse 0.5 0.6
 ForwardDiff 0.1 0.2
 Calculus

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.4
 MathProgBase 0.4.0 0.5.0-
 ReverseDiffSparse 0.4 0.5
+ForwardDiff 0.1 0.2
 Calculus

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -18,6 +18,7 @@ import MathProgBase
 
 using Calculus
 using ReverseDiffSparse
+using ForwardDiff
 
 function __init__()
     ENABLE_NLP_RESOLVE[1] = false

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -348,6 +348,12 @@ function MathProgBase.initialize(d::JuMPNLPEvaluator, requested_features::Vector
         end
     end
 
+    # JIT warm-up
+    if :Grad in requested_features
+        MathProgBase.eval_grad_f(d, zeros(numVar), d.m.colVal)
+        MathProgBase.eval_g(d, zeros(MathProgBase.numconstr(d.m)), d.m.colVal)
+    end
+
     tprep = toq()
     #println("Prep time: $tprep")
 

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -396,11 +396,11 @@ function MathProgBase.eval_grad_f(d::JuMPNLPEvaluator, g, x)
         ex = d.objective
         subexpr_reverse_values = d.subexpression_reverse_values
         subexpr_reverse_values[ex.dependent_subexpressions] = 0.0
-        reverse_eval(g,ex.reverse_storage,ex.forward_storage,ex.partials_storage,ex.nd,ex.adj,subexpr_reverse_values,1.0)
+        reverse_eval(g,ex.reverse_storage,ex.partials_storage,ex.nd,ex.adj,subexpr_reverse_values,1.0)
         for i in length(ex.dependent_subexpressions):-1:1
             k = ex.dependent_subexpressions[i]
             subexpr = d.subexpressions[k]
-            reverse_eval(g,subexpr.reverse_storage,subexpr.forward_storage,subexpr.partials_storage,subexpr.nd,subexpr.adj,subexpr_reverse_values,subexpr_reverse_values[k])
+            reverse_eval(g,subexpr.reverse_storage,subexpr.partials_storage,subexpr.nd,subexpr.adj,subexpr_reverse_values,subexpr_reverse_values[k])
 
         end
     else
@@ -488,11 +488,11 @@ function MathProgBase.eval_jac_g(d::JuMPNLPEvaluator, J, x)
         grad_storage[nzidx] = 0.0
         subexpr_reverse_values[ex.dependent_subexpressions] = 0.0
 
-        reverse_eval(grad_storage,ex.reverse_storage,ex.forward_storage,ex.partials_storage,ex.nd,ex.adj,subexpr_reverse_values,1.0)
+        reverse_eval(grad_storage,ex.reverse_storage,ex.partials_storage,ex.nd,ex.adj,subexpr_reverse_values,1.0)
         for i in length(ex.dependent_subexpressions):-1:1
             k = ex.dependent_subexpressions[i]
             subexpr = d.subexpressions[k]
-            reverse_eval(grad_storage,subexpr.reverse_storage,subexpr.forward_storage,subexpr.partials_storage,subexpr.nd,subexpr.adj,subexpr_reverse_values,subexpr_reverse_values[k])
+            reverse_eval(grad_storage,subexpr.reverse_storage,subexpr.partials_storage,subexpr.nd,subexpr.adj,subexpr_reverse_values,subexpr_reverse_values[k])
         end
 
         for k in 1:length(nzidx)
@@ -570,7 +570,7 @@ function MathProgBase.eval_hesslag_prod(
     if d.has_nlobj
         ex = d.objective
         forward_eval(d.forward_storage_hess,d.partials_storage_hess,ex.nd,ex.adj,ex.const_values,d.parameter_values,d.forward_input_vector,subexpr_forward_values)
-        reverse_eval(reverse_output_vector,d.reverse_storage_hess,d.forward_storage_hess,d.partials_storage_hess,ex.nd,ex.adj,subexpr_reverse_values, Dual(σ)) # note scaled by σ
+        reverse_eval(reverse_output_vector,d.reverse_storage_hess,d.partials_storage_hess,ex.nd,ex.adj,subexpr_reverse_values, Dual(σ)) # note scaled by σ
     end
 
 
@@ -578,14 +578,14 @@ function MathProgBase.eval_hesslag_prod(
         ex = d.constraints[i]
         l = μ[row]
         forward_eval(d.forward_storage_hess,d.partials_storage_hess,ex.nd,ex.adj,ex.const_values,d.parameter_values,d.forward_input_vector,subexpr_forward_values)
-        reverse_eval(reverse_output_vector,d.reverse_storage_hess,d.forward_storage_hess,d.partials_storage_hess,ex.nd,ex.adj,subexpr_reverse_values, Dual(l))
+        reverse_eval(reverse_output_vector,d.reverse_storage_hess,d.partials_storage_hess,ex.nd,ex.adj,subexpr_reverse_values, Dual(l))
         row += 1
     end
 
     for i in length(ex.dependent_subexpressions):-1:1
         expridx = ex.dependent_subexpressions[i]
         subexpr = d.subexpressions[expridx]
-        reverse_eval(reverse_output_vector,subexpr.reverse_hessian_storage,subexpr.forward_hessian_storage,subexpr.partials_hessian_storage,subexpr.nd,subexpr.adj,subexpr.const_values,subexpr_reverse_values,subexpr_reverse_values[expridx])
+        reverse_eval(reverse_output_vector,subexpr.reverse_hessian_storage,subexpr.partials_hessian_storage,subexpr.nd,subexpr.adj,subexpr.const_values,subexpr_reverse_values,subexpr_reverse_values[expridx])
     end
 
     for i in 1:length(x)
@@ -694,11 +694,11 @@ function hessian_slice(d, ex, x, H, scale, nzcount, recovery_tmp_storage)
 
         # do a reverse pass
         subexpr_reverse_values[ex.dependent_subexpressions] = zero(Dual{Float64})
-        reverse_eval(reverse_output_vector,d.reverse_storage_hess,d.forward_storage_hess,d.partials_storage_hess,ex.nd,ex.adj,subexpr_reverse_values, Dual(1.0))
+        reverse_eval(reverse_output_vector,d.reverse_storage_hess,d.partials_storage_hess,ex.nd,ex.adj,subexpr_reverse_values, Dual(1.0))
         for i in length(ex.dependent_subexpressions):-1:1
             expridx = ex.dependent_subexpressions[i]
             subexpr = d.subexpressions[expridx]
-            reverse_eval(reverse_output_vector,subexpr.reverse_hessian_storage,subexpr.forward_hessian_storage,subexpr.partials_hessian_storage,subexpr.nd,subexpr.adj,subexpr_reverse_values,subexpr_reverse_values[expridx])
+            reverse_eval(reverse_output_vector,subexpr.reverse_hessian_storage,subexpr.partials_hessian_storage,subexpr.nd,subexpr.adj,subexpr_reverse_values,subexpr_reverse_values[expridx])
         end
 
 

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -559,6 +559,17 @@ facts("[nonlinear] Hessians through MPB") do
     # Convert from lower triangular
     hess_sparse = hess_raw + hess_raw' - sparse(diagm(diag(hess_raw)))
     @fact hess_sparse --> roughly([0.0 1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 2.0])
+
+    # make sure we don't get NaNs in this case
+    @setNLObjective(m, Min, a * b + 3*c^2)
+    d = JuMPNLPEvaluator(m)
+    MathProgBase.initialize(d, [:Hess])
+    setValue(c, -1.0)
+    V = zeros(length(I))
+    MathProgBase.eval_hesslag(d, V, m.colVal, 1.0, Float64[])
+    hess_raw = sparse(I,J,V)
+    hess_sparse = hess_raw + hess_raw' - sparse(diagm(diag(hess_raw)))
+    @fact hess_sparse --> roughly([0.0 1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 6.0])
 end
 
 facts("[nonlinear] Hess-vec through MPB") do

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -9,9 +9,11 @@
 #############################################################################
 # test/nonlinear.jl
 # Test general nonlinear
-# Must be run as part of runtests.jl, as it needs a list of solvers.
 #############################################################################
 using JuMP, FactCheck
+
+# If solvers not loaded, load them (i.e running just these tests)
+!isdefined(:nlp_solvers) && include("solvers.jl")
 
 facts("[nonlinear] Test getValue on arrays") do
     m = Model()


### PR DESCRIPTION
For opf.jl 6620, no iteration limit:

With this PR, Julia 0.4 (``simplify_nonlinear_expressions=true``):
```
Total CPU secs in IPOPT (w/o function evaluations)   =      2.364
Total CPU secs in NLP function evaluations           =      5.312
```

JuMP master, Julia 0.4 (``simplify_nonlinear_expressions=true``):
```
Total CPU secs in IPOPT (w/o function evaluations)   =      2.324
Total CPU secs in NLP function evaluations           =      7.652
```

JuMP master, Julia 0.4 (``simplify_nonlinear_expressions=false``):
```
Total CPU secs in IPOPT (w/o function evaluations)   =      3.692
Total CPU secs in NLP function evaluations           =     33.268
```

With Julia 0.3, JuMP 0.11
```
Total CPU secs in IPOPT (w/o function evaluations)   =      2.400
Total CPU secs in NLP function evaluations           =      7.648
```

For clnlbeam 50000, 20 iteration max
With this PR, Julia 0.4:
```
Total CPU secs in IPOPT (w/o function evaluations)   =     30.740
Total CPU secs in NLP function evaluations           =      3.344
```

JuMP master, Julia 0.4:
```
Total CPU secs in IPOPT (w/o function evaluations)   =     33.500
Total CPU secs in NLP function evaluations           =      3.316
```

JuMP 0.11, Julia 0.3:
```
Total CPU secs in IPOPT (w/o function evaluations)   =     36.952
Total CPU secs in NLP function evaluations           =      2.764
```
clnlbeam has a diagonal hessian, so there's no speedup expected from chunking.

CC @jrevels, to load the tuples from the seed matrix R, I just write to the raw memory instead of going through staged functions

Overall a decent speedup in opf.jl over the pre-rewrite code. There's a bit of a regression in clnlbeam but it's a very easy problem (IPOPT time is greater than derivative evaluation time).