### PR TITLE
RFC: support for user-defined nonlinear functions

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -39,6 +39,7 @@ export
     addConstraint, addSOS1, addSOS2, solve,
     getInternalModel, buildInternalModel, setSolveHook, setPrintHook,
     getConstraintBounds,
+    registerNLFunction,
     # Variable
     setName, getName, setLower, setUpper, getLower, getUpper,
     getValue, setValue, getDual, setCategory, getCategory,

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -5,8 +5,6 @@
 
 include("nlpmacros.jl")
 
-import DualNumbers: Dual, epsilon
-
 type NonlinearExprData
     nd::Vector{NodeData}
     const_values::Vector{Float64}


### PR DESCRIPTION
``autodiff=true`` makes a beautiful comeback: 

```julia
mysquare(x) = x^2
myf(x,y) = (x-1)^2+(y-2)^2

registerNLFunction(:myf, 2, myf, autodiff=true)
registerNLFunction(:mysquare, 1, mysquare, autodiff=true)

m = Model()

@defVar(m, x[1:2] >= 0.5)
@setNLObjective(m, Min, myf(x[1],mysquare(x[2])))

status = solve(m)
@show getValue(x)
```

Only major caveat at the moment is that we don't yet support hessians for multivariate functions. Mostly looking to get feedback on the syntax. Interesting usage examples would also be appreciated for the documentation.

CC @jrevels @davidanthoff @anriseth @tkelman @dpo