### PR TITLE
take in model object as first argument to @defExpr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ JuMP release notes
 Unversioned
 -----------
 
+  * ``@defExpr`` and ``@defNLExpr`` now take the model as the first argument. The previous one-argument version of ``@defExpr`` is deprecated; all expressions should be named. E.g., replace ``@defExpr(2x+y)`` with ``@defExpr(jump_model, my_expr, 2x+y)``.
   * Replaced iteration over ``AffExpr`` with ``Number``-like scalar iteration; previous iteration behavior is now available via ``linearterms(::AffExpr)``.
   * Stopping the solver via ``throw(CallbackAbort())`` from a callback no longer triggers an exception. Instead, ``solve()`` returns ``UserLimit`` status.
 

--- a/doc/nlp.rst
+++ b/doc/nlp.rst
@@ -80,11 +80,6 @@ the syntax for linear and quadratic expressions. We note some important points b
     @defNLExpr(m, myexpr[i=1:n], sin(x[i]))
     @addNLConstraint(m, myconstr[i=1:n], myexpr[i] <= 0.5)
 
-.. note::
-    The syntax of ``@defNLExpr`` differs from ``@defExpr``. The former requires the
-    model object as the first argument, while the latter does not take the JuMP
-    model as an argument.
-
 .. _nonlinearprobmod:
 
 Nonlinear Parameters
@@ -111,7 +106,7 @@ Nonlinear parameters can be used *within nonlinear expressions* only::
     @defVar(m, z)
     @setObjective(m, Max, x*z)       # error: x is a nonlinear parameter
     @setNLObjective(m, Max, x*z)     # ok
-    @defExpr(my_expr, x*z^2)         # error: x is a nonlinear parameter
+    @defExpr(m, my_expr, x*z^2)      # error: x is a nonlinear parameter
     @defNLExpr(m, my_nl_expr, x*z^2) # ok
 
 Nonlinear parameters are useful when solving nonlinear models in a sequence::

--- a/doc/refexpr.rst
+++ b/doc/refexpr.rst
@@ -50,15 +50,15 @@ Methods
       sum_to_one[i=1:3], z[i] + y == 1
     end)
 
-* ``@defExpr(ref, expr)`` - efficiently builds a linear or quadratic expression but does not add to model immediately. Instead, returns the expression which can then be inserted in other constraints. For example::
+* ``@defExpr(m::Model, ref, expr)`` - efficiently builds a linear, quadratic, or second-order cone expression but does not add to model immediately. Instead, returns the expression which can then be inserted in other constraints. For example::
 
-    @defExpr(shared, sum{i*x[i], i=1:5})
+    @defExpr(m, shared, sum{i*x[i], i=1:5})
     @addConstraint(m, shared + y >= 5)
     @addConstraint(m, shared + z <= 10)
 
 The ``ref`` accepts index sets in the same way as ``@defVar``, and those indices can be used in the construction of the expressions::
 
-    @defExpr(expr[i=1:3], i*sum{x[j], j=1:3})
+    @defExpr(m, expr[i=1:3], i*sum{x[j], j=1:3})
 * ``@addSDPConstraint(m::Model, expr)`` - adds a semidefinite constraint to the model ``m``. The expression ``expr`` must be a square, two-dimensional array.
 * ``addSOS1(m::Model, coll::Vector{AffExpr})`` - adds special ordered set constraint
   of type 1 (SOS1). Specify the set as a vector of weighted variables, e.g. ``coll = [3x, y, 2z]``.

--- a/test/fuzzer.jl
+++ b/test/fuzzer.jl
@@ -104,6 +104,6 @@ println("[fuzzer] Check macros for expression construction")
 
 for _ in 1:100
     raff = random_aff_expr(N, vars)
-    ex = @eval @defExpr($raff)
+    ex = @eval @JuMP.Expression($raff)
     @fact test_approx_equal_exprs(ex, eval(raff)) --> true
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -69,13 +69,13 @@ facts("[macros] Check @addConstraint basics") do
     @fact conToStr(m.linconstr[end]) --> "-1 $leq x $leq 1"
     @fact_throws @addConstraint(m, x <= t <= y)
 
-    @defExpr(aff, 3x - y - 3.3(w + 2z) + 5)
+    @defExpr(m, aff, 3x - y - 3.3(w + 2z) + 5)
     @fact affToStr(aff) --> "3 x - y - 3.3 w - 6.6 z + 5"
 
     @addConstraint(m, 3 + 5*7 <= 0)
     @fact conToStr(m.linconstr[end]) --> "0 $leq -38"
 
-    @defExpr(qaff, (w+3)*(2x+1)+10)
+    @defExpr(m, qaff, (w+3)*(2x+1)+10)
     @fact quadToStr(qaff) --> "2 w*x + 6 x + w + 13"
 end
 
@@ -325,14 +325,20 @@ end
 facts("[macros] @defExpr") do
     model = Model()
     @defVar(model, x[1:3,1:3])
-    @defExpr(expr, sum{i*x[i,j] + j, i=1:3,j in 1:3})
+    @defExpr(model, expr, sum{i*x[i,j] + j, i=1:3,j in 1:3})
     @fact affToStr(expr) --> "x[1,1] + x[1,2] + x[1,3] + 2 x[2,1] + 2 x[2,2] + 2 x[2,3] + 3 x[3,1] + 3 x[3,2] + 3 x[3,3] + 18"
 
-    @fact_throws @defExpr(blah[i=1:3], x[i,1]^2)
+    @fact_throws @defExpr(model, blah[i=1:3], x[i,1]^2)
 
-    @defExpr(y[i=1:2], sum{x[i,1]; i == 1})
+    @defExpr(model, y[i=1:2], sum{x[i,1]; i == 1})
     @fact affToStr(y[1]) --> "x[1,1]"
     @fact affToStr(y[2]) --> "0"
+
+    # deprecated versions
+    @defExpr(expr2, sum{i*x[i,j] + j, i=1:3,j in 1:3})
+    @fact affToStr(expr2) --> "x[1,1] + x[1,2] + x[1,3] + 2 x[2,1] + 2 x[2,2] + 2 x[2,3] + 3 x[3,1] + 3 x[3,2] + 3 x[3,3] + 18"
+    expr2 = @defExpr(sum{i*x[i,j] + j, i=1:3,j in 1:3})
+    @fact affToStr(expr2) --> "x[1,1] + x[1,2] + x[1,3] + 2 x[2,1] + 2 x[2,2] + 2 x[2,3] + 3 x[3,1] + 3 x[3,2] + 3 x[3,3] + 18"
 end
 
 facts("[macros] Conditions in constraint indexing") do

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -527,16 +527,16 @@ context("Vectorized arithmetic") do
                         2x[2] + x[1] + x[3]
                         x[2] + 2x[3]]) --> true
     @fact TestHelper.vec_eq(A*x, B*x) --> true
-    @fact TestHelper.vec_eq(A*x, @defExpr(B*x)) --> true
-    @fact TestHelper.vec_eq(@defExpr(A*x), @defExpr(B*x)) --> true
+    @fact TestHelper.vec_eq(A*x, @JuMP.Expression(B*x)) --> true
+    @fact TestHelper.vec_eq(@JuMP.Expression(A*x), @JuMP.Expression(B*x)) --> true
     @fact TestHelper.vec_eq(x'*A, [2x[1]+x[2]; 2x[2]+x[1]+x[3]; x[2]+2x[3]]') --> true
     @fact TestHelper.vec_eq(x'*A, x'*B) --> true
-    @fact TestHelper.vec_eq(x'*A, @defExpr(x'*B)) --> true
-    @fact TestHelper.vec_eq(@defExpr(x'*A), @defExpr(x'*B)) --> true
+    @fact TestHelper.vec_eq(x'*A, @JuMP.Expression(x'*B)) --> true
+    @fact TestHelper.vec_eq(@JuMP.Expression(x'*A), @JuMP.Expression(x'*B)) --> true
     @fact TestHelper.vec_eq(x'*A*x, [2x[1]*x[1] + 2x[1]*x[2] + 2x[2]*x[2] + 2x[2]*x[3] + 2x[3]*x[3]]) --> true
     @fact TestHelper.vec_eq(x'A*x, x'*B*x) --> true
-    @fact TestHelper.vec_eq(x'*A*x, @defExpr(x'*B*x)) --> true
-    @fact TestHelper.vec_eq(@defExpr(x'*A*x), @defExpr(x'*B*x)) --> true
+    @fact TestHelper.vec_eq(x'*A*x, @JuMP.Expression(x'*B*x)) --> true
+    @fact TestHelper.vec_eq(@JuMP.Expression(x'*A*x), @JuMP.Expression(x'*B*x)) --> true
 
     y = A*x
     @fact TestHelper.vec_eq(-x, [-x[1], -x[2], -x[3]]) --> true
@@ -583,7 +583,7 @@ context("Vectorized arithmetic") do
                              x[1] + 3x[2] +  x[3]
                                      x[2] + 3x[3]]) --> true
 
-    @fact TestHelper.vec_eq(@defExpr(A*x/2), A*x/2) --> true
+    @fact TestHelper.vec_eq(@JuMP.Expression(A*x/2), A*x/2) --> true
 end
 
 context("Dot-ops") do
@@ -668,10 +668,10 @@ context("Vectorized comparisons") do
     @fact TestHelper.vec_eq((x'A)' + 2A*x, (x'A)' + 2B*x) --> true
     @fact TestHelper.vec_eq((x'A)' + 2A*x, (x'B)' + 2A*x) --> true
     @fact TestHelper.vec_eq((x'A)' + 2A*x, (x'B)' + 2B*x) --> true
-    @fact TestHelper.vec_eq((x'A)' + 2A*x, @defExpr((x'A)' + 2A*x)) --> true
-    @fact TestHelper.vec_eq((x'A)' + 2A*x, @defExpr((x'B)' + 2A*x)) --> true
-    @fact TestHelper.vec_eq((x'A)' + 2A*x, @defExpr((x'A)' + 2B*x)) --> true
-    @fact TestHelper.vec_eq((x'A)' + 2A*x, @defExpr((x'B)' + 2B*x)) --> true
+    @fact TestHelper.vec_eq((x'A)' + 2A*x, @JuMP.Expression((x'A)' + 2A*x)) --> true
+    @fact TestHelper.vec_eq((x'A)' + 2A*x, @JuMP.Expression((x'B)' + 2A*x)) --> true
+    @fact TestHelper.vec_eq((x'A)' + 2A*x, @JuMP.Expression((x'A)' + 2B*x)) --> true
+    @fact TestHelper.vec_eq((x'A)' + 2A*x, @JuMP.Expression((x'B)' + 2B*x)) --> true
 
     @addConstraint(m, -1 .<= (x'A)' + 2A*x .<= 1)
     terms = map(v->v.terms, m.linconstr[4:6])


### PR DESCRIPTION
All calls to ``@defExpr`` will now take three arguments. I added a version of ``@JuMP.Expression`` to replace the one-argument ``@defExpr``. Not sure I want to export this at this point.