### PR TITLE
debugging work for travis failure on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ julia:
 notifications:
     email: false
 sudo: false
+dist: trusty
 addons:
     apt_packages:
         - gfortran

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,6 +1,7 @@
 FactCheck
 Cbc
 Clp
+GLPKMathProgInterface
 Ipopt
 ECOS
 SCS

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,7 +1,6 @@
 FactCheck
 Cbc
 Clp
-GLPKMathProgInterface
 Ipopt
 ECOS
 SCS


### PR DESCRIPTION
Travis has been failing on Julia nightly for a while, would be nice if it didn't.

Current failure mode is:
```
[callback] Test user cuts
  > With solver GLPKMathProgInterface.GLPKInterfaceMIP.GLPKSolverMIP
No output has been received in the last 10 minutes, this potentially indicates a stalled build or something wrong with the build itself.
```

CC @tkelman 