### PR TITLE
better error message for vectors in nonlinear expressions

### DIFF
--- a/src/nlpmacros.jl
+++ b/src/nlpmacros.jl
@@ -158,6 +158,10 @@ function parseNLExpr_runtime(m::Model, x::NonlinearParameter, tape, parent, valu
     nothing
 end
 
+function parseNLExpr_runtime(m::Model, x::Vector, tape, parent, values)
+    error("Unexpected vector $x in nonlinear expression. Nonlinear expressions may contain only scalar expressions.")
+end
+
 macro processNLExpr(m, ex)
     parsed = parseNLExpr(m, ex, :tape, -1, :values)
     quote

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -234,6 +234,13 @@ facts("[macros] @addNLConstraints") do
 
 end
 
+facts("[macros] Vectors in nonlinear expressions") do
+    m = Model()
+    @defVar(m, x[1:3])
+    @fact_throws ErrorException @setNLObjective(m, Min, x)
+    @fact_throws ErrorException @setNLObjective(m, Min, [1,2,3])
+end
+
 facts("[macros] @setObjective with quadratic") do
     m = Model()
     @defVar(m, x[1:5])


### PR DESCRIPTION
```
julia> @defVar(m, x[1:2])

julia> @setNLObjective(m, Min, x)
ERROR: Unexpected vector x[i] free ∀ i ∈ {1,2} in nonlinear expression. Only scalar expressions are allowed.
 in error at error.jl:21
 in parseNLExpr_runtime at /home/mlubin/.julia/v0.4/JuMP/src/nlpmacros.jl:162

julia> @setNLObjective(m, Min, [1,2,3])
ERROR: Unexpected vector [1,2,3] in nonlinear expression. Only scalar expressions are allowed.
 in error at ./error.jl:21
 in parseNLExpr_runtime at /home/mlubin/.julia/v0.4/JuMP/src/nlpmacros.jl:162
```

Printing of variables is a bit weird but still better than a missing method error.