### PR TITLE
Add support for setting base name in defVar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 JuMP release notes
 ==================
 
+Unversioned
+-----------
+
+  * Change name printed for variable using the ``basename`` keyword argument to ``@defVar``.
+
 Version 0.12.2 (March 9, 2016)
 ------------------------------
 

--- a/doc/refvariable.rst
+++ b/doc/refvariable.rst
@@ -95,7 +95,14 @@ This form of constructing variables is not considered idiomatic JuMP code.
     The reference to the first set of variables has been lost, although they will remain
     in the model.
 
-Finally, the constructor ``Variable(m::Model,idx::Int)`` may be used to create a variable object corresponding to an *existing* variable in the model (the constructor does not add a new variable to the model). The variable indices correspond to those of the internal MathProgBase model. The inverse of this operation is ``getLinearIndex(x::Variable)``, which returns the flattened out (linear) index of a variable as JuMP provides it to a solver. We guarantee that ``Variable(m,getLinearIndex(x))`` returns ``x`` itself. These methods are only useful if you intend to interact with solver properties which are not directly exposed through JuMP.
+The constructor ``Variable(m::Model,idx::Int)`` may be used to create a variable object corresponding to an *existing* variable in the model (the constructor does not add a new variable to the model). The variable indices correspond to those of the internal MathProgBase model. The inverse of this operation is ``getLinearIndex(x::Variable)``, which returns the flattened out (linear) index of a variable as JuMP provides it to a solver. We guarantee that ``Variable(m,getLinearIndex(x))`` returns ``x`` itself. These methods are only useful if you intend to interact with solver properties which are not directly exposed through JuMP.
+
+If you would like to change the name used when printing a variable or group of variables, you may use the ``basename`` keyword argument:
+
+    i = 3
+    @defVar(m, x[1:3], basename="myvariable-$i")
+
+Printing ``x[2]`` will display ``myvariable-3[2]``.
 
 Semidefinite and symmetric variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/print.jl
+++ b/test/print.jl
@@ -582,3 +582,24 @@ facts("[print] User-created Array{Variable}") do
  x  y
  y  x""")
 end
+
+facts("[print] basename keyword argument") do
+    m = Model()
+    @defVar(m, x, basename="foo")
+    @defVar(m, y[1:3], basename=:bar)
+    num = 123
+    @defVar(m, z[[:red,:blue]], basename="color_$num")
+    @defVar(m, v[1:2,1:2], SDP, basename=string("i","$num",num))
+    @defVar(m, w[1:3,1:3], Symmetric, basename="symm")
+
+    io_test(REPLMode,   x, "foo")
+    io_test(IJuliaMode, x, "foo")
+    io_test(REPLMode,   y[2], "bar[2]")
+    io_test(IJuliaMode, y[2], "bar_{2}")
+    io_test(REPLMode,   z[:red], "color_123[red]")
+    io_test(IJuliaMode, z[:red], "color_123_{red}")
+    io_test(REPLMode,   v[2,1], "i123123[1,2]")
+    io_test(IJuliaMode, v[2,1], "i123123_{1,2}")
+    io_test(REPLMode,   w[1,3], "symm[1,3]")
+    io_test(IJuliaMode, w[1,3], "symm_{1,3}")
+end


### PR DESCRIPTION
Could be useful for extensions:
```jl
julia> i = 3;

julia> @defVar(m, x[1:3], basename="foo-$i")
3-element Array{JuMP.Variable,1}:
 foo-3[1]
 foo-3[2]
 foo-3[3]

julia> x[2]
foo-3[2]
```
cc @juan-pablo-vielma