### PR TITLE
support for _locally_ valid lazy constraints and user cuts

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -162,6 +162,7 @@ const sensemap = Dict(:(<=) => '<', :(==) => '=', :(>=) => '>')
 
 ## Lazy constraints
 export addLazyConstraint, @addLazyConstraint
+export addLazyConstraintLocal, @addLazyConstraintLocal
 
 macro addLazyConstraint(cbdata, x)
     cbdata = esc(cbdata)
@@ -184,6 +185,29 @@ macro addLazyConstraint(cbdata, x)
     end
 end
 
+macro addLazyConstraintLocal(cbdata, x)
+    cbdata = esc(cbdata)
+    if VERSION < v"0.5.0-dev+3231"
+        x = comparison_to_call(x)
+    end
+    if isexpr(x, :call) && length(x.args) == 3 # simple comparison
+        lhs = :($(x.args[2]) - $(x.args[3])) # move everything to the lhs
+        newaff, parsecode = parseExprToplevel(lhs, :aff)
+        sense, vectorized = _canonicalize_sense(x.args[1])
+        vectorized && error("Cannot add vectorized constraint in lazy callback")
+        quote
+            aff = zero(AffExpr)
+            $parsecode
+            constr = constructconstraint!($newaff, $(quot(sense)))
+            addLazyConstraintLocal($cbdata, constr)
+        end
+    else
+        error("Syntax error in addLazyConstraint, expected one-sided comparison.")
+    end
+end
+
+
+
 function addLazyConstraint(cbdata::MathProgBase.MathProgCallbackData, constr::LinearConstraint)
     if length(constr.terms.vars) == 0
         MathProgBase.cbaddlazy!(cbdata, Cint[], Float64[], sensemap[sense(constr)], rhs(constr))
@@ -195,10 +219,24 @@ function addLazyConstraint(cbdata::MathProgBase.MathProgCallbackData, constr::Li
     MathProgBase.cbaddlazy!(cbdata, indices, coeffs, sensemap[sense(constr)], rhs(constr))
 end
 
+function addLazyConstraintLocal(cbdata::MathProgBase.MathProgCallbackData, constr::LinearConstraint)
+    if length(constr.terms.vars) == 0
+        MathProgBase.cbaddlazylocal!(cbdata, Cint[], Float64[], sensemap[sense(constr)], rhs(constr))
+        return
+    end
+    assert_isfinite(constr.terms)
+    m::Model = constr.terms.vars[1].m
+    indices, coeffs = merge_duplicates(Cint, constr.terms, m.indexedVector, m)
+    MathProgBase.cbaddlazylocal!(cbdata, indices, coeffs, sensemap[sense(constr)], rhs(constr))
+end
+
+
 addLazyConstraint(cbdata::MathProgBase.MathProgCallbackData,constr::QuadConstraint) = error("Quadratic lazy constraints are not supported.")
+addLazyConstraintLocal(cbdata::MathProgBase.MathProgCallbackData,constr::QuadConstraint) = error("Quadratic lazy constraints are not supported.")
 
 ## User cuts
 export addUserCut, @addUserCut
+export addUserCutLocal, @addUserCutLocal
 
 macro addUserCut(cbdata, x)
     cbdata = esc(cbdata)
@@ -221,6 +259,31 @@ macro addUserCut(cbdata, x)
     end
 end
 
+macro addUserCutLocal(cbdata, x)
+    cbdata = esc(cbdata)
+    if VERSION < v"0.5.0-dev+3231"
+        x = comparison_to_call(x)
+    end
+    if isexpr(x, :call) && length(x.args) == 3 # simple comparison
+        lhs = :($(x.args[2]) - $(x.args[3])) # move everything to the lhs
+        newaff, parsecode = parseExprToplevel(lhs, :aff)
+        sense, vectorized = _canonicalize_sense(x.args[1])
+        vectorized && error("Cannot add vectorized constraint in cut callback")
+        quote
+            aff = zero(AffExpr)
+            $parsecode
+            constr = constructconstraint!($newaff, $(quot(sense)))
+            addUserCutLocal($cbdata, constr)
+        end
+    else
+        error("Syntax error in addUserCut, expected one-sided comparison.")
+    end
+end
+
+
+
+
+
 function addUserCut(cbdata::MathProgBase.MathProgCallbackData, constr::LinearConstraint)
     if length(constr.terms.vars) == 0
         MathProgBase.cbaddcut!(cbdata, Cint[], Float64[], sensemap[sense(constr)], rhs(constr))
@@ -231,6 +294,18 @@ function addUserCut(cbdata::MathProgBase.MathProgCallbackData, constr::LinearCon
     indices, coeffs = merge_duplicates(Cint, constr.terms, m.indexedVector, m)
     MathProgBase.cbaddcut!(cbdata, indices, coeffs, sensemap[sense(constr)], rhs(constr))
 end
+
+function addUserCutLocal(cbdata::MathProgBase.MathProgCallbackData, constr::LinearConstraint)
+    if length(constr.terms.vars) == 0
+        MathProgBase.cbaddcutlocal!(cbdata, Cint[], Float64[], sensemap[sense(constr)], rhs(constr))
+        return
+    end
+    assert_isfinite(constr.terms)
+    m::Model = constr.terms.vars[1].m
+    indices, coeffs = merge_duplicates(Cint, constr.terms, m.indexedVector, m)
+    MathProgBase.cbaddcutlocal!(cbdata, indices, coeffs, sensemap[sense(constr)], rhs(constr))
+end
+
 
 ## User heuristic
 export addSolution, setSolutionValue!


### PR DESCRIPTION
First, thanks a lot for all these wonderful and truely useful tools!

Having re-coded some algorithm using _local_ lazy constraints* with Julia/JuMP, here is a suggestion of very small additions handling them in JuMP/MathProgBase/CPLEX (joint additions, cf the forks at https://github.com/madanim). As far as I know, this feature is only avalaible in CPLEX and XPress MP.

It simply consists in duplicating the current mechanics for lazy constraints and user cuts, and using the CPLEX naming convention, appending 'local' or 'Local' where applicable: e.g. '@addLazyConstraintLocal' instead of '@addLazyConstraint', etc (in the CPLEX C Api the variant is 'cutcallbackaddlocal' instead of 'cutcallbackadd').

Do you think this way of proceeding is consistent with the packages design, or would it be preferable to handle the feature by passing a parameter value (as in AIMMS) throughout the 'call chain' instead - e.g. for maintenance purposes ? And displaying an error message when used with solvers not supporting the feature ?

Thanks a lot!,

Kind Regards,

Mehdi


*http://www.ibm.com/support/knowledgecenter/SS9UKU_12.6.0/com.ibm.cplex.zos.help/refcallablelibrary/mipapi/cutcallbackaddlocal.html