### PR TITLE
new link for 0.12 versioned docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Our documentation includes an installation guide, quick-start guide, and referen
 [juliaopt-notebooks]: https://github.com/JuliaOpt/juliaopt-notebooks
 
 **Latest Release**: 0.12.2 (via ``Pkg.add``)
-  * [Documentation](https://jump.readthedocs.org/en/latest)
+  * [Documentation](https://juliaopt.github.io/JuMP.jl/0.12/)
   * [Examples](https://github.com/JuliaOpt/JuMP.jl/tree/release-0.12/examples)
   * Testing status:
     * TravisCI: [![Build Status](https://travis-ci.org/JuliaOpt/JuMP.jl.svg?branch=release-0.12)](https://travis-ci.org/JuliaOpt/JuMP.jl)


### PR DESCRIPTION
The docs are working now at juliaopt.github.io but not through juliaopt.org, not sure why. This link is safe to publish and it's better directing people to the correct docs ASAP. Already got an email asking why ``getobjbound`` isn't working.

Ref #439