### PR TITLE
RFC: big macro rename

### DIFF
--- a/examples/basic.jl
+++ b/examples/basic.jl
@@ -20,11 +20,11 @@ using JuMP
 
 m = Model()
 
-@defVar(m, 0 <= x <= 2)
-@defVar(m, 0 <= y <= 30)
+@variable(m, 0 <= x <= 2)
+@variable(m, 0 <= y <= 30)
 
-@setObjective(m, Max, 5x + 3y)
-@addConstraint(m, 1x + 5y <= 3.0)
+@objective(m, Max, 5x + 3y)
+@constraint(m, 1x + 5y <= 3.0)
 
 print(m)
 

--- a/examples/bnatt350.jl
+++ b/examples/bnatt350.jl
@@ -47,7 +47,7 @@ u = MathProgBase.getconstrUB(m_internal)
 vtypes = MathProgBase.getvartype(m_internal)
 
 # populate JuMP model with data from internal model
-@defVar(mod, x[1:n])
+@variable(mod, x[1:n])
 for i in 1:n
     setLower(x[i], xlb[i])
     setUpper(x[i], xub[i])
@@ -55,9 +55,9 @@ for i in 1:n
 end
 At = A' # transpose to get useful row-wise sparse representation
 for i in 1:At.n
-    @addConstraint( mod, l[i] <= sum{ At.nzval[idx]*x[At.rowval[idx]], idx = At.colptr[i]:(At.colptr[i+1]-1) } <= u[i] )
+    @constraint( mod, l[i] <= sum{ At.nzval[idx]*x[At.rowval[idx]], idx = At.colptr[i]:(At.colptr[i+1]-1) } <= u[i] )
 end
-@setObjective(mod, Min, sum{ c[i]*x[i], i=1:n })
+@objective(mod, Min, sum{ c[i]*x[i], i=1:n })
 
 function myheuristic(cb)
     fp = open("data/bnatt350.sol", "r")

--- a/examples/cannery.jl
+++ b/examples/cannery.jl
@@ -33,18 +33,18 @@ function solveCannery(plants, markets, capacity, demand, distance, freight)
   nummarkets = length(markets)
   cannery = Model()
 
-  @defVar(cannery, ship[1:numplants, 1:nummarkets] >= 0)
+  @variable(cannery, ship[1:numplants, 1:nummarkets] >= 0)
 
   # Ship no more than plant capacity
-  @addConstraint(cannery, xyconstr[i=1:numplants],
+  @constraint(cannery, xyconstr[i=1:numplants],
                    sum{ship[i,j], j=1:nummarkets}<=capacity[i])
 
   # Ship at least market demand
-  @addConstraint(cannery, xyconstr[j=1:nummarkets],
+  @constraint(cannery, xyconstr[j=1:nummarkets],
                sum{ship[i,j], i=1:numplants}>=demand[j])
 
   # Minimize transporatation cost
-  @setObjective(cannery, Min,
+  @objective(cannery, Min,
               sum{distance[i,j]* freight * ship[i,j], i=1:numplants, j=1:nummarkets})
 
   solution = solve(cannery)

--- a/examples/cluster.jl
+++ b/examples/cluster.jl
@@ -34,20 +34,20 @@ end
 mod = Model()
 
 # Z >= 0, PSD
-@defVar(mod, Z[1:m,1:m], SDP)
-@addConstraint(mod, Z .>= 0)
+@variable(mod, Z[1:m,1:m], SDP)
+@constraint(mod, Z .>= 0)
 
 # min Tr(W(I-Z))
-@setObjective(mod, Min, trace(W * (eye(m,m) - Z)))
+@objective(mod, Min, trace(W * (eye(m,m) - Z)))
 
 # Z e = e
-@addConstraint(mod, Z*ones(m) .== ones(m))
+@constraint(mod, Z*ones(m) .== ones(m))
 #for i = 1:m
 #    addConstraint(mod, sum([ Z[i,j] for j = 1:m]) == 1)
 #end
 
 # Tr(Z) = k
-@addConstraint(mod, trace(Z) == k)
+@constraint(mod, trace(Z) == k)
 
 solve(mod)
 

--- a/examples/corr_sdp.jl
+++ b/examples/corr_sdp.jl
@@ -20,27 +20,27 @@ using JuMP
 
 m = Model()
 
-@defVar(m, X[1:3,1:3], SDP)
+@variable(m, X[1:3,1:3], SDP)
 
 # Diagonal is 1s
-@addConstraint(m, X[1,1] == 1)
-@addConstraint(m, X[2,2] == 1)
-@addConstraint(m, X[3,3] == 1)
+@constraint(m, X[1,1] == 1)
+@constraint(m, X[2,2] == 1)
+@constraint(m, X[3,3] == 1)
 
 # Bounds on the known correlations
-@addConstraint(m, X[1,2] >= -0.2)
-@addConstraint(m, X[1,2] <= -0.1)
-@addConstraint(m, X[2,3] >=  0.4)
-@addConstraint(m, X[2,3] <=  0.5)
+@constraint(m, X[1,2] >= -0.2)
+@constraint(m, X[1,2] <= -0.1)
+@constraint(m, X[2,3] >=  0.4)
+@constraint(m, X[2,3] <=  0.5)
 
 # Find upper bound
-@setObjective(m, Max, X[1,3])
+@objective(m, Max, X[1,3])
 solve(m)
 println("Maximum value is ", getValue(X)[1,3])
 @assert +0.8719 <= getValue(X)[1,3] <= +0.8720
 
 # Find lower bound
-@setObjective(m, Min, X[1,3])
+@objective(m, Min, X[1,3])
 solve(m)
 println("Minimum value is ", getValue(X)[1,3])
 @assert -0.9779 >= getValue(X)[1,3] >= -0.9799

--- a/examples/diet.jl
+++ b/examples/diet.jl
@@ -55,16 +55,16 @@ function SolveDiet()
     m = Model()
 
     # Variables for nutrition info
-    @defVar(m, minNutrition[i] <= nutrition[i=1:numCategories] <= maxNutrition[i])
+    @variable(m, minNutrition[i] <= nutrition[i=1:numCategories] <= maxNutrition[i])
     # Variables for which foods to buy
-    @defVar(m, buy[i=1:numFoods] >= 0)
+    @variable(m, buy[i=1:numFoods] >= 0)
 
     # Objective - minimize cost
-    @setObjective(m, Min, dot(cost, buy))
+    @objective(m, Min, dot(cost, buy))
 
     # Nutrition constraints
     for j = 1:numCategories
-        @addConstraint(m, sum{nutritionValues[i,j]*buy[i], i=1:numFoods} == nutrition[j])
+        @constraint(m, sum{nutritionValues[i,j]*buy[i], i=1:numFoods} == nutrition[j])
     end
 
     # Solve
@@ -73,7 +73,7 @@ function SolveDiet()
     PrintSolution(status, foods, buy)
 
     # Limit dairy
-    @addConstraint(m, buy[8] + buy[9] <= 6)
+    @constraint(m, buy[8] + buy[9] <= 6)
     println("Solving dairy-limited problem...")
     status = solve(m)
     PrintSolution(status, foods, buy)

--- a/examples/iis.jl
+++ b/examples/iis.jl
@@ -65,10 +65,10 @@ End of IIS
 function iis_example()
     m = Model(solver=GurobiSolver())
 
-    @defVar(m, 0 <= x <= 1)
-    @defVar(m, 0 <= y <= 1)
+    @variable(m, 0 <= x <= 1)
+    @variable(m, 0 <= y <= 1)
 
-    @addConstraint(m, x+y >= 3)
+    @constraint(m, x+y >= 3)
 
     status = solve(m)
     @assert status == :Infeasible

--- a/examples/knapsack.jl
+++ b/examples/knapsack.jl
@@ -20,17 +20,17 @@ using JuMP
 # Maximization problem
 m = Model()
 
-@defVar(m, x[1:5], Bin)
+@variable(m, x[1:5], Bin)
 
 profit = [ 5, 3, 2, 7, 4 ]
 weight = [ 2, 8, 4, 2, 5 ]
 capacity = 10
 
 # Objective: maximize profit
-@setObjective(m, Max, dot(profit, x))
+@objective(m, Max, dot(profit, x))
 
 # Constraint: can carry all
-@addConstraint(m, dot(weight, x) <= capacity)
+@constraint(m, dot(weight, x) <= capacity)
 
 # Solve problem using MIP solver
 status = solve(m)

--- a/examples/maxcut_sdp.jl
+++ b/examples/maxcut_sdp.jl
@@ -24,9 +24,9 @@ function solve_maxcut_sdp(n, W)
 
     # Solve the SDP relaxation
     m = Model()
-    @defVar(m, X[1:n,1:n], SDP)
-    @setObjective(m, Max, dot(L,X))
-    @addConstraint(m, diag(X) .== 1)
+    @variable(m, X[1:n,1:n], SDP)
+    @objective(m, Max, dot(L,X))
+    @constraint(m, diag(X) .== 1)
     solve(m)
 
     # Cholesky the result

--- a/examples/mindistortion.jl
+++ b/examples/mindistortion.jl
@@ -42,18 +42,18 @@ D = [0.0 1.0 1.0 1.0
      1.0 2.0 0.0 2.0
      1.0 2.0 2.0 0.0]
 
-@defVar(m, cSq >= 1.0)
+@variable(m, cSq >= 1.0)
 
-@defVar(m, Q[1:4,1:4], SDP)
+@variable(m, Q[1:4,1:4], SDP)
 
 for i in 1:4
     for j in (i+1):4
-        @addConstraint(m, D[i,j]^2 <= Q[i,i] + Q[j,j] - 2Q[i,j])
-        @addConstraint(m, Q[i,i] + Q[j,j] - 2Q[i,j] <= D[i,j]^2*cSq )
+        @constraint(m, D[i,j]^2 <= Q[i,i] + Q[j,j] - 2Q[i,j])
+        @constraint(m, Q[i,i] + Q[j,j] - 2Q[i,j] <= D[i,j]^2*cSq )
     end
 end
 
-@setObjective(m, Min, cSq)
+@objective(m, Min, cSq)
 
 solve(m)
 

--- a/examples/minellipse.jl
+++ b/examples/minellipse.jl
@@ -40,10 +40,10 @@ W = [1.0 0.0
      0.0 1.0];
 
 mod = Model()
-@defVar(mod, X[1:2,1:2], SDP)
-@setObjective(mod, Min, trace(W*X))
+@variable(mod, X[1:2,1:2], SDP)
+@objective(mod, Min, trace(W*X))
 for i = 1:m
-    @addSDPConstraint(mod, X >= As[i])
+    @SDconstraint(mod, X >= As[i])
 end
 solve(mod)
 

--- a/examples/mle.jl
+++ b/examples/mle.jl
@@ -13,10 +13,10 @@ data = randn(n)
 
 m = Model()
 
-@defVar(m, μ, start = 0.0)
-@defVar(m, σ >= 0.0, start = 1.0)
+@variable(m, μ, start = 0.0)
+@variable(m, σ >= 0.0, start = 1.0)
 
-@setNLObjective(m, Max, (n/2)*log(1/(2π*σ^2))-sum{(data[i]-μ)^2, i=1:n}/(2σ^2))
+@NLobjective(m, Max, (n/2)*log(1/(2π*σ^2))-sum{(data[i]-μ)^2, i=1:n}/(2σ^2))
 
 solve(m)
 
@@ -27,7 +27,7 @@ println("var(data) = ", var(data))
 println("MLE objective: ", getObjectiveValue(m))
 
 # constrained MLE?
-@addNLConstraint(m, μ == σ^2)
+@NLconstraint(m, μ == σ^2)
 
 solve(m)
 println("\nWith constraint μ == σ^2:")

--- a/examples/multi.jl
+++ b/examples/multi.jl
@@ -77,28 +77,28 @@ multi = Model()
 
 #  VARIABLES
 
-@defVar(multi, Trans[1:numorig, 1:numdest, 1:numprod] >= 0)
+@variable(multi, Trans[1:numorig, 1:numdest, 1:numprod] >= 0)
 
 #  OBJECTIVE
 
 length(cost)
 
-@setObjective(multi, Max,
+@objective(multi, Max,
               sum{sum{sum{cost[j, i, p] * Trans[i,j, p],
                         i=1:numorig}, j=1:numdest}, p=1:numprod})
 
 #  CONSTRAINTS
 
 # Supply constraint
-@addConstraint(multi, xyconstr[i=1:numorig, p=1:numprod],
+@constraint(multi, xyconstr[i=1:numorig, p=1:numprod],
                sum{Trans[i,j,p], j=1:numdest} == supply[p,i])
 
 # Demand constraint
-@addConstraint(multi, xyconstr[j=1:numdest, p=1:numprod],
+@constraint(multi, xyconstr[j=1:numdest, p=1:numprod],
                sum{Trans[i,j,p], i=1:numorig} == demand[p,j])
 
 # Total shipment constraint
-@addConstraint(multi, xyconstr[i=1:numorig, j=1:numdest],
+@constraint(multi, xyconstr[i=1:numorig, j=1:numdest],
                sum{Trans[i,j,p], p=1:numprod} - limit[i][j] <= 0)
 limit[2][3]
 status = solve(multi)

--- a/examples/noswot.jl
+++ b/examples/noswot.jl
@@ -41,7 +41,7 @@ u = MathProgBase.getconstrUB(m_internal)
 vtypes = MathProgBase.getvartype(m_internal)
 
 # populate JuMP model with data from internal model
-@defVar(mod, x[1:n])
+@variable(mod, x[1:n])
 for i in 1:n
     setLower(x[i], xlb[i])
     setUpper(x[i], xub[i])
@@ -49,21 +49,21 @@ for i in 1:n
 end
 At = A' # transpose to get useful row-wise sparse representation
 for i in 1:At.n
-    @addConstraint( mod, l[i] <= sum{ At.nzval[idx]*x[At.rowval[idx]], idx = At.colptr[i]:(At.colptr[i+1]-1) } <= u[i] )
+    @constraint( mod, l[i] <= sum{ At.nzval[idx]*x[At.rowval[idx]], idx = At.colptr[i]:(At.colptr[i+1]-1) } <= u[i] )
 end
-@setObjective(mod, Min, sum{ c[i]*x[i], i=1:n })
+@objective(mod, Min, sum{ c[i]*x[i], i=1:n })
 
 function mycutgenerator(cb) # valid cuts
     x_val = getValue(x)
     println("in callback")
-    @addUserCut(cb, x[62]-x[63] <= 0)
-    @addUserCut(cb, x[63]-x[64] <= 0)
-    @addUserCut(cb, x[64]-x[65] <= 0)
-    @addUserCut(cb, 2.08x[52] + 2.98x[62] +   3.47x[72] + 2.24x[82] +  2.08x[92] + 0.25x[51] + 0.25x[61] + 0.25x[71] + 0.25x[81] + 0.25x[91] <= 20.25)
-    @addUserCut(cb, 2.08x[54] + 2.98x[64] +   3.47x[74] + 2.24x[84] +  2.08x[94] + 0.25x[53] + 0.25x[63] + 0.25x[73] + 0.25x[83] + 0.25x[93] <= 20.25)
-    @addUserCut(cb, 2.08x[56] + 2.98x[66] + 3.4722x[76] + 2.24x[86] +  2.08x[96] + 0.25x[55] + 0.25x[65] + 0.25x[75] + 0.25x[85] + 0.25x[95] <= 20.25)
-    @addUserCut(cb, 2.08x[58] + 2.98x[68] +   3.47x[78] + 2.24x[88] +  2.08x[98] + 0.25x[57] + 0.25x[67] + 0.25x[77] + 0.25x[87] + 0.25x[97] <= 20.25)
-    @addUserCut(cb, 2.08x[60] + 2.98x[70] +   3.47x[80] + 2.24x[90] + 2.08x[100] + 0.25x[59] + 0.25x[69] + 0.25x[79] + 0.25x[89] + 0.25x[99] <= 16.25)
+    @usercut(cb, x[62]-x[63] <= 0)
+    @usercut(cb, x[63]-x[64] <= 0)
+    @usercut(cb, x[64]-x[65] <= 0)
+    @usercut(cb, 2.08x[52] + 2.98x[62] +   3.47x[72] + 2.24x[82] +  2.08x[92] + 0.25x[51] + 0.25x[61] + 0.25x[71] + 0.25x[81] + 0.25x[91] <= 20.25)
+    @usercut(cb, 2.08x[54] + 2.98x[64] +   3.47x[74] + 2.24x[84] +  2.08x[94] + 0.25x[53] + 0.25x[63] + 0.25x[73] + 0.25x[83] + 0.25x[93] <= 20.25)
+    @usercut(cb, 2.08x[56] + 2.98x[66] + 3.4722x[76] + 2.24x[86] +  2.08x[96] + 0.25x[55] + 0.25x[65] + 0.25x[75] + 0.25x[85] + 0.25x[95] <= 20.25)
+    @usercut(cb, 2.08x[58] + 2.98x[68] +   3.47x[78] + 2.24x[88] +  2.08x[98] + 0.25x[57] + 0.25x[67] + 0.25x[77] + 0.25x[87] + 0.25x[97] <= 20.25)
+    @usercut(cb, 2.08x[60] + 2.98x[70] +   3.47x[80] + 2.24x[90] + 2.08x[100] + 0.25x[59] + 0.25x[69] + 0.25x[79] + 0.25x[89] + 0.25x[99] <= 16.25)
 end  # End of callback function
 
 # # Tell JuMP/CPLEX to use our callback function

--- a/examples/optcontrol.jl
+++ b/examples/optcontrol.jl
@@ -27,19 +27,19 @@ let
 
     m = Model()
 
-    @defVar(m, -1 <= t[1:(ni+1)] <= 1)
-    @defVar(m, -0.05 <= x[1:(ni+1)] <= 0.05)
-    @defVar(m, u[1:(ni+1)])
+    @variable(m, -1 <= t[1:(ni+1)] <= 1)
+    @variable(m, -0.05 <= x[1:(ni+1)] <= 0.05)
+    @variable(m, u[1:(ni+1)])
 
-    @setNLObjective(m, Min, sum{ 0.5*h*(u[i+1]^2 + u[i]^2) + 0.5*alpha*h*(cos(t[i+1]) + cos(t[i])), i = 1:ni})
+    @NLobjective(m, Min, sum{ 0.5*h*(u[i+1]^2 + u[i]^2) + 0.5*alpha*h*(cos(t[i+1]) + cos(t[i])), i = 1:ni})
 
     # cons1
     for i in 1:ni
-        @addNLConstraint(m, x[i+1] - x[i] - (0.5h)*(sin(t[i+1])+sin(t[i])) == 0)
+        @NLconstraint(m, x[i+1] - x[i] - (0.5h)*(sin(t[i+1])+sin(t[i])) == 0)
     end
     # cons2
     for i in 1:ni
-        @addConstraint(m, t[i+1] - t[i] - (0.5h)*u[i+1] - (0.5h)*u[i] == 0)
+        @constraint(m, t[i+1] - t[i] - (0.5h)*u[i+1] - (0.5h)*u[i] == 0)
     end
 
     solve(m)

--- a/examples/qcp.jl
+++ b/examples/qcp.jl
@@ -19,17 +19,17 @@ using JuMP
 m = Model()
 
 # Need nonnegativity for (rotated) second-order cone
-@defVar(m, x)
-@defVar(m, y >= 0)
-@defVar(m, z >= 0)
+@variable(m, x)
+@variable(m, y >= 0)
+@variable(m, z >= 0)
 
 # Maximize x
-@setObjective(m, Max, x)
+@objective(m, Max, x)
 
 # Subject to 1 linear and 2 nonlinear constraints
-@addConstraint(m, x + y + z == 1)
-@addConstraint(m, x*x + y*y - z*z <= 0)
-@addConstraint(m, x*x - y*z <= 0)
+@constraint(m, x + y + z == 1)
+@constraint(m, x*x + y*y - z*z <= 0)
+@constraint(m, x*x - y*z <= 0)
 
 # Print the model to check correctness
 print(m)

--- a/examples/robust_uncertainty.jl
+++ b/examples/robust_uncertainty.jl
@@ -28,19 +28,19 @@ M = rand(d,d)
 
 m = Model()
 
-@defVar(m, Σ[1:d,1:d], SDP)
-@defVar(m, u[1:d])
-@defVar(m, μ[1:d])
+@variable(m, Σ[1:d,1:d], SDP)
+@variable(m, u[1:d])
+@variable(m, μ[1:d])
 
-@addConstraint(m, norm(μ-μhat) <= Γ1(𝛿/2,N))
-@addConstraint(m, vecnorm(Σ-Σhat) <= Γ2(𝛿/2,N))
+@constraint(m, norm(μ-μhat) <= Γ1(𝛿/2,N))
+@constraint(m, vecnorm(Σ-Σhat) <= Γ2(𝛿/2,N))
 
 A = [(1-ɛ)/ɛ (u-μ)';
      (u-μ)     Σ   ]
-@addSDPConstraint(m, A >= 0)
+@SDconstraint(m, A >= 0)
 
 c = randn(d)
-@setObjective(m, Max, dot(c,u))
+@objective(m, Max, dot(c,u))
 
 solve(m)
 

--- a/examples/rosenbrock.jl
+++ b/examples/rosenbrock.jl
@@ -9,10 +9,10 @@ let
 
     m = Model()
 
-    @defVar(m, x)
-    @defVar(m, y)
+    @variable(m, x)
+    @variable(m, y)
 
-    @setNLObjective(m, Min, (1-x)^2 + 100(y-x^2)^2)
+    @NLobjective(m, Min, (1-x)^2 + 100(y-x^2)^2)
 
     solve(m)
 

--- a/examples/simpleheur.jl
+++ b/examples/simpleheur.jl
@@ -21,14 +21,14 @@ using Gurobi
 m = Model(solver=GurobiSolver(Cuts=0, Presolve=0, Heuristics=0.0))
 
 # Define our variables to be inside a box, and integer
-@defVar(m, 0 <= x <= 2, Int)
-@defVar(m, 0 <= y <= 2, Int)
+@variable(m, 0 <= x <= 2, Int)
+@variable(m, 0 <= y <= 2, Int)
 
 # Optimal solution is trying to go towards top-right corner (2.0, 2.0)
-@setObjective(m, Max, x + 2y)
+@objective(m, Max, x + 2y)
 
 # We have one constraint that cuts off the top right corner
-@addConstraint(m, y + x <= 3.5)
+@constraint(m, y + x <= 3.5)
 
 # Optimal solution of relaxed problem will be (1.5, 2.0)
 

--- a/examples/simplelazy.jl
+++ b/examples/simplelazy.jl
@@ -20,10 +20,10 @@ using Gurobi
 m = Model(solver=GurobiSolver())
 
 # Define our variables to be inside a box, and integer
-@defVar(m, 0 <= x <= 2, Int)
-@defVar(m, 0 <= y <= 2, Int)
+@variable(m, 0 <= x <= 2, Int)
+@variable(m, 0 <= y <= 2, Int)
 
-@setObjective(m, Max, y)
+@objective(m, Max, y)
 
 # We now define our callback function that takes one argument,
 # the callback handle. Note that we can access m, x, and y because
@@ -53,13 +53,13 @@ function corners(cb)
         # Cut off this solution
         println("Solution was in top left, cut it off")
         # Use the original variables
-        @addLazyConstraint(cb, y - x <= 1)
+        @lazyconstraint(cb, y - x <= 1)
     # Check top right
     elseif y_val + x_val > 3 + TOL
         # Cut off this solution
         println("Solution was in top right, cut it off")
         # Use the original variables
-        @addLazyConstraint(cb, y + x <= 3)
+        @lazyconstraint(cb, y + x <= 3)
     end
 end  # End of callback function
 

--- a/examples/simplelazy2.jl
+++ b/examples/simplelazy2.jl
@@ -60,9 +60,9 @@ end
 function solveProblem()
     m = Model(solver=GurobiSolver())
 
-    @defVar(m, 0 <= x <= 2, Int)
-    @defVar(m, 0 <= y <= 2, Int)
-    @setObjective(m, Max, y)
+    @variable(m, 0 <= x <= 2, Int)
+    @variable(m, 0 <= y <= 2, Int)
+    @objective(m, Max, y)
 
     # Note that the callback is now a stub that passes off
     # the work to the "algorithm"
@@ -74,7 +74,7 @@ function solveProblem()
         newcut, x_coeff, y_coeff, rhs = cornerChecker(x_val, y_val)
 
         if newcut
-            @addLazyConstraint(cb, x_coeff*x + y_coeff*y <= rhs)
+            @lazyconstraint(cb, x_coeff*x + y_coeff*y <= rhs)
         end
     end  # End of callback function
 

--- a/examples/simpleusercut.jl
+++ b/examples/simpleusercut.jl
@@ -22,14 +22,14 @@ using Gurobi
 m = Model(solver=GurobiSolver(PreCrush=1, Cuts=0, Presolve=0, Heuristics=0.0))
 
 # Define our variables to be inside a box, and integer
-@defVar(m, 0 <= x <= 2, Int)
-@defVar(m, 0 <= y <= 2, Int)
+@variable(m, 0 <= x <= 2, Int)
+@variable(m, 0 <= y <= 2, Int)
 
 # Optimal solution is trying to go towards top-right corner (2.0, 2.0)
-@setObjective(m, Max, x + 2y)
+@objective(m, Max, x + 2y)
 
 # We have one constraint that cuts off the top right corner
-@addConstraint(m, y + x <= 3.5)
+@constraint(m, y + x <= 3.5)
 
 # Optimal solution of relaxed problem will be (1.5, 2.0)
 # We can add a user cut that will cut of this fractional solution.
@@ -50,7 +50,7 @@ function mycutgenerator(cb)
         # Cut off this solution
         println("Fractional solution was in top right, cut it off")
         # Use the original variables
-        @addUserCut(cb, y + x <= 3)
+        @usercut(cb, y + x <= 3)
     end
 end  # End of callback function
 

--- a/examples/steelT3.jl
+++ b/examples/steelT3.jl
@@ -57,32 +57,32 @@ print(market["coils"]["west"][1])
 
 # Decision Variables
 
-@defVar(Prod, Make[p=prod, t=1:T] >= 0); # tons produced
-@defVar(Prod, Inv[p=prod, t=0:T] >= 0); # tons inventoried
-@defVar(Prod, market[p][a][t] >= Sell[p=prod, a=area[p],t=1:T] >= 0); # tons sold
+@variable(Prod, Make[p=prod, t=1:T] >= 0); # tons produced
+@variable(Prod, Inv[p=prod, t=0:T] >= 0); # tons inventoried
+@variable(Prod, market[p][a][t] >= Sell[p=prod, a=area[p],t=1:T] >= 0); # tons sold
 
-@addConstraint(Prod, triconstr[p=prod, a=area[p], t=1:T],
+@constraint(Prod, triconstr[p=prod, a=area[p], t=1:T],
                Sell[p, a, t] - market[p][a][t] <= 0)
 
 
-@addConstraint(Prod, xyconst[t=1:T],
+@constraint(Prod, xyconst[t=1:T],
                sum{(1/rate[p]) * Make[p,t], p=prod} <= avail[t])
 
 # Total of hours used by all products
 # may not exceed hours available, in each week
 
-@addConstraint(Prod, xyconst[p=prod],
+@constraint(Prod, xyconst[p=prod],
                Inv[p,0] == inv0[p])
 # Initial inventory must equal given value
 
-@addConstraint(Prod, xyconst[p=prod, t=1:T],
+@constraint(Prod, xyconst[p=prod, t=1:T],
                Make[p,t] + Inv[p, t-1] == sum{Sell[p,a,t], a=area[p]} + Inv[p,t])
 
 # Tons produced and taken from inventory
 # must equal tons sold and put into inventory
 
 
-@setObjective(Prod, Max,
+@objective(Prod, Max,
               sum{
                 sum{revenue[p][a][t] * Sell[p, a, t] -
                       prodcost[p] * Make[p,t] -

--- a/examples/sudoku.jl
+++ b/examples/sudoku.jl
@@ -37,9 +37,9 @@ end
 function SolveModel(initgrid)
     m = Model()
 
-    @defVar(m, x[1:9, 1:9, 1:9], Bin)
+    @variable(m, x[1:9, 1:9, 1:9], Bin)
 
-    @addConstraints m begin
+    @constraints m begin
         # Constraint 1 - Only one value appears in each cell
         # Constraint 2 - Each value appears in each row once only
         # Constraint 3 - Each value appears in each column once only
@@ -53,7 +53,7 @@ function SolveModel(initgrid)
     # Initial solution
     for row in 1:9, col in 1:9
         if initgrid[row,col] != 0
-            @addConstraint(m, x[row, col, initgrid[row, col]] == 1)
+            @constraint(m, x[row, col, initgrid[row, col]] == 1)
         end
     end
 

--- a/examples/transp.jl
+++ b/examples/transp.jl
@@ -31,14 +31,14 @@ cost = [
 
 m = Model();
 
-@defVar(m, Trans[i=1:length(ORIG), j=1:length(DEST)] >= 0);
+@variable(m, Trans[i=1:length(ORIG), j=1:length(DEST)] >= 0);
 
 
-@setObjective(m, Min, sum{cost[i,j] * Trans[i,j], i=1:length(ORIG), j=1:length(DEST)});
+@objective(m, Min, sum{cost[i,j] * Trans[i,j], i=1:length(ORIG), j=1:length(DEST)});
 
-@addConstraint(m, xyconstr[i=1:1:length(ORIG)], sum{Trans[i,j], j=1:length(DEST)} == supply[i]);
+@constraint(m, xyconstr[i=1:1:length(ORIG)], sum{Trans[i,j], j=1:length(DEST)} == supply[i]);
 
-@addConstraint(m, xyconstr[j = 1:length(DEST)], sum{Trans[i,j], i=1:length(ORIG)} == demand[j]);
+@constraint(m, xyconstr[j = 1:length(DEST)], sum{Trans[i,j], i=1:length(ORIG)} == demand[j]);
 
 println("Solving original problem...")
 status = solve(m);

--- a/examples/tsp.jl
+++ b/examples/tsp.jl
@@ -114,23 +114,23 @@ function solveTSP(n, cities)
     # x[i,j] is 1 iff we travel between i and j, 0 otherwise
     # Although we define all n^2 variables, we will only use
     # the upper triangle
-    @defVar(m, x[1:n,1:n], Bin)
+    @variable(m, x[1:n,1:n], Bin)
 
     # Minimize length of tour
-    @setObjective(m, Min, sum{dist[i,j]*x[i,j], i=1:n,j=i:n})
+    @objective(m, Min, sum{dist[i,j]*x[i,j], i=1:n,j=i:n})
 
     # Make x_ij and x_ji be the same thing (undirectional)
     # Don't allow self-arcs
     for i = 1:n
-        @addConstraint(m, x[i,i] == 0)
+        @constraint(m, x[i,i] == 0)
         for j = (i+1):n
-            @addConstraint(m, x[i,j] == x[j,i])
+            @constraint(m, x[i,j] == x[j,i])
         end
     end
 
     # We must enter and leave every city once and only once
     for i = 1:n
-        @addConstraint(m, sum{x[i,j], j=1:n} == 2)
+        @constraint(m, sum{x[i,j], j=1:n} == 2)
     end
 
     function subtour(cb)
@@ -177,7 +177,7 @@ function solveTSP(n, cities)
         # Add the new subtour elimination constraint we built
         println("Adding subtour elimination cut")
         println("----")
-        @addLazyConstraint(cb, arcs_from_subtour >= 2)
+        @lazyconstraint(cb, arcs_from_subtour >= 2)
     end  # End function subtour
 
     # Solve the problem with our cut generator

--- a/examples/urbanplan.jl
+++ b/examples/urbanplan.jl
@@ -21,16 +21,16 @@ function SolveUrban()
     m = Model()
 
     # x is indexed by row and column
-    @defVar(m, 0 <= x[1:5,1:5] <= 1, Int)
+    @variable(m, 0 <= x[1:5,1:5] <= 1, Int)
 
     # y is indexed by R or C, and the points
     # JuMP allows indexing on arbitrary sets
     rowcol = ["R","C"]
     points = [+5,+4,+3,-3,-4,-5]
-    @defVar(m, 0 <= y[rowcol,points,i=1:5] <= 1, Int)
+    @variable(m, 0 <= y[rowcol,points,i=1:5] <= 1, Int)
 
     # Objective - combine the positive and negative parts
-    @setObjective(m, Max, sum{
+    @objective(m, Max, sum{
       3*(y["R", 3,i] + y["C", 3,i])
     + 1*(y["R", 4,i] + y["C", 4,i])
     + 1*(y["R", 5,i] + y["C", 5,i])
@@ -39,27 +39,27 @@ function SolveUrban()
     - 1*(y["R",-5,i] + y["C",-5,i]), i=1:5})
 
     # Constrain the number of residential lots
-    @addConstraint(m, sum{x[i,j], i=1:5, j=1:5} == 12)
+    @constraint(m, sum{x[i,j], i=1:5, j=1:5} == 12)
 
     # Add the constraints that link the auxiliary y variables
     # to the x variables
     # Rows
     for i = 1:5
-        @addConstraint(m, y["R", 5,i] <=   1/5*sum{x[i,j], j=1:5}) # sum = 5
-        @addConstraint(m, y["R", 4,i] <=   1/4*sum{x[i,j], j=1:5}) # sum = 4
-        @addConstraint(m, y["R", 3,i] <=   1/3*sum{x[i,j], j=1:5}) # sum = 3
-        @addConstraint(m, y["R",-3,i] >= 1-1/3*sum{x[i,j], j=1:5}) # sum = 2
-        @addConstraint(m, y["R",-4,i] >= 1-1/2*sum{x[i,j], j=1:5}) # sum = 1
-        @addConstraint(m, y["R",-5,i] >= 1-1/1*sum{x[i,j], j=1:5}) # sum = 0
+        @constraint(m, y["R", 5,i] <=   1/5*sum{x[i,j], j=1:5}) # sum = 5
+        @constraint(m, y["R", 4,i] <=   1/4*sum{x[i,j], j=1:5}) # sum = 4
+        @constraint(m, y["R", 3,i] <=   1/3*sum{x[i,j], j=1:5}) # sum = 3
+        @constraint(m, y["R",-3,i] >= 1-1/3*sum{x[i,j], j=1:5}) # sum = 2
+        @constraint(m, y["R",-4,i] >= 1-1/2*sum{x[i,j], j=1:5}) # sum = 1
+        @constraint(m, y["R",-5,i] >= 1-1/1*sum{x[i,j], j=1:5}) # sum = 0
     end
     # Columns
     for j = 1:5
-        @addConstraint(m, y["C", 5,j] <=   1/5*sum{x[i,j], i=1:5}) # sum = 5
-        @addConstraint(m, y["C", 4,j] <=   1/4*sum{x[i,j], i=1:5}) # sum = 4
-        @addConstraint(m, y["C", 3,j] <=   1/3*sum{x[i,j], i=1:5}) # sum = 3
-        @addConstraint(m, y["C",-3,j] >= 1-1/3*sum{x[i,j], i=1:5}) # sum = 2
-        @addConstraint(m, y["C",-4,j] >= 1-1/2*sum{x[i,j], i=1:5}) # sum = 1
-        @addConstraint(m, y["C",-5,j] >= 1-1/1*sum{x[i,j], i=1:5}) # sum = 0
+        @constraint(m, y["C", 5,j] <=   1/5*sum{x[i,j], i=1:5}) # sum = 5
+        @constraint(m, y["C", 4,j] <=   1/4*sum{x[i,j], i=1:5}) # sum = 4
+        @constraint(m, y["C", 3,j] <=   1/3*sum{x[i,j], i=1:5}) # sum = 3
+        @constraint(m, y["C",-3,j] >= 1-1/3*sum{x[i,j], i=1:5}) # sum = 2
+        @constraint(m, y["C",-4,j] >= 1-1/2*sum{x[i,j], i=1:5}) # sum = 1
+        @constraint(m, y["C",-5,j] >= 1-1/1*sum{x[i,j], i=1:5}) # sum = 0
     end
 
     # Solve it with the default solver (CBC)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -49,12 +49,15 @@ export
     affToStr, quadToStr, exprToStr, conToStr, chgConstrRHS, linearterms,
 
 # Macros and support functions
-    @addConstraint, @addConstraints, @addSDPConstraint,
     @LinearConstraint, @LinearConstraints, @QuadConstraint, @QuadConstraints,
     @SOCConstraint, @SOCConstraints,
-    @defVar, @defConstrRef, @setObjective, addToExpression, @defExpr, @defVars,
-    @setNLObjective, @addNLConstraint, @addNLConstraints,
-    @defNLExpr, @defNLParam
+    addToExpression,
+    @expression, @NLexpression,
+    @variable, @variables, @constraint, @constraints,
+    @NLconstraint, @NLconstraints,
+    @SDconstraint, @SDconstraints,
+    @objective, @NLobjective,
+    @NLparameter, @constraintref
 
 include("JuMPContainer.jl")
 include("utils.jl")
@@ -733,6 +736,8 @@ include("callbacks.jl")
 include("print.jl")
 # Nonlinear-specific code
 include("nlp.jl")
+# Deprecations
+include("deprecated.jl")
 
 getValue{T<:JuMPTypes}(arr::Array{T}) = map(getValue, arr)
 

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -158,9 +158,10 @@ const sensemap = Dict(:(<=) => '<', :(==) => '=', :(>=) => '>')
 
 
 ## Lazy constraints
-export addLazyConstraint, @addLazyConstraint
+export addLazyConstraint
+export @lazyconstraint
 
-macro addLazyConstraint(cbdata, x)
+macro lazyconstraint(cbdata, x)
     cbdata = esc(cbdata)
     if VERSION < v"0.5.0-dev+3231"
         x = comparison_to_call(x)
@@ -177,7 +178,7 @@ macro addLazyConstraint(cbdata, x)
             addLazyConstraint($cbdata, constr)
         end
     else
-        error("Syntax error in addLazyConstraint, expected one-sided comparison.")
+        error("Syntax error in @lazyconstraint, expected one-sided comparison.")
     end
 end
 
@@ -195,9 +196,10 @@ end
 addLazyConstraint(cbdata::MathProgBase.MathProgCallbackData,constr::QuadConstraint) = error("Quadratic lazy constraints are not supported.")
 
 ## User cuts
-export addUserCut, @addUserCut
+export addUserCut
+export @usercut
 
-macro addUserCut(cbdata, x)
+macro usercut(cbdata, x)
     cbdata = esc(cbdata)
     if VERSION < v"0.5.0-dev+3231"
         x = comparison_to_call(x)
@@ -214,7 +216,7 @@ macro addUserCut(cbdata, x)
             addUserCut($cbdata, constr)
         end
     else
-        error("Syntax error in addUserCut, expected one-sided comparison.")
+        error("Syntax error in @usercut, expected one-sided comparison.")
     end
 end
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,46 @@
+#  Copyright 2016, Iain Dunning, Joey Huchette, Miles Lubin, and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#############################################################################
+# JuMP
+# An algebraic modeling language for Julia
+# See http://github.com/JuliaOpt/JuMP.jl
+#############################################################################
+# deprecated.jl
+# List of deprecated macros and functions, mostly from the "big renaming"
+macro deprecate_macro(old,new)
+    oldmac = symbol(string("@",old))
+    newmac = symbol(string("@",new))
+    s = string(oldmac," is deprecated, use ", newmac, " instead.")
+    if VERSION > v"0.5-"
+        # backtraces are ok on 0.5
+        depwarn = :(Base.depwarn($s,$(quot(oldmac))))
+    else
+        # backtraces are junk on 0.4
+        depwarn = :(Base.warn_once($s))
+    end
+    @eval macro $old(args...)
+        return Expr(:block, $depwarn, Expr(:macrocall, $(quot(newmac)), [esc(x) for x in args]...))
+    end
+    eval(Expr(:export,oldmac))
+    return
+end
+
+@deprecate_macro defVar variable
+@deprecate_macro defVars variables
+@deprecate_macro setObjective objective
+@deprecate_macro setNLObjective NLobjective
+@deprecate_macro addConstraint constraint
+@deprecate_macro addConstraints constraints
+@deprecate_macro addNLConstraint NLconstraint
+@deprecate_macro addNLConstraints NLconstraints
+@deprecate_macro addSDPConstraint SDconstraint
+@deprecate_macro defExpr expression
+@deprecate_macro defNLExpr NLexpression
+@deprecate_macro defNLParam NLparameter
+@deprecate_macro defConstrRef constraintref
+
+# callback macros
+@deprecate_macro addLazyConstraint lazyconstraint
+@deprecate_macro addUserCut usercut

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -14,8 +14,8 @@ using JuMP, FactCheck
 
 facts("[expr] Test expression construction") do
     maff = Model()
-    @defVar(maff, 0 <= x[1:5] <= 1)
-    @defVar(maff, 0 <= LongName <= 99)
+    @variable(maff, 0 <= x[1:5] <= 1)
+    @variable(maff, 0 <= LongName <= 99)
 
     context("AffExpr") do
         # Test affToStr
@@ -47,7 +47,7 @@ end
 
 facts("[expr] Test getValue(expr)") do
     m = Model()
-    @defVar(m, 1 <= x[1:3] <= 2)
+    @variable(m, 1 <= x[1:3] <= 2)
     setValue(x[3], 2)
     setValue(x[2], 2)
     setValue(x[1], 1)
@@ -57,7 +57,7 @@ end
 
 facts("[expr] Test expression iterators") do
     m = Model()
-    @defVar(m, x[1:10])
+    @variable(m, x[1:10])
 
     a1 = 1*x[1] + 2*x[2]
     k = 1

--- a/test/fuzzer.jl
+++ b/test/fuzzer.jl
@@ -51,11 +51,11 @@ function random_aff_expr(N, vars::Vector)
 end
 
 m = Model()
-@defVar(m, x)
-@defVar(m, y)
-@defVar(m, z)
-@defVar(m, w)
-@defVar(m, v)
+@variable(m, x)
+@variable(m, y)
+@variable(m, z)
+@variable(m, w)
+@variable(m, v)
 
 N = 5
 vars = [:x, :y, :z, :w, :v, :(identity(x)), :(identity(y)), :(identity(z))]

--- a/test/hockschittkowski/hs109.jl
+++ b/test/hockschittkowski/hs109.jl
@@ -33,32 +33,32 @@ L = [0.0, 0.0, -0.55, -0.55, 196, 196, 196, -400, -400]
 U = [Inf, Inf,  0.55,  0.55, 252, 252, 252,  800,  800]
 
 m = Model()
-@defVar(m, L[i] <= x[i=1:9] <= U[i], start = 0.0)
+@variable(m, L[i] <= x[i=1:9] <= U[i], start = 0.0)
 
-@setNLObjective(m, Min, 3 * x[1] + 1e-6 * x[1]^3 + 2 * x[2] + .522074e-6 * x[2]^3)
+@NLobjective(m, Min, 3 * x[1] + 1e-6 * x[1]^3 + 2 * x[2] + .522074e-6 * x[2]^3)
 
-@addNLConstraint(m, x[4] - x[3] + 0.55 >= 0)
-@addNLConstraint(m, x[3] - x[4] + 0.55 >= 0)
-@addNLConstraint(m, 2250000 - x[1]^2 - x[8]^2 >= 0)
-@addNLConstraint(m, 2250000 - x[2]^2 - x[9]^2 >= 0)
-@addNLConstraint(m,
+@NLconstraint(m, x[4] - x[3] + 0.55 >= 0)
+@NLconstraint(m, x[3] - x[4] + 0.55 >= 0)
+@NLconstraint(m, 2250000 - x[1]^2 - x[8]^2 >= 0)
+@NLconstraint(m, 2250000 - x[2]^2 - x[9]^2 >= 0)
+@NLconstraint(m,
     x[5] * x[6] * sin(-x[3] - .25) + x[5] * x[7] * sin(-x[4] - .25) +
     2 * b * x[5]^2 - a * x[1] + 400 * a == 0)
-@addNLConstraint(m,
+@NLconstraint(m,
     x[5] * x[6] * sin(x[3] - .25) + x[6] * x[7] * sin(x[3] - x[4] - .25) +
     2 * b * x[6]^2 - a * x[2] + 400 * a == 0)
-@addNLConstraint(m,
+@NLconstraint(m,
     x[5] * x[7] * sin(x[4] - .25) + x[6] * x[7] * sin(x[4] - x[3] - .25) +
     2 * b * x[7]^2 + 881.779 * a == 0)
-@addNLConstraint(m,
+@NLconstraint(m,
     a * x[8] + x[5] * x[6] * cos(-x[3] - .25) +
     x[5] * x[7] * cos(-x[4] - .25) - 200 * a - 2 * c * x[5]^2 +
     .7533e-3 * a * x[5]^2 == 0)
-@addNLConstraint(m,
+@NLconstraint(m,
     a * x[9] + x[5] * x[6] * cos(x[3] - .25) +
     x[6] * x[7] * cos(x[3] - x[4] - .25) - 2 * c * x[6]^2 +
     .7533e-3 * a * x[6]^2 - 200 * a == 0)
-@addNLConstraint(m,
+@NLconstraint(m,
     x[5] * x[7] * cos(x[4] - .25) + x[6] * x[7] * cos(x[4] - x[3] - .25) -
     2 * c * x[7]^2 + 22.938 * a + .7533e-3 * a * x[7] ^2 == 0)
 

--- a/test/hockschittkowski/hs110.jl
+++ b/test/hockschittkowski/hs110.jl
@@ -25,9 +25,9 @@ using Base.Test
 let
 
 m = Model()
-@defVar(m, -2.001 <= x[1:10] <= 9.999, start = 9)
+@variable(m, -2.001 <= x[1:10] <= 9.999, start = 9)
 
-@setNLObjective(m, Min,
+@NLobjective(m, Min,
     sum{ log(x[j] - 2)^2 + log(10 - x[j])^2, j=1:10} -
     prod{x[i],i=1:10} ^ 0.2
 )

--- a/test/hockschittkowski/hs111.jl
+++ b/test/hockschittkowski/hs111.jl
@@ -27,14 +27,14 @@ let
 c = [-6.089, -17.164, -34.054, -5.914, -24.721, -14.986, -24.100, -10.708, -26.662, -22.179]
 
 m = Model()
-@defVar(m, -100 <= x[1:10] <= 100, start = -2.3)
+@variable(m, -100 <= x[1:10] <= 100, start = -2.3)
 
-@setNLObjective(m, Min,
+@NLobjective(m, Min,
     sum{exp(x[j]) * (c[j] + x[j] - log( sum{exp(x[k]), k=1:10} ) ), j=1:10})
 
-@addNLConstraint(m, exp(x[1]) + 2*exp(x[2]) + 2*exp(x[3]) +   exp(x[6]) + exp(x[10]) == 2)
-@addNLConstraint(m, exp(x[4]) + 2*exp(x[5]) +   exp(x[6]) +   exp(x[7])              == 1)
-@addNLConstraint(m, exp(x[3]) +   exp(x[7]) +   exp(x[8]) + 2*exp(x[9]) + exp(x[10]) == 1)
+@NLconstraint(m, exp(x[1]) + 2*exp(x[2]) + 2*exp(x[3]) +   exp(x[6]) + exp(x[10]) == 2)
+@NLconstraint(m, exp(x[4]) + 2*exp(x[5]) +   exp(x[6]) +   exp(x[7])              == 1)
+@NLconstraint(m, exp(x[3]) +   exp(x[7]) +   exp(x[8]) + 2*exp(x[9]) + exp(x[10]) == 1)
 
 solve(m)
 

--- a/test/hockschittkowski/hs112.jl
+++ b/test/hockschittkowski/hs112.jl
@@ -27,13 +27,13 @@ let
 c = [-6.089, -17.164, -34.054, -5.914, -24.721, -14.986, -24.100, -10.708, -26.662, -22.179]
 
 m = Model()
-@defVar(m, x[1:10] >= 1e-6, start = 0.1)
+@variable(m, x[1:10] >= 1e-6, start = 0.1)
 
-@setNLObjective(m, Min, sum{x[j]*(c[j] + log(x[j]/sum{x[k],k=1:10})), j=1:10})
+@NLobjective(m, Min, sum{x[j]*(c[j] + log(x[j]/sum{x[k],k=1:10})), j=1:10})
 
-@addNLConstraint(m, x[1] + 2*x[2] + 2*x[3] + x[6] + x[10] == 2)
-@addNLConstraint(m, x[4] + 2*x[5] + x[6] + x[7] == 1)
-@addNLConstraint(m, x[3] + x[7] + x[8] + 2*x[9] + x[10] == 1)
+@NLconstraint(m, x[1] + 2*x[2] + 2*x[3] + x[6] + x[10] == 2)
+@NLconstraint(m, x[4] + 2*x[5] + x[6] + x[7] == 1)
+@NLconstraint(m, x[3] + x[7] + x[8] + 2*x[9] + x[10] == 1)
 
 solve(m)
 

--- a/test/hockschittkowski/hs114.jl
+++ b/test/hockschittkowski/hs114.jl
@@ -33,21 +33,21 @@ upper = [2000, 16000, 120, 5000, 2000, 93, 95, 12, 4, 162]
 start = [1745, 12000, 110, 3048, 1974, 89.2, 92.8, 8, 3.6, 145]
 
 m = Model()
-@defVar(m, lower[i] <= x[i=1:n] <= upper[i], start = start[i])
+@variable(m, lower[i] <= x[i=1:n] <= upper[i], start = start[i])
 
-@setNLObjective(m, Min, 5.04*x[1] + .035*x[2] + 10*x[3] + 3.36*x[5] - .063*x[4]*x[7])
+@NLobjective(m, Min, 5.04*x[1] + .035*x[2] + 10*x[3] + 3.36*x[5] - .063*x[4]*x[7])
 
-@addNLConstraint(m, 35.82 - .222*x[10] - b*x[9] >= 0)
-@addNLConstraint(m, -133 + 3*x[7] - a*x[10] >= 0)
-@addNLConstraint(m, -(35.82 - .222*x[10] - b*x[9]) + x[9]*(1/b - b) >= 0)
-@addNLConstraint(m, -(-133 + 3*x[7] - a*x[10]) + (1/a - a)*x[10] >= 0)
-@addNLConstraint(m, 1.12*x[1] + .13167*x[1]*x[8] - .00667*x[1]*x[8]^2 - a*x[4] >= 0)
-@addNLConstraint(m, 57.425 + 1.098*x[8] - .038*x[8]^2 + .325*x[6] - a*x[7] >= 0)
-@addNLConstraint(m, -(1.12*x[1] + .13167*x[1]*x[8] - .00667*x[1]*x[8]^2 - a*x[4]) + (1/a - a)*x[4] >= 0)
-@addNLConstraint(m, -(57.425 + 1.098*x[8] - .038*x[8]^2 + .325*x[6] - a*x[7]) + (1/a - a)*x[7] >= 0)
-@addNLConstraint(m, 1.22*x[4] - x[1] - x[5] == 0)
-@addNLConstraint(m, 98000*x[3]/(x[4]*x[9] + 1000*x[3]) - x[6] == 0)
-@addNLConstraint(m, (x[2] + x[5])/x[1] - x[8] == 0)
+@NLconstraint(m, 35.82 - .222*x[10] - b*x[9] >= 0)
+@NLconstraint(m, -133 + 3*x[7] - a*x[10] >= 0)
+@NLconstraint(m, -(35.82 - .222*x[10] - b*x[9]) + x[9]*(1/b - b) >= 0)
+@NLconstraint(m, -(-133 + 3*x[7] - a*x[10]) + (1/a - a)*x[10] >= 0)
+@NLconstraint(m, 1.12*x[1] + .13167*x[1]*x[8] - .00667*x[1]*x[8]^2 - a*x[4] >= 0)
+@NLconstraint(m, 57.425 + 1.098*x[8] - .038*x[8]^2 + .325*x[6] - a*x[7] >= 0)
+@NLconstraint(m, -(1.12*x[1] + .13167*x[1]*x[8] - .00667*x[1]*x[8]^2 - a*x[4]) + (1/a - a)*x[4] >= 0)
+@NLconstraint(m, -(57.425 + 1.098*x[8] - .038*x[8]^2 + .325*x[6] - a*x[7]) + (1/a - a)*x[7] >= 0)
+@NLconstraint(m, 1.22*x[4] - x[1] - x[5] == 0)
+@NLconstraint(m, 98000*x[3]/(x[4]*x[9] + 1000*x[3]) - x[6] == 0)
+@NLconstraint(m, (x[2] + x[5])/x[1] - x[8] == 0)
 
 solve(m)
 

--- a/test/hockschittkowski/hs116.jl
+++ b/test/hockschittkowski/hs116.jl
@@ -36,26 +36,26 @@ upper = [1.0, 1.0, 1.0, 0.1, 0.9, 0.9, 1000, 1000, 1000, 500, 150, 150, 150, Inf
 start = [0.5  2 0.8  3 0.9  4 0.1  5 0.14  6 0.5  7 489  8 80  9 650 0.5  2 0.8  3 0.9  4 0.1  5 0.14  6 0.5  7 489  8 80  9 650]
 
 m = Model()
-@defVar(m, lower[i] <= x[i=1:N] <= upper[i], start = start[i])
-@setNLObjective(m, Min, x[11] + x[12] + x[13])
+@variable(m, lower[i] <= x[i=1:N] <= upper[i], start = start[i])
+@NLobjective(m, Min, x[11] + x[12] + x[13])
 
-@addNLConstraint(m, x[3] - x[2] >= 0)
-@addNLConstraint(m, x[2] - x[1] >= 0)
-@addNLConstraint(m, 1 - a * x[7] + a * x[8] >= 0)
-@addNLConstraint(m, x[11] + x[12] + x[13] >= 50)
-@addNLConstraint(m, x[13] - b * x[10] + c * x[3] * x[10] >= 0)
-@addNLConstraint(m, x[5] - d * x[2] - e * x[2] * x[5] + f * x[2]^2 >= 0)
-@addNLConstraint(m, x[6] - d * x[3] - e * x[3] * x[6] + f * x[3]^2 >= 0)
-@addNLConstraint(m, x[4] - d * x[1] - e * x[1] * x[4] + f * x[1]^2 >= 0)
-@addNLConstraint(m, x[12] - b * x[9] + c * x[2] * x[9] >= 0)
-@addNLConstraint(m, x[11] - b * x[8] + c * x[1] * x[8] >= 0)
-@addNLConstraint(m, x[5] * x[7] - x[1] * x[8] - x[4] * x[7] + x[4] * x[8] >= 0)
-@addNLConstraint(m, 1 - a * (x[2] * x[9] + x[5] * x[8] - x[1] * x[8] - x[6] * x[9]) -
+@NLconstraint(m, x[3] - x[2] >= 0)
+@NLconstraint(m, x[2] - x[1] >= 0)
+@NLconstraint(m, 1 - a * x[7] + a * x[8] >= 0)
+@NLconstraint(m, x[11] + x[12] + x[13] >= 50)
+@NLconstraint(m, x[13] - b * x[10] + c * x[3] * x[10] >= 0)
+@NLconstraint(m, x[5] - d * x[2] - e * x[2] * x[5] + f * x[2]^2 >= 0)
+@NLconstraint(m, x[6] - d * x[3] - e * x[3] * x[6] + f * x[3]^2 >= 0)
+@NLconstraint(m, x[4] - d * x[1] - e * x[1] * x[4] + f * x[1]^2 >= 0)
+@NLconstraint(m, x[12] - b * x[9] + c * x[2] * x[9] >= 0)
+@NLconstraint(m, x[11] - b * x[8] + c * x[1] * x[8] >= 0)
+@NLconstraint(m, x[5] * x[7] - x[1] * x[8] - x[4] * x[7] + x[4] * x[8] >= 0)
+@NLconstraint(m, 1 - a * (x[2] * x[9] + x[5] * x[8] - x[1] * x[8] - x[6] * x[9]) -
           x[5] - x[6] >= 0)
-@addNLConstraint(m, x[2] * x[9] - x[3] * x[10] - x[6] * x[9] - 500 * x[2] +
+@NLconstraint(m, x[2] * x[9] - x[3] * x[10] - x[6] * x[9] - 500 * x[2] +
           500 * x[6] + x[2] * x[10] >= 0)
-@addNLConstraint(m, x[2] - 0.9 - a * (x[2] * x[10] - x[3] * x[10]) >= 0)
-@addNLConstraint(m, x[11] + x[12] + x[13] <= 250)
+@NLconstraint(m, x[2] - 0.9 - a * (x[2] * x[10] - x[3] * x[10]) >= 0)
+@NLconstraint(m, x[11] + x[12] + x[13] <= 250)
 
 
 solve(m)

--- a/test/hockschittkowski/hs118.jl
+++ b/test/hockschittkowski/hs118.jl
@@ -40,9 +40,9 @@ for k in 1:4
     U[3*k+3] =  60.0
 end
 
-@defVar(m, L[i] <= x[i=1:15] <= U[i])
+@variable(m, L[i] <= x[i=1:15] <= U[i])
 
-@setNLObjective(m, Min,
+@NLobjective(m, Min,
     sum{2.3     * x[3*k+1]   +
         0.0001  * x[3*k+1]^2 +
         1.7     * x[3*k+2]   +
@@ -61,29 +61,29 @@ end
 
 # constr1
 for j in 1:4
-    @addConstraint(m, x[3*j+1] - x[3*j-2] + 7 <= 13)
-    @addConstraint(m, x[3*j+1] - x[3*j-2] + 7 >=  0)
+    @constraint(m, x[3*j+1] - x[3*j-2] + 7 <= 13)
+    @constraint(m, x[3*j+1] - x[3*j-2] + 7 >=  0)
 end
 
 # constr2
 for j in 1:4
-    @addConstraint(m, x[3*j+2] - x[3*j-1] + 7 <= 14)
-    @addConstraint(m, x[3*j+2] - x[3*j-1] + 7 >=  0)
+    @constraint(m, x[3*j+2] - x[3*j-1] + 7 <= 14)
+    @constraint(m, x[3*j+2] - x[3*j-1] + 7 >=  0)
 end
 
 # constr3
 for j in 1:4
-    @addConstraint(m, x[3*j+3] - x[3*j  ] + 7 <= 13)
-    @addConstraint(m, x[3*j+3] - x[3*j  ] + 7 >=  0)
+    @constraint(m, x[3*j+3] - x[3*j  ] + 7 <= 13)
+    @constraint(m, x[3*j+3] - x[3*j  ] + 7 >=  0)
 end
 
-@addConstraint(m, x[1] + x[2] + x[3]    >= 60)
-@addConstraint(m, x[4] + x[5] + x[6]    >= 50)
-@addConstraint(m, x[7] + x[8] + x[9]    >= 70)
-@addConstraint(m, x[10] + x[11] + x[12] >= 85)
-@addConstraint(m, x[13] + x[14] + x[15] >= 100)
+@constraint(m, x[1] + x[2] + x[3]    >= 60)
+@constraint(m, x[4] + x[5] + x[6]    >= 50)
+@constraint(m, x[7] + x[8] + x[9]    >= 70)
+@constraint(m, x[10] + x[11] + x[12] >= 85)
+@constraint(m, x[13] + x[14] + x[15] >= 100)
 
-# Initial solution (could also use 'start' keyword in @defVar)
+# Initial solution (could also use 'start' keyword in @variable)
 setValue(x[1], 20.0)
 setValue(x[2], 55.0)
 setValue(x[3], 15.0)

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -12,13 +12,13 @@ import JuMP
 
 mymod = JuMP.Model()
 mysense = :Min
-JuMP.@defVar(mymod, x >= 0)
+JuMP.@variable(mymod, x >= 0)
 r = 3:5
-JuMP.@defVar(mymod, y[i=r] <= i)
-JuMP.@addConstraint(mymod, x + sum{ j*y[j], j=r } <= 1)
-JuMP.@addConstraint(mymod, sum{ y[j], j=r ; j == 4} <= 1)
-JuMP.@addConstraint(mymod, -1 <= x + y[3] <= 1)
-JuMP.@setObjective(mymod, mysense, y[4])
-JuMP.@addNLConstraint(mymod, y[3] == 1)
+JuMP.@variable(mymod, y[i=r] <= i)
+JuMP.@constraint(mymod, x + sum{ j*y[j], j=r } <= 1)
+JuMP.@constraint(mymod, sum{ y[j], j=r ; j == 4} <= 1)
+JuMP.@constraint(mymod, -1 <= x + y[3] <= 1)
+JuMP.@objective(mymod, mysense, y[4])
+JuMP.@NLconstraint(mymod, y[3] == 1)
 
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -42,80 +42,80 @@ facts("[macros] Check Julia expression parsing") do
     @fact sumexpr.args[4].head --> :(=)
 end
 
-facts("[macros] Check @addConstraint basics") do
+facts("[macros] Check @constraint basics") do
     m = Model()
-    @defVar(m, w)
-    @defVar(m, x)
-    @defVar(m, y)
-    @defVar(m, z)
+    @variable(m, w)
+    @variable(m, x)
+    @variable(m, y)
+    @variable(m, z)
     t = 10
 
-    @addConstraint(m, 3x - y == 3.3(w + 2z) + 5)
+    @constraint(m, 3x - y == 3.3(w + 2z) + 5)
     @fact conToStr(m.linconstr[end]) --> "3 x - y - 3.3 w - 6.6 z $eq 5"
-    @addConstraint(m, 3x - y == (w + 2z)*3.3 + 5)
+    @constraint(m, 3x - y == (w + 2z)*3.3 + 5)
     @fact conToStr(m.linconstr[end]) --> "3 x - y - 3.3 w - 6.6 z $eq 5"
-    @addConstraint(m, (x+y)/2 == 1)
+    @constraint(m, (x+y)/2 == 1)
     @fact conToStr(m.linconstr[end]) --> "0.5 x + 0.5 y $eq 1"
-    @addConstraint(m, -1 <= x-y <= t)
+    @constraint(m, -1 <= x-y <= t)
     @fact conToStr(m.linconstr[end]) --> "-1 $leq x - y $leq 10"
-    @addConstraint(m, -1 <= x+1 <= 1)
+    @constraint(m, -1 <= x+1 <= 1)
     @fact conToStr(m.linconstr[end]) --> "-2 $leq x $leq 0"
-    @addConstraint(m, -1 <= x <= 1)
+    @constraint(m, -1 <= x <= 1)
     @fact conToStr(m.linconstr[end]) --> "-1 $leq x $leq 1"
-    @addConstraint(m, -1 <= x <= sum{0.5, i = 1:2})
+    @constraint(m, -1 <= x <= sum{0.5, i = 1:2})
     @fact conToStr(m.linconstr[end]) --> "-1 $leq x $leq 1"
-    @fact_throws @addConstraint(m, x <= t <= y)
+    @fact_throws @constraint(m, x <= t <= y)
 
-    @defExpr(m, aff, 3x - y - 3.3(w + 2z) + 5)
+    @expression(m, aff, 3x - y - 3.3(w + 2z) + 5)
     @fact affToStr(aff) --> "3 x - y - 3.3 w - 6.6 z + 5"
 
-    @addConstraint(m, 3 + 5*7 <= 0)
+    @constraint(m, 3 + 5*7 <= 0)
     @fact conToStr(m.linconstr[end]) --> "0 $leq -38"
 
-    @defExpr(m, qaff, (w+3)*(2x+1)+10)
+    @expression(m, qaff, (w+3)*(2x+1)+10)
     @fact quadToStr(qaff) --> "2 w*x + 6 x + w + 13"
 end
 
-facts("[macros] Checking @defVar with reverse direction bounds") do
+facts("[macros] Checking @variable with reverse direction bounds") do
     m = Model()
-    @defVar(m, 3.2 >= x >= 1)
+    @variable(m, 3.2 >= x >= 1)
     @fact m.colLower --> [1.0]
     @fact m.colUpper --> [3.2]
 end
 
 facts("[macros] sum{}") do
     m = Model()
-    @defVar(m, x[1:3,1:3])
-    @defVar(m, y)
+    @variable(m, x[1:3,1:3])
+    @variable(m, y)
     C = [1 2 3; 4 5 6; 7 8 9]
-    @addConstraint(m, sum{ C[i,j]*x[i,j], i in 1:2, j = 2:3 } <= 1)
+    @constraint(m, sum{ C[i,j]*x[i,j], i in 1:2, j = 2:3 } <= 1)
     @fact conToStr(m.linconstr[end]) --> "2 x[1,2] + 3 x[1,3] + 5 x[2,2] + 6 x[2,3] $leq 1"
-    @addConstraint(m, sum{ C[i,j]*x[i,j], i = 1:3, j in 1:3; i != j} == y)
+    @constraint(m, sum{ C[i,j]*x[i,j], i = 1:3, j in 1:3; i != j} == y)
     @fact conToStr(m.linconstr[end]) --> "2 x[1,2] + 3 x[1,3] + 4 x[2,1] + 6 x[2,3] + 7 x[3,1] + 8 x[3,2] - y $eq 0"
 
-    @addConstraint(m, sum{ C[i,j]*x[i,j], i = 1:3, j = 1:i} == 0);
+    @constraint(m, sum{ C[i,j]*x[i,j], i = 1:3, j = 1:i} == 0);
     @fact conToStr(m.linconstr[end]) --> "x[1,1] + 4 x[2,1] + 5 x[2,2] + 7 x[3,1] + 8 x[3,2] + 9 x[3,3] $eq 0"
 
-    @addConstraint(m, sum{ 0*x[i,1], i=1:3} == 0)
+    @constraint(m, sum{ 0*x[i,1], i=1:3} == 0)
     @fact conToStr(m.linconstr[end]) --> "0 $eq 0"
 
-    @addConstraint(m, sum{ 0*x[i,1] + y, i=1:3} == 0)
+    @constraint(m, sum{ 0*x[i,1] + y, i=1:3} == 0)
     @fact conToStr(m.linconstr[end]) --> "3 y $eq 0"
 
 end
 
 facts("[macros] Problem modification") do
     m = Model()
-    @defVar(m, x[1:3,1:3])
+    @variable(m, x[1:3,1:3])
     C = [1 2 3; 4 5 6; 7 8 9]
 
-    @addConstraint(m, sum{ x[i,j]*(C[i,j]-1), i in 1:3, j = 1:3; i != j} == 0)
+    @constraint(m, sum{ x[i,j]*(C[i,j]-1), i in 1:3, j = 1:3; i != j} == 0)
     @fact conToStr(m.linconstr[end]) --> "x[1,2] + 2 x[1,3] + 3 x[2,1] + 5 x[2,3] + 6 x[3,1] + 7 x[3,2] $eq 0"
 
-    con = @addConstraint(m, sum{ C[i,j]*x[i,j], i = 1:3, j = 1:3; i != j} == 0)
+    con = @constraint(m, sum{ C[i,j]*x[i,j], i = 1:3, j = 1:3; i != j} == 0)
     @fact conToStr(m.linconstr[end]) --> "2 x[1,2] + 3 x[1,3] + 4 x[2,1] + 6 x[2,3] + 7 x[3,1] + 8 x[3,2] $eq 0"
 
-    @defVar(m, y, objective = 0, inconstraints = [con], coefficients = [-1.0])
+    @variable(m, y, objective = 0, inconstraints = [con], coefficients = [-1.0])
     @fact conToStr(m.linconstr[end]) --> "2 x[1,2] + 3 x[1,3] + 4 x[2,1] + 6 x[2,3] + 7 x[3,1] + 8 x[3,2] - y $eq 0"
 
     chgConstrRHS(con, 3)
@@ -124,26 +124,26 @@ end
 
 facts("[macros] Using pre-built affine is OK in macro") do
     m = Model()
-    @defVar(m, x)
-    @defVar(m, y)
+    @variable(m, x)
+    @variable(m, y)
     temp = x + 2y + 1
-    @addConstraint(m, 3*temp - x - 2 >= 0)
+    @constraint(m, 3*temp - x - 2 >= 0)
     @fact conToStr(m.linconstr[end]) --> "6 y + 2 x $geq -1"
     # More complex expression
     a = 1.0*x
-    @addConstraint(m, (2+2)*((3+4)*(1+a)) == 0)
+    @constraint(m, (2+2)*((3+4)*(1+a)) == 0)
     @fact conToStr(m.linconstr[end]) --> "28 x $eq -28"
     @fact affToStr(a) --> "x"
 
     @fact conToStr(@LinearConstraint(1 + 0*temp == 0)) --> "0 $eq -1"
 end
 
-facts("[macros] Test ranges in @defVar") do
+facts("[macros] Test ranges in @variable") do
     m = Model()
-    @defVar(m, x[1:5])
-    @defVar(m, y[3:2:9])
-    @defVar(m, z[4:3:8])
-    @defVar(m, w[6:5])
+    @variable(m, x[1:5])
+    @variable(m, y[3:2:9])
+    @variable(m, z[4:3:8])
+    @variable(m, w[6:5])
 
     @fact length(x) --> 5
     @fact length(y) --> 4
@@ -160,15 +160,15 @@ end
 
 facts("[macros] Unicode comparisons") do
     m = Model()
-    @defVar(m, 0 ≤ x ≤ 1)
-    @defVar(m, y ≥ 2)
-    @defVar(m, z ≤ 3)
+    @variable(m, 0 ≤ x ≤ 1)
+    @variable(m, y ≥ 2)
+    @variable(m, z ≤ 3)
     @fact m.colUpper --> [1.0, Inf,  3.0]
     @fact m.colLower --> [0.0, 2.0, -Inf]
-    @addConstraint(m, 0 ≤ x + y ≤ 1)
-    @addConstraint(m, x + z ≤ 2)
-    @addConstraint(m, y + z ≥ 3)
-    @addConstraint(m, y*z ≤ 1)
+    @constraint(m, 0 ≤ x + y ≤ 1)
+    @constraint(m, x + z ≤ 2)
+    @constraint(m, y + z ≥ 3)
+    @constraint(m, y*z ≤ 1)
     @fact m.linconstr[1].lb --> 0.0
     @fact m.linconstr[1].ub --> 1.0
     @fact m.linconstr[2].lb --> -Inf
@@ -178,27 +178,27 @@ facts("[macros] Unicode comparisons") do
     @fact m.quadconstr[1].sense --> :(<=)
 end
 
-facts("[macros] Three argument @addConstraint") do
+facts("[macros] Three argument @constraint") do
     m = Model()
-    @defVar(m, x[1:5])
-    @defVar(m, y[2:2:6])
+    @variable(m, x[1:5])
+    @variable(m, y[2:2:6])
 
-    @addConstraint(m, c, x[4] - y[4] == 1)
+    @constraint(m, c, x[4] - y[4] == 1)
     @fact conToStr(m.linconstr[c.idx]) --> "x[4] - y[4] $eq 1"
 
-    @addConstraint(m, d[i in 1:5,j=6:-2:2], x[i] - y[j] == 2)
+    @constraint(m, d[i in 1:5,j=6:-2:2], x[i] - y[j] == 2)
     @fact conToStr(m.linconstr[d[4,4].idx]) --> "x[4] - y[4] $eq 2"
 
-    @addConstraint(m, q[i=1:5], x[i]^2 == 1)
+    @constraint(m, q[i=1:5], x[i]^2 == 1)
     @fact conToStr(m.quadconstr[q[5].idx]) --> "x[5]² - 1 $eq 0"
 end
 
-facts("[macros] @addConstraints") do
+facts("[macros] @constraints") do
     m = Model()
-    @defVar(m, x)
-    @defVar(m, y[1:3])
+    @variable(m, x)
+    @variable(m, y[1:3])
 
-    @addConstraints(m, begin
+    @constraints(m, begin
         x + y[1] == 1
         ref[i=1:3], y[1] + y[i] >= i
     end)
@@ -209,13 +209,13 @@ facts("[macros] @addConstraints") do
     @fact conToStr(m.linconstr[4]) --> "y[1] + y[3] $geq 3"
 end
 
-facts("[macros] @addNLConstraints") do
+facts("[macros] @NLconstraints") do
     m = Model()
-    @defVar(m, 0 <= x <= 1)
-    @defVar(m, y[1:3])
-    @setObjective(m, Max, x)
+    @variable(m, 0 <= x <= 1)
+    @variable(m, y[1:3])
+    @objective(m, Max, x)
 
-    @addNLConstraints(m, begin
+    @NLconstraints(m, begin
         ref[i=1:3], y[i] == 0
         x + y[1] * y[2] * y[3] <= 0.5
     end)
@@ -233,52 +233,52 @@ end
 
 facts("[macros] Vectors in nonlinear expressions") do
     m = Model()
-    @defVar(m, x[1:3])
-    @fact_throws ErrorException @setNLObjective(m, Min, x)
-    @fact_throws ErrorException @setNLObjective(m, Min, [1,2,3])
+    @variable(m, x[1:3])
+    @fact_throws ErrorException @NLobjective(m, Min, x)
+    @fact_throws ErrorException @NLobjective(m, Min, [1,2,3])
 end
 
-facts("[macros] @setObjective with quadratic") do
+facts("[macros] @objective with quadratic") do
     m = Model()
-    @defVar(m, x[1:5])
-    @setObjective(m, Max, sum{i*x[i]*x[j], i=1:5, j=5:-1:1; isodd(i) && iseven(j)} + 2x[5])
+    @variable(m, x[1:5])
+    @objective(m, Max, sum{i*x[i]*x[j], i=1:5, j=5:-1:1; isodd(i) && iseven(j)} + 2x[5])
 
     @fact quadToStr(m.obj) --> "x[1]*x[2] + 3 x[2]*x[3] + x[1]*x[4] + 3 x[3]*x[4] + 5 x[2]*x[5] + 5 x[4]*x[5] + 2 x[5]"
 end
 
-facts("[macros] @addConstraint with quadratic") do
+facts("[macros] @constraint with quadratic") do
     m = Model()
-    @defVar(m, x[1:5])
+    @variable(m, x[1:5])
 
-    @addConstraint(m, x[3]*x[1] + sum{x[i]*x[5-i+1], i=1:5; 2 <= i <= 4} + 4x[5] == 1)
+    @constraint(m, x[3]*x[1] + sum{x[i]*x[5-i+1], i=1:5; 2 <= i <= 4} + 4x[5] == 1)
     @fact conToStr(m.quadconstr[end]) --> "x[1]*x[3] + x[3]² + 2 x[2]*x[4] + 4 x[5] - 1 $eq 0"
 
-    @addConstraint(m, sum{sum{(x[i] - 2)*x[j],j=4:5},i=2:3} >= -3*x[2]*2*x[4])
+    @constraint(m, sum{sum{(x[i] - 2)*x[j],j=4:5},i=2:3} >= -3*x[2]*2*x[4])
     @fact conToStr(m.quadconstr[end]) --> "7 x[2]*x[4] + x[3]*x[4] + x[2]*x[5] + x[3]*x[5] - 4 x[4] - 4 x[5] $geq 0"
 
     foo(x) = x
-    @addConstraint(m, x[1] ≤ foo(x[1])^2)
+    @constraint(m, x[1] ≤ foo(x[1])^2)
     @fact conToStr(m.quadconstr[end]) --> "-x[1]² + x[1] $leq 0"
 
-    @addConstraint(m, sum{x[i],i=1:2}*sum{x[i],i=2:3} >= 0)
+    @constraint(m, sum{x[i],i=1:2}*sum{x[i],i=2:3} >= 0)
     @fact conToStr(m.quadconstr[end]) --> "x[1]*x[2] + x[2]² + x[1]*x[3] + x[2]*x[3] $geq 0"
-    @addConstraint(m, x[1]^2 + x[2]*x[3] >= 0)
+    @constraint(m, x[1]^2 + x[2]*x[3] >= 0)
     @fact conToStr(m.quadconstr[end]) --> "x[1]² + x[2]*x[3] $geq 0"
-    @addConstraint(m, x[1]^2 + (x[2]+3)*(x[3]-1) >= 0)
+    @constraint(m, x[1]^2 + (x[2]+3)*(x[3]-1) >= 0)
     @fact conToStr(m.quadconstr[end]) --> "x[1]² + x[2]*x[3] + 3 x[3] - x[2] - 3 $geq 0"
-    @addConstraint(m, sum{x[i],i=1:2}^2 >= 0)
+    @constraint(m, sum{x[i],i=1:2}^2 >= 0)
     @fact conToStr(m.quadconstr[end]) --> "x[1]² + 2 x[1]*x[2] + x[2]² $geq 0"
 
     myquadexpr = x[1]*x[2]
-    @addConstraint(m, sum{i*myquadexpr + x[i], i=1:3} + sum{x[i] + myquadexpr*i, i=1:3} == 0)
+    @constraint(m, sum{i*myquadexpr + x[i], i=1:3} + sum{x[i] + myquadexpr*i, i=1:3} == 0)
     @fact conToStr(m.quadconstr[end]) --> "12 x[1]*x[2] + 2 x[1] + 2 x[2] + 2 x[3] $eq 0"
 
-    @addConstraint(m, (x[1] + x[2])*sum{ 0*x[i] + x[3], i=1:3} == 0)
+    @constraint(m, (x[1] + x[2])*sum{ 0*x[i] + x[3], i=1:3} == 0)
     @fact conToStr(m.quadconstr[end]) --> "3 x[1]*x[3] + 3 x[2]*x[3] $eq 0"
 
     @fact conToStr(@QuadConstraint(1 + 0*myquadexpr == 0)) --> "1 $eq 0"
 
-    @defVar(m, y)
+    @variable(m, y)
     @fact conToStr(@QuadConstraint(1 + (2y)*y   == 0)) --> "2 y² + 1 $eq 0"
     @fact conToStr(@QuadConstraint(1 +   y *y*2 == 0)) --> "2 y² + 1 $eq 0"
     z = 2y
@@ -288,13 +288,13 @@ end
 facts("[macros] Triangular indexing, iteration") do
     n = 10
     trimod = Model()
-    @defVar(trimod, x[i=1:n,j=i:n])
-    @defVar(trimod, y[i=3:2:7,j=-i])
+    @variable(trimod, x[i=1:n,j=i:n])
+    @variable(trimod, y[i=3:2:7,j=-i])
     @fact MathProgBase.numvar(trimod) --> n*(n+1)/2 + 3
     S = Any[(i,i+2) for i in 1:5]
-    @defVar(trimod, z[(i,j)=S,k=i:j])
+    @variable(trimod, z[(i,j)=S,k=i:j])
     @fact length(z.tupledict) --> 15
-    @addConstraint(trimod, cref[i=1:n,j=i:n], x[i,j] + y[5,-5] == 1)
+    @constraint(trimod, cref[i=1:n,j=i:n], x[i,j] + y[5,-5] == 1)
     @fact MathProgBase.numconstr(trimod) --> n*(n+1)/2
 
     cntr = zeros(Bool, n, n)
@@ -312,7 +312,7 @@ facts("[macros] Multidimensional indexing") do
     I1 = 1:5
     I2 = 2:8
     I3 = 5:6
-    @defVar(model, x[1:5,2:8,5:6])
+    @variable(model, x[1:5,2:8,5:6])
     coll = Int[]
     for v in values(x)
         push!(coll, v.col)
@@ -326,30 +326,30 @@ facts("[macros] Multidimensional indexing") do
     @fact match --> true
 end
 
-facts("[macros] @defExpr") do
+facts("[macros] @expression") do
     model = Model()
-    @defVar(model, x[1:3,1:3])
-    @defExpr(model, expr, sum{i*x[i,j] + j, i=1:3,j in 1:3})
+    @variable(model, x[1:3,1:3])
+    @expression(model, expr, sum{i*x[i,j] + j, i=1:3,j in 1:3})
     @fact affToStr(expr) --> "x[1,1] + x[1,2] + x[1,3] + 2 x[2,1] + 2 x[2,2] + 2 x[2,3] + 3 x[3,1] + 3 x[3,2] + 3 x[3,3] + 18"
 
-    @fact_throws @defExpr(model, blah[i=1:3], x[i,1]^2)
+    @fact_throws @expression(model, blah[i=1:3], x[i,1]^2)
 
-    @defExpr(model, y[i=1:2], sum{x[i,1]; i == 1})
+    @expression(model, y[i=1:2], sum{x[i,1]; i == 1})
     @fact affToStr(y[1]) --> "x[1,1]"
     @fact affToStr(y[2]) --> "0"
 
     # deprecated versions
-    @defExpr(expr2, sum{i*x[i,j] + j, i=1:3,j in 1:3})
+    @expression(expr2, sum{i*x[i,j] + j, i=1:3,j in 1:3})
     @fact affToStr(expr2) --> "x[1,1] + x[1,2] + x[1,3] + 2 x[2,1] + 2 x[2,2] + 2 x[2,3] + 3 x[3,1] + 3 x[3,2] + 3 x[3,3] + 18"
-    expr2 = @defExpr(sum{i*x[i,j] + j, i=1:3,j in 1:3})
+    expr2 = @expression(sum{i*x[i,j] + j, i=1:3,j in 1:3})
     @fact affToStr(expr2) --> "x[1,1] + x[1,2] + x[1,3] + 2 x[2,1] + 2 x[2,2] + 2 x[2,3] + 3 x[3,1] + 3 x[3,2] + 3 x[3,3] + 18"
 end
 
 facts("[macros] Conditions in constraint indexing") do
     model = Model()
-    @defVar(model, x[1:10])
-    @addConstraint(model, c1[i=1:9;isodd(i)], x[i] + x[i+1] <= 1)
-    @addNLConstraint(model, c2[i=["red","blue","green"], k=9:-2:2; (i == "red" && isodd(k)) || (k >=4 && (i == "blue" || i == "green"))], x[k]^3 <= 1)
+    @variable(model, x[1:10])
+    @constraint(model, c1[i=1:9;isodd(i)], x[i] + x[i+1] <= 1)
+    @NLconstraint(model, c2[i=["red","blue","green"], k=9:-2:2; (i == "red" && isodd(k)) || (k >=4 && (i == "blue" || i == "green"))], x[k]^3 <= 1)
     @fact length(model.linconstr) --> 5
     @fact conToStr(model.linconstr[1]) --> "x[1] + x[2] $leq 1"
     @fact conToStr(model.linconstr[2]) --> "x[3] + x[4] $leq 1"
@@ -374,30 +374,30 @@ end
 
 facts("[macros] Norm parsing") do
     model = Model()
-    @defVar(model, x[1:2,1:2])
-    @addConstraint(model, -2norm2{x[i,j], i in 1:2, j=1:2} + x[1,2] >= -1)
-    @addConstraint(model, -2norm2{x[i,j], i=1:2, j in 1:2; iseven(i+j)} + x[1,2] >= -1)
-    @addConstraint(model, 1 >= 2*norm2{x[i,1], i in 1:2})
+    @variable(model, x[1:2,1:2])
+    @constraint(model, -2norm2{x[i,j], i in 1:2, j=1:2} + x[1,2] >= -1)
+    @constraint(model, -2norm2{x[i,j], i=1:2, j in 1:2; iseven(i+j)} + x[1,2] >= -1)
+    @constraint(model, 1 >= 2*norm2{x[i,1], i in 1:2})
     @fact conToStr(model.socconstr[1]) --> "2.0 $Vert[x[1,1],x[1,2],x[2,1],x[2,2]]$Vert$sub2 $leq x[1,2] + 1"
     @fact conToStr(model.socconstr[2]) --> "2.0 $Vert[x[1,1],x[2,2]]$Vert$sub2 $leq x[1,2] + 1"
     @fact conToStr(model.socconstr[3]) --> "2.0 $Vert[x[1,1],x[2,1]]$Vert$sub2 $leq 1"
-    @fact_throws @addConstraint(model, (x[1,1]+1)*norm2{x[i,j], i=1:2, j=1:2} + x[1,2] >= -1)
-    @fact_throws @addConstraint(model, norm2{x[i,j], i=1:2, j=1:2} + x[1,2] >= -1)
+    @fact_throws @constraint(model, (x[1,1]+1)*norm2{x[i,j], i=1:2, j=1:2} + x[1,2] >= -1)
+    @fact_throws @constraint(model, norm2{x[i,j], i=1:2, j=1:2} + x[1,2] >= -1)
 end
 
 facts("[macros] Extraneous terms in QuadExpr (#535)") do
     model = Model()
-    @defVar(model, x)
-    @defVar(model, y)
-    @addConstraint(model, x*x <= y*y)
+    @variable(model, x)
+    @variable(model, y)
+    @constraint(model, x*x <= y*y)
     @fact conToStr(model.quadconstr[1]) --> "x² - y² $leq 0"
 end
 
 facts("[macros] Special-case binary multiplication in addToExpression_reorder (#537)") do
     dual = Model()
-    @defVar(dual, α[1:3] <= 0)
-    @defVar(dual, γ >= 0)
-    @addConstraint(dual, ones(3)*γ .<= α)
+    @variable(dual, α[1:3] <= 0)
+    @variable(dual, γ >= 0)
+    @constraint(dual, ones(3)*γ .<= α)
     @fact conToStr(dual.linconstr[1]) --> "γ - α[1] $leq 0"
     @fact conToStr(dual.linconstr[2]) --> "γ - α[2] $leq 0"
     @fact conToStr(dual.linconstr[3]) --> "γ - α[3] $leq 0"
@@ -407,41 +407,41 @@ facts("[macros] Indices in macros don't leak out of scope (#582)") do
     m = Model()
     cnt = 4
     for i in 5:8
-        @defVar(m, x[i=1:3,j=1:3] ≤ i)
+        @variable(m, x[i=1:3,j=1:3] ≤ i)
         cnt += 1
         @fact i --> cnt
     end
     cnt = 4
     for i in 5:8
-        @defVar(m, y[i=2:4,j=1:3] ≤ i)
+        @variable(m, y[i=2:4,j=1:3] ≤ i)
         cnt += 1
         @fact i --> cnt
     end
     cnt = 4
     for i in 5:8
-        @defVar(m, z[i=[1:3;],j=1:3] ≤ i)
+        @variable(m, z[i=[1:3;],j=1:3] ≤ i)
         cnt += 1
         @fact i --> cnt
     end
     @fact m.colUpper --> vcat(repeat([1.0,2.0,3.0], inner=[3], outer=[4]),
                               repeat([2.0,3.0,4.0], inner=[3], outer=[4]),
                               repeat([1.0,2.0,3.0], inner=[3], outer=[4]))
-    @defVar(m, x[i=1:3] ≤ i)
+    @variable(m, x[i=1:3] ≤ i)
     cnt = 4
     for i in 5:8
-        @addConstraint(m, sum{x[i], i=1, j=1, k=1} == 1)
+        @constraint(m, sum{x[i], i=1, j=1, k=1} == 1)
         cnt += 1
         @fact i --> cnt
     end
     cnt = 4
     for i in 5:8
-        @addConstraint(m, norm2{x[i], i=1, j=1, k=1} <= 1)
+        @constraint(m, norm2{x[i], i=1, j=1, k=1} <= 1)
         cnt += 1
         @fact i --> cnt
     end
     cnt = 4
     for i in 5:8
-        @addConstraint(m, c[i=1:3,j=1:3], x[i] == 1)
+        @constraint(m, c[i=1:3,j=1:3], x[i] == 1)
         cnt += 1
         @fact i --> cnt
     end
@@ -449,7 +449,7 @@ end
 
 facts("[macros] Issue #621") do
     m = Model()
-    @defVar(m, x)
+    @variable(m, x)
 
     q = x^2
     a = x+1
@@ -457,15 +457,15 @@ facts("[macros] Issue #621") do
     @fact conToStr(con) --> "3 x² + x + 1 $leq 0"
 end
 
-facts("[macros] @defVars and @addConstraints") do
+facts("[macros] @variables and @constraints") do
     m = Model()
-    @defVars m begin
+    @variables m begin
         0 ≤ x[i=1:2] ≤ i
         y ≥ 2, Int, (start = 0.7)
         z ≤ 3, (start=10)
         q, (Bin, start=0.5)
     end
-    @addConstraints m begin
+    @constraints m begin
         0 ≤ x[1] + y ≤ 1
         x[1] + z ≤ 2
         y + z ≥ 3

--- a/test/model.jl
+++ b/test/model.jl
@@ -30,28 +30,28 @@ facts("[model] Check error cases") do
     @fact_throws Model(solver=:Foo)
     modErr = Model()
     @fact_throws setObjectiveSense(modErr, :Maximum)
-    @defVar(modErr, errVar)
+    @variable(modErr, errVar)
     @fact getValue(errVar) --> isnan
     @fact_throws getDual(errVar)
 
     modErr = Model()
-    @defVar(modErr, x, Bin)
-    @setObjective(modErr, Max, x)
-    con = @addConstraint(modErr, x <= 0.5)
+    @variable(modErr, x, Bin)
+    @objective(modErr, Max, x)
+    con = @constraint(modErr, x <= 0.5)
     solve(modErr)
     @fact_throws getDual(con)
 
     modErr = Model()
-    @defVar(modErr, 0 <= x <= 1)
-    @setObjective(modErr, Max, x)
-    @addConstraint(modErr, x <= -1)
+    @variable(modErr, 0 <= x <= 1)
+    @objective(modErr, Max, x)
+    @constraint(modErr, x <= -1)
     solve(modErr, suppress_warnings=true)
     @fact getValue(x) --> isnan
 end
 
 facts("[model] Performance warnings") do
     m = Model()
-    @defVar(m, x[1:2], start=0)
+    @variable(m, x[1:2], start=0)
     for i in 1:500
        getValue(x)
     end
@@ -64,14 +64,14 @@ end
 facts("[model] Test printing a model") do
     modA = Model()
     x = Variable(modA, 0, Inf, :Cont)
-    @defVar(modA, y <= 5, Int)
-    @defVar(modA, 2 <= z <= 4)
-    @defVar(modA, 0 <= r[i=3:6] <= i)
-    @setObjective(modA, Max, ((x + y)/2.0 + 3.0)/3.0 + z + r[3])
-    @defConstrRef constraints[1:3]
-    constraints[1] = @addConstraint(modA, 2 <= x+y <= 4)
-    constraints[2] = @addConstraint(modA, sum{r[i],i=3:5} <= (2 - x)/2.0)
-    constraints[3] = @addConstraint(modA, 6y + y <= z + r[6]/1.9)
+    @variable(modA, y <= 5, Int)
+    @variable(modA, 2 <= z <= 4)
+    @variable(modA, 0 <= r[i=3:6] <= i)
+    @objective(modA, Max, ((x + y)/2.0 + 3.0)/3.0 + z + r[3])
+    @constraintref constraints[1:3]
+    constraints[1] = @constraint(modA, 2 <= x+y <= 4)
+    constraints[2] = @constraint(modA, sum{r[i],i=3:5} <= (2 - x)/2.0)
+    constraints[3] = @constraint(modA, 6y + y <= z + r[6]/1.9)
     #####################################################################
     # Test LP writer
     writeLP(modA, modPath * "A.lp")
@@ -235,9 +235,9 @@ end
 
 facts("[model] Quadratic MPS writer") do
     modQ = Model()
-    @defVar(modQ, x == 1)
-    @defVar(modQ, y ≥ 0)
-    @setObjective(modQ, Min, x^2 - 2*x*y + y^2 + x)
+    @variable(modQ, x == 1)
+    @variable(modQ, y ≥ 0)
+    @objective(modQ, Min, x^2 - 2*x*y + y^2 + x)
 
     #####################################################################
     # Test MPS writer
@@ -280,14 +280,14 @@ facts("[model] Test solving a MILP") do
 for solver in ip_solvers
 context("With solver $(typeof(solver))") do
     modA = Model(solver=solver)
-    @defVar(modA, x >= 0)
-    @defVar(modA, y <= 5, Int)
-    @defVar(modA, 2 <= z <= 4)
-    @defVar(modA, 0 <= r[i=3:6] <= i)
-    @setObjective(modA, Max, ((x + y)/2.0 + 3.0)/3.0 + z + r[3])
-    @addConstraint(modA, 2 <= x+y)
-    @addConstraint(modA, sum{r[i],i=3:5} <= (2 - x)/2.0)
-    @addConstraint(modA, 7.0*y <= z + r[6]/1.9)
+    @variable(modA, x >= 0)
+    @variable(modA, y <= 5, Int)
+    @variable(modA, 2 <= z <= 4)
+    @variable(modA, 0 <= r[i=3:6] <= i)
+    @objective(modA, Max, ((x + y)/2.0 + 3.0)/3.0 + z + r[3])
+    @constraint(modA, 2 <= x+y)
+    @constraint(modA, sum{r[i],i=3:5} <= (2 - x)/2.0)
+    @constraint(modA, 7.0*y <= z + r[6]/1.9)
 
     @fact solve(modA)       --> :Optimal
     @fact modA.objVal       --> roughly(1.0+4.833334, TOL)
@@ -307,15 +307,15 @@ facts("[model] Test solving an LP (Min)") do
 for solver in lp_solvers
 context("With solver $(typeof(solver))") do
     modA = Model(solver=solver)
-    @defVar(modA, x >= 0)
-    @defVar(modA, y <= 5)
-    @defVar(modA, 2 <= z <= 4)
-    @defVar(modA, 0 <= r[i=3:6] <= i)
-    @setObjective(modA, Min, -((x + y)/2.0 + 3.0)/3.0 - z - r[3])
-    @defConstrRef cons[1:3]
-    cons[1] = @addConstraint(modA, x+y >= 2)
-    cons[2] = @addConstraint(modA, sum{r[i],i=3:5} <= (2 - x)/2.0)
-    cons[3] = @addConstraint(modA, 7.0*y <= z + r[6]/1.9)
+    @variable(modA, x >= 0)
+    @variable(modA, y <= 5)
+    @variable(modA, 2 <= z <= 4)
+    @variable(modA, 0 <= r[i=3:6] <= i)
+    @objective(modA, Min, -((x + y)/2.0 + 3.0)/3.0 - z - r[3])
+    @constraintref cons[1:3]
+    cons[1] = @constraint(modA, x+y >= 2)
+    cons[2] = @constraint(modA, sum{r[i],i=3:5} <= (2 - x)/2.0)
+    cons[3] = @constraint(modA, 7.0*y <= z + r[6]/1.9)
 
     # Solution
     @fact solve(modA) --> :Optimal
@@ -349,15 +349,15 @@ facts("[model] Test solving an LP (Max)") do
 for solver in lp_solvers
 context("With solver $(typeof(solver))") do
     modA = Model(solver=solver)
-    @defVar(modA, x >= 0)
-    @defVar(modA, y <= 5)
-    @defVar(modA, 2 <= z <= 4)
-    @defVar(modA, 0 <= r[i=3:6] <= i)
-    @setObjective(modA, Max, ((x + y)/2.0 + 3.0)/3.0 + z + r[3])
-    @defConstrRef cons[1:3]
-    cons[1] = @addConstraint(modA, x+y >= 2)
-    cons[2] = @addConstraint(modA, sum{r[i],i=3:5} <= (2 - x)/2.0)
-    cons[3] = @addConstraint(modA, 7.0*y <= z + r[6]/1.9)
+    @variable(modA, x >= 0)
+    @variable(modA, y <= 5)
+    @variable(modA, 2 <= z <= 4)
+    @variable(modA, 0 <= r[i=3:6] <= i)
+    @objective(modA, Max, ((x + y)/2.0 + 3.0)/3.0 + z + r[3])
+    @constraintref cons[1:3]
+    cons[1] = @constraint(modA, x+y >= 2)
+    cons[2] = @constraint(modA, sum{r[i],i=3:5} <= (2 - x)/2.0)
+    cons[3] = @constraint(modA, 7.0*y <= z + r[6]/1.9)
 
     # Solution
     @fact solve(modA) --> :Optimal
@@ -393,9 +393,9 @@ facts("[model] Test binary variable handling") do
 for solver in ip_solvers
 context("With solver $(typeof(solver))") do
     modB = Model(solver=solver)
-    @defVar(modB, x, Bin)
-    @setObjective(modB, Max, x)
-    @addConstraint(modB, x <= 10)
+    @variable(modB, x, Bin)
+    @objective(modB, Max, x)
+    @constraint(modB, x <= 10)
     status = solve(modB)
     @fact status --> :Optimal
     @fact getValue(x) --> roughly(1.0, TOL)
@@ -406,21 +406,21 @@ end
 
 facts("[model] Test model copying") do
     source = Model()
-    @defVar(source, 2 <= x <= 5)
-    @defVar(source, 0 <= y <= 1, Int)
-    @setObjective(source, Max, 3*x + 1*y)
-    @addConstraint(source, x + 2.0*y <= 6)
-    @addConstraint(source, x*x <= 1)
+    @variable(source, 2 <= x <= 5)
+    @variable(source, 0 <= y <= 1, Int)
+    @objective(source, Max, 3*x + 1*y)
+    @constraint(source, x + 2.0*y <= 6)
+    @constraint(source, x*x <= 1)
     addSOS2(source, [x, 2y])
-    @addSDPConstraint(source, x*ones(3,3) >= eye(3,3))
-    @addSDPConstraint(source, ones(3,3) <= 0)
-    @defVar(source, z[1:3])
-    @defVar(source, w[2:4]) # JuMPArray
-    @defVar(source, v[[:red],i=1:3;isodd(i)]) # JuMPDict
+    @SDconstraint(source, x*ones(3,3) >= eye(3,3))
+    @SDconstraint(source, ones(3,3) <= 0)
+    @variable(source, z[1:3])
+    @variable(source, w[2:4]) # JuMPArray
+    @variable(source, v[[:red],i=1:3;isodd(i)]) # JuMPDict
     setSolveHook(source, m -> :Optimal)
 
     # uncomment when NLP copying is implemented
-    # @addNLConstraint(source, c[k=1:3], x^2 + y^3 * sin(x+k*y) >= 1)
+    # @NLconstraint(source, c[k=1:3], x^2 + y^3 * sin(x+k*y) >= 1)
 
     dest = copy(source)
 
@@ -430,13 +430,13 @@ facts("[model] Test model copying") do
     # end
 
     # Obj
-    @setObjective(source, Max, 1x)
+    @objective(source, Max, 1x)
     @fact length(source.obj.aff.coeffs) --> 1
     @fact length(dest.obj.aff.coeffs) --> 2
-    @setObjective(dest, Max, 1x)
+    @objective(dest, Max, 1x)
     @fact length(source.obj.aff.coeffs) --> 1
     @fact length(dest.obj.aff.coeffs) --> 1
-    @setObjective(dest, Max, 3*x + 1*y)
+    @objective(dest, Max, 3*x + 1*y)
     @fact length(source.obj.aff.coeffs) --> 1
     @fact length(dest.obj.aff.coeffs) --> 2
 
@@ -485,89 +485,89 @@ end
 
 facts("[model] Test variable/model 'hygiene'") do
 context("Linear constraint") do
-    modA = Model(); @defVar(modA, x)
-    modB = Model(); @defVar(modB, y)
-    @addConstraint(modA, x+y == 1)
+    modA = Model(); @variable(modA, x)
+    modB = Model(); @variable(modB, y)
+    @constraint(modA, x+y == 1)
     @fact_throws solve(modA)
 end
 context("Linear objective") do
-    modA = Model(); @defVar(modA, 0 <= x <= 1)
-    modB = Model(); @defVar(modB, 0 <= y <= 1)
-    @setObjective(modA, Min, x + y)
+    modA = Model(); @variable(modA, 0 <= x <= 1)
+    modB = Model(); @variable(modB, 0 <= y <= 1)
+    @objective(modA, Min, x + y)
     @fact_throws solve(modA)
 end
 context("Quadratic constraint") do
-    modA = Model(); @defVar(modA, x)
-    modB = Model(); @defVar(modB, y)
-    @addConstraint(modB, x*y >= 1)
+    modA = Model(); @variable(modA, x)
+    modB = Model(); @variable(modB, y)
+    @constraint(modB, x*y >= 1)
     @fact_throws solve(modB)
 end
 context("Affine in quadratic constraint") do
-    modA = Model(); @defVar(modA, x)
-    modB = Model(); @defVar(modB, y)
-    @addConstraint(modB, y*y + x + y <= 1)
+    modA = Model(); @variable(modA, x)
+    modB = Model(); @variable(modB, y)
+    @constraint(modB, y*y + x + y <= 1)
     @fact_throws solve(modB)
 end
 context("Quadratic objective") do
-    modA = Model(); @defVar(modA, x)
-    modB = Model(); @defVar(modB, y)
-    @setObjective(modB, Min, x*y)
+    modA = Model(); @variable(modA, x)
+    modB = Model(); @variable(modB, y)
+    @objective(modB, Min, x*y)
     @fact_throws solve(modB)
 end
 end
 
 facts("[model] Test NaN checking") do
     mod = Model()
-    @defVar(mod, x)
-    @setObjective(mod, Min, NaN*x)
+    @variable(mod, x)
+    @objective(mod, Min, NaN*x)
     @fact_throws solve(mod)
     setObjective(mod, :Min, NaN*x^2)
     @fact_throws solve(mod)
-    @setObjective(mod, Min, x)
-    @addConstraint(mod, Min, NaN*x == 0)
+    @objective(mod, Min, x)
+    @constraint(mod, Min, NaN*x == 0)
     @fact_throws solve(mod)
 end
 
 facts("[model] Test column-wise modeling") do
     mod = Model()
-    @defVar(mod, 0 <= x <= 1)
-    @defVar(mod, 0 <= y <= 1)
-    @setObjective(mod, Max, 5x + 1y)
-    @addConstraint(mod, con[i=1:2], i*x + y <= i+5)
-    @defVar(mod, 0 <= z1 <= 1, objective=10.0, inconstraints=con, coefficients=[1.0,-2.0])
-    @defVar(mod, 0 <= z2 <= 1, objective=10.0, inconstraints=Any[con[i] for i in 1:2], coefficients=[1.0,-2.0])
+    @variable(mod, 0 <= x <= 1)
+    @variable(mod, 0 <= y <= 1)
+    @objective(mod, Max, 5x + 1y)
+    @constraint(mod, con[i=1:2], i*x + y <= i+5)
+    @variable(mod, 0 <= z1 <= 1, objective=10.0, inconstraints=con, coefficients=[1.0,-2.0])
+    @variable(mod, 0 <= z2 <= 1, objective=10.0, inconstraints=Any[con[i] for i in 1:2], coefficients=[1.0,-2.0])
     @fact solve(mod) --> :Optimal
     @fact getValue(z1) --> roughly(1.0, TOL)
     @fact getValue(z2) --> roughly(1.0, TOL)
 
     # do a vectorized version as well
     mod = Model()
-    @defVar(mod, 0 <= x <= 1)
-    @defVar(mod, 0 <= y <= 1)
+    @variable(mod, 0 <= x <= 1)
+    @variable(mod, 0 <= y <= 1)
     obj = [5,1]'*[x,y]
-    @setObjective(mod, Max, obj[1])
+    @objective(mod, Max, obj[1])
     A = [1 1
          2 1]
-    @addConstraint(mod, A*[x,y] .<= [6,7])
-    @defVar(mod, 0 <= z1 <= 1, objective=10.0, inconstraints=con, coefficients=[1.0,-2.0])
-    @defVar(mod, 0 <= z2 <= 1, objective=10.0, inconstraints=Any[con[i] for i in 1:2], coefficients=[1.0,-2.0])
+    @constraint(mod, A*[x,y] .<= [6,7])
+    @variable(mod, 0 <= z1 <= 1, objective=10.0, inconstraints=con, coefficients=[1.0,-2.0])
+    @variable(mod, 0 <= z2 <= 1, objective=10.0, inconstraints=Any[con[i] for i in 1:2], coefficients=[1.0,-2.0])
     @fact solve(mod) --> :Optimal
     @fact getValue(z1) --> roughly(1.0, TOL)
     @fact getValue(z2) --> roughly(1.0, TOL)
 
     # vectorized with sparse matrices
     mod = Model()
-    @defVar(mod, 0 <= x <= 1)
-    @defVar(mod, 0 <= y <= 1)
+    @variable(mod, 0 <= x <= 1)
+    @variable(mod, 0 <= y <= 1)
     # TODO: get this to work by adding method for Ac_mul_B!
     # obj = sparse([5,1])'*[x,y]
     obj = sparse([5,1]')*[x,y]
-    @setObjective(mod, Max, obj[1])
+    @objective(mod, Max, obj[1])
     A = sparse([1 1
                 2 1])
-    @addConstraint(mod, A*[x,y] .<= [6,7])
-    @defVar(mod, 0 <= z1 <= 1, objective=10.0, inconstraints=con, coefficients=[1.0,-2.0])
-    @defVar(mod, 0 <= z2 <= 1, objective=10.0, inconstraints=Any[con[i] for i in 1:2], coefficients=[1.0,-2.0])
+    @constraint(mod, A*[x,y] .<= [6,7])
+    @variable(mod, 0 <= z1 <= 1, objective=10.0, inconstraints=con, coefficients=[1.0,-2.0])
+    @variable(mod, 0 <= z2 <= 1, objective=10.0, inconstraints=Any[con[i] for i in 1:2], coefficients=[1.0,-2.0])
     @fact solve(mod) --> :Optimal
     @fact getValue(z1) --> roughly(1.0, TOL)
     @fact getValue(z2) --> roughly(1.0, TOL)
@@ -575,23 +575,23 @@ end
 
 facts("[model] Test all MPS paths") do
     mod = Model()
-    @defVar(mod, free_var)
-    @defVar(mod, int_var, Bin)
-    @defVar(mod, low_var >= 5)
-    @addConstraint(mod, free_var == int_var)
-    @addConstraint(mod, free_var - int_var >= 0)
+    @variable(mod, free_var)
+    @variable(mod, int_var, Bin)
+    @variable(mod, low_var >= 5)
+    @constraint(mod, free_var == int_var)
+    @constraint(mod, free_var - int_var >= 0)
     setObjective(mod, :Max, free_var*int_var + low_var)
     writeMPS(mod,"test.mps")
 end
 
 facts("[model] Test all LP paths") do
     mod = Model()
-    @defVar(mod, free_var)
+    @variable(mod, free_var)
     setObjective(mod, :Max, free_var*free_var)
     @fact_throws writeLP(mod,"test.lp")
-    @setObjective(mod, Max, free_var)
-    @addConstraint(mod, free_var - 2*free_var == 0)
-    @addConstraint(mod, free_var + 2*free_var >= 1)
+    @objective(mod, Max, free_var)
+    @constraint(mod, free_var - 2*free_var == 0)
+    @constraint(mod, free_var + 2*free_var >= 1)
     writeLP(mod,"test.lp")
 end
 
@@ -599,10 +599,10 @@ facts("[model] Test semi-continuous variables") do
 for solver in semi_solvers
 context("With solver $(typeof(solver))") do
     mod = Model(solver=solver)
-    @defVar(mod, x >= 3, SemiCont)
-    @defVar(mod, y >= 2, SemiCont)
-    @addConstraint(mod, x + y >= 1)
-    @setObjective(mod, Min, x+y)
+    @variable(mod, x >= 3, SemiCont)
+    @variable(mod, y >= 2, SemiCont)
+    @constraint(mod, x + y >= 1)
+    @objective(mod, Min, x+y)
     solve(mod)
     @fact getValue(x) --> roughly(0.0, TOL)
     @fact getValue(y) --> roughly(2.0, TOL)
@@ -612,10 +612,10 @@ facts("[model] Test semi-integer variables") do
 for solver in semi_solvers
 context("With solver $(typeof(solver))") do
     mod = Model(solver=solver)
-    @defVar(mod, x >= 3, SemiInt)
-    @defVar(mod, y >= 2, SemiInt)
-    @addConstraint(mod, x + y >= 2.5)
-    @setObjective(mod, Min, x+1.1y)
+    @variable(mod, x >= 3, SemiInt)
+    @variable(mod, y >= 2, SemiInt)
+    @constraint(mod, x + y >= 2.5)
+    @objective(mod, Min, x+1.1y)
     solve(mod)
     @fact getValue(x) --> roughly(3.0, TOL)
     @fact getValue(y) --> 0.0
@@ -625,9 +625,9 @@ facts("[model] Test fixed variables don't leak through MPB") do
 for solver in lp_solvers
 context("With solver $(typeof(solver))") do
     mod = Model(solver=solver)
-    @defVar(mod, 0 <= x[1:3] <= 2)
-    @defVar(mod, y[k=1:2] == k)
-    @setObjective(mod, Min, x[1] + x[2] + x[3] + y[1] + y[2])
+    @variable(mod, 0 <= x[1:3] <= 2)
+    @variable(mod, y[k=1:2] == k)
+    @objective(mod, Min, x[1] + x[2] + x[3] + y[1] + y[2])
     solve(mod)
     for i in 1:3
         @fact getValue(x[i]) --> roughly(0, TOL)
@@ -639,8 +639,8 @@ end; end
 for solver in ip_solvers
 context("With solver $(typeof(solver))") do
     mod = Model(solver=solver)
-    @defVar(mod, x[1:3], Bin)
-    @defVar(mod, y[k=1:2] == k)
+    @variable(mod, x[1:3], Bin)
+    @variable(mod, y[k=1:2] == k)
     buildInternalModel(mod)
     @fact MathProgBase.getvartype(getInternalModel(mod)) --> [:Bin,:Bin,:Bin,:Cont,:Cont]
 end; end; end
@@ -651,18 +651,18 @@ for solver in sos_solvers
 context("With solver $(typeof(solver))") do
     modS = Model(solver=solver)
 
-    @defVar(modS, x[1:3], Bin)
-    @defVar(modS, y[1:5], Bin)
-    @defVar(modS, z)
-    @defVar(modS, w)
+    @variable(modS, x[1:3], Bin)
+    @variable(modS, y[1:5], Bin)
+    @variable(modS, z)
+    @variable(modS, w)
 
     setObjective(modS, :Max, z+w)
 
     a = [1,2,3]
     b = [5,4,7,2,1]
 
-    @addConstraint(modS, z == sum{a[i]*x[i], i=1:3})
-    @addConstraint(modS, w == sum{b[i]*y[i], i=1:5})
+    @constraint(modS, z == sum{a[i]*x[i], i=1:3})
+    @constraint(modS, w == sum{b[i]*y[i], i=1:5})
 
     @fact_throws constructSOS([x[1]+y[1]])
     @fact_throws constructSOS([1z])
@@ -680,8 +680,8 @@ context("With solver $(typeof(solver))") do
 
     m = Model(solver=solver)
     ub = [1,1,2]
-    @defVar(m, x[i=1:3] <= ub[i])
-    @setObjective(m, Max, 2x[1]+x[2]+x[3])
+    @variable(m, x[i=1:3] <= ub[i])
+    @objective(m, Max, 2x[1]+x[2]+x[3])
     addSOS1(m, [x[1],2x[2]])
     addSOS1(m, [x[1],2x[3]])
 
@@ -695,20 +695,20 @@ facts("[model] Test vectorized model creation") do
     A = sprand(50,10,0.15)
     B = sprand(50, 7,0.2)
     modV = Model()
-    @defVar(modV, x[1:10])
-    @defVar(modV, y[1:7])
-    @addConstraint(modV, A*x + B*y .<= 1)
+    @variable(modV, x[1:10])
+    @variable(modV, y[1:7])
+    @constraint(modV, A*x + B*y .<= 1)
     obj = (x'*2A')*(2A*x) + (B*2y)'*(B*(2y))
-    @setObjective(modV, Max, obj[1])
+    @objective(modV, Max, obj[1])
 
     modS = Model()
-    @defVar(modS, x[1:10])
-    @defVar(modS, y[1:7])
+    @variable(modS, x[1:10])
+    @variable(modS, y[1:7])
     for i in 1:50
-        @addConstraint(modS, sum{A[i,j]*x[j], j=1:10} + sum{B[i,k]*y[k], k=1:7} <= 1)
+        @constraint(modS, sum{A[i,j]*x[j], j=1:10} + sum{B[i,k]*y[k], k=1:7} <= 1)
     end
     AA, BB = 4A'*A, 4B'*A
-    @setObjective(modS, Max, sum{AA[i,j]*x[i]*x[j], i=1:10,j=1:10} + sum{BB[i,j]*y[i]*y[j], i=1:7, j=1:7})
+    @objective(modS, Max, sum{AA[i,j]*x[i]*x[j], i=1:10,j=1:10} + sum{BB[i,j]*y[i]*y[j], i=1:7, j=1:7})
 
     @fact JuMP.prepConstrMatrix(modV) --> JuMP.prepConstrMatrix(modS)
     @fact JuMP.prepProblemBounds(modV) --> JuMP.prepProblemBounds(modS)
@@ -719,17 +719,17 @@ facts("[model] Test MIQP vectorization") do
     p = 4
     function bestsubset(solver,X,y,K,M,integer)
         mod = Model(solver=solver)
-        @defVar(mod, β[1:p])
+        @variable(mod, β[1:p])
         if integer
-            @defVar(mod, z[1:p], Bin)
+            @variable(mod, z[1:p], Bin)
         else
-            @defVar(mod, 0 <= z[1:p] <= 1)
+            @variable(mod, 0 <= z[1:p] <= 1)
         end
         obj = (y-X*β)'*(y-X*β)
-        @setObjective(mod, Min, obj[1])
-        @addConstraint(mod, eye(p)*β .<=  M*eye(p)*z)
-        @addConstraint(mod, eye(p)*β .>= -M*eye(p)*z)
-        @addConstraint(mod, sum(z) == K)
+        @objective(mod, Min, obj[1])
+        @constraint(mod, eye(p)*β .<=  M*eye(p)*z)
+        @constraint(mod, eye(p)*β .>= -M*eye(p)*z)
+        @constraint(mod, sum(z) == K)
         solve(mod)
         return getValue(β)[:]
     end
@@ -748,8 +748,8 @@ end
 
 facts("[model] Test setSolver") do
     m = Model()
-    @defVar(m, x[1:5])
-    @addConstraint(m, con[i=1:5], x[6-i] == i)
+    @variable(m, x[1:5])
+    @constraint(m, con[i=1:5], x[6-i] == i)
     @fact solve(m) --> :Optimal
 
     for solver in lp_solvers
@@ -764,7 +764,7 @@ end
 
 facts("[model] Setting solve hook") do
     m = Model()
-    @defVar(m, x ≥ 0)
+    @variable(m, x ≥ 0)
     dummy = [1]
     kwarglist = Any[]
     function solvehook(m::Model; kwargs...)
@@ -780,7 +780,7 @@ end
 
 facts("[model] Setting print hook") do
     m = Model()
-    @defVar(m, x ≥ 0)
+    @variable(m, x ≥ 0)
     dummy = [1]
     function printhook(io::IO, m::Model)
         dummy[1] += 1
@@ -792,7 +792,7 @@ end
 
 facts("[model] Test getLinearIndex") do
     m = Model()
-    @defVar(m, x[1:5])
+    @variable(m, x[1:5])
     for i in 1:5
         @fact isequal(Variable(m,getLinearIndex(x[i])),x[i]) --> true
     end
@@ -800,27 +800,27 @@ end
 
 facts("[model] Test LinearConstraint from ConstraintRef") do
     m = Model()
-    @defVar(m, x)
-    @addConstraint(m, constr, x == 1)
+    @variable(m, x)
+    @constraint(m, constr, x == 1)
     real_constr = LinearConstraint(constr)
     @fact real_constr.terms --> @LinearConstraint(x == 1).terms
 end
 
 facts("[model] Test getValue on OneIndexedArrays") do
     m = Model()
-    @defVar(m, x[i=1:5], start=i)
+    @variable(m, x[i=1:5], start=i)
     @fact typeof(x) --> Vector{Variable}
     @fact typeof(getValue(x)) --> Vector{Float64}
 end
 
 facts("[model] Relaxation keyword argument to solve") do
     m = Model()
-    @defVar(m, 1.5 <= y <= 2, Int)
-    @defVar(m, z, Bin)
-    @defVar(m, 0.5 <= w <= 1.5, Int)
-    @defVar(m, 1 <= v <= 2)
+    @variable(m, 1.5 <= y <= 2, Int)
+    @variable(m, z, Bin)
+    @variable(m, 0.5 <= w <= 1.5, Int)
+    @variable(m, 1 <= v <= 2)
 
-    @setObjective(m, Min, y + z + w + v)
+    @objective(m, Min, y + z + w + v)
 
     # Force LP solver since not all MIP solvers
     # return duals (i.e. Cbc)
@@ -845,11 +845,11 @@ facts("[model] Relaxation keyword argument to solve") do
     @fact getValue(v) --> 1
     @fact getObjectiveValue(m) --> 2 + 0 + 1 + 1
 
-    @defVar(m, 1 <= x <= 2, SemiCont)
-    @defVar(m, -2 <= t <= -1, SemiInt)
+    @variable(m, 1 <= x <= 2, SemiCont)
+    @variable(m, -2 <= t <= -1, SemiInt)
 
     addSOS1(m, [x, 2y, 3z, 4w, 5v, 6t])
-    @setObjective(m, Min, x + y + z + w + v - t)
+    @objective(m, Min, x + y + z + w + v - t)
 
     @fact solve(m, relaxation=true) --> :Optimal
 

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -17,10 +17,10 @@ using JuMP, FactCheck
 
 facts("[nonlinear] Test getValue on arrays") do
     m = Model()
-    @defVar(m, x, start = π/2)
-    @defNLExpr(m, f1, sin(x))
-    @defNLExpr(m, f2, sin(2x))
-    @defNLExpr(m, f3[i=1:2], sin(i*x))
+    @variable(m, x, start = π/2)
+    @NLexpression(m, f1, sin(x))
+    @NLexpression(m, f2, sin(2x))
+    @NLexpression(m, f3[i=1:2], sin(i*x))
 
     @fact getValue(f1) --> roughly(1, 1e-5)
     @fact getValue(f2) --> roughly(0, 1e-5)
@@ -28,7 +28,7 @@ facts("[nonlinear] Test getValue on arrays") do
     @fact getValue([f1, f2]) --> getValue(f3)
 
     v = [1.0, 2.0]
-    @defNLParam(m, vparam[i=1:2] == v[i])
+    @NLparameter(m, vparam[i=1:2] == v[i])
     @fact getValue(vparam) --> v
     v[1] = 3.0
     setValue(vparam, v)
@@ -48,10 +48,10 @@ context("With solver $(typeof(nlp_solver))") do
     # End at (1.000..., 4.743..., 3.821..., 1.379...)
     m = Model(solver=nlp_solver)
     initval = [1,5,5,1]
-    @defVar(m, 1 <= x[i=1:4] <= 5, start=initval[i])
-    @setNLObjective(m, Min, x[1]*x[4]*(x[1]+x[2]+x[3]) + x[3])
-    @addNLConstraint(m, x[1]*x[2]*x[3]*x[4] >= 25)
-    @addNLConstraint(m, sum{x[i]^2,i=1:4} == 40)
+    @variable(m, 1 <= x[i=1:4] <= 5, start=initval[i])
+    @NLobjective(m, Min, x[1]*x[4]*(x[1]+x[2]+x[3]) + x[3])
+    @NLconstraint(m, x[1]*x[2]*x[3]*x[4] >= 25)
+    @NLconstraint(m, sum{x[i]^2,i=1:4} == 40)
     @fact MathProgBase.numconstr(m) --> 2
     status = solve(m)
 
@@ -71,12 +71,12 @@ context("With solver $(typeof(nlp_solver))") do
         #     ...
         m = Model(solver=nlp_solver)
         start = [1.0, 5.0, 5.0, 1.0]
-        @defVar(m, 1 <= x[i=1:4] <= 5, start = start[i])
-        @defVar(m, t, start = 100)
-        @setObjective(m, Min, t)
-        @addNLConstraint(m, t >= x[1]*x[4]*(x[1]+x[2]+x[3]) + x[3])
-        @addNLConstraint(m, x[1]*x[2]*x[3]*x[4] >= 25)
-        @addNLConstraint(m, sum{x[i]^2,i=1:4} == 40)
+        @variable(m, 1 <= x[i=1:4] <= 5, start = start[i])
+        @variable(m, t, start = 100)
+        @objective(m, Min, t)
+        @NLconstraint(m, t >= x[1]*x[4]*(x[1]+x[2]+x[3]) + x[3])
+        @NLconstraint(m, x[1]*x[2]*x[3]*x[4] >= 25)
+        @NLconstraint(m, sum{x[i]^2,i=1:4} == 40)
         status = solve(m)
 
         @fact status --> :Optimal
@@ -89,9 +89,9 @@ for nlp_solver in nlp_solvers
 (contains("$(typeof(nlp_solver))", "OsilSolver") || contains("$(typeof(nlp_solver))", "NLoptSolver")) && continue
 context("With solver $(typeof(nlp_solver))") do
         m = Model(solver=nlp_solver)
-        @defVar(m, x, start = 2)
+        @variable(m, x, start = 2)
         # minimizer at smooth point, solvers should be okay
-        @setNLObjective(m, Min, ifelse( x <= 1, x^2, x) )
+        @NLobjective(m, Min, ifelse( x <= 1, x^2, x) )
         status = solve(m)
 
         @fact status --> :Optimal
@@ -103,10 +103,10 @@ for nlp_solver in convex_nlp_solvers
 for simplify in [true, false]
 context("With solver $(typeof(nlp_solver)), simplify = $simplify") do
     m = Model(solver=nlp_solver, simplify_nonlinear_expressions=simplify)
-    @defVar(m, x == 0)
-    @defVar(m, y ≥ 0)
-    @setObjective(m, Min, y)
-    @addNLConstraint(m, y ≥ x^2)
+    @variable(m, x == 0)
+    @variable(m, y ≥ 0)
+    @objective(m, Min, y)
+    @NLconstraint(m, y ≥ x^2)
     EnableNLPResolve()
     for α in 1:4
         setValue(x, α)
@@ -122,16 +122,16 @@ context("With solver $(typeof(nlp_solver))") do
     # Solve a problem with quadratic objective with linear
     # constraints, but force it to use the nonlinear code.
     m = Model(solver=nlp_solver)
-    @defVar(m, 0.5 <= x <=  2)
-    @defVar(m, 0.0 <= y <= 30)
-    @defNLParam(m, param == 1.0)
-    @setObjective(m, Min, (x+y)^2)
-    @addNLConstraint(m, x + y >= param)
+    @variable(m, 0.5 <= x <=  2)
+    @variable(m, 0.0 <= y <= 30)
+    @NLparameter(m, param == 1.0)
+    @objective(m, Min, (x+y)^2)
+    @NLconstraint(m, x + y >= param)
     status = solve(m)
 
     @fact status --> :Optimal
     @fact m.objVal --> roughly(1.0, 1e-6)
-    @defNLExpr(m, lhs, x+y)
+    @NLexpression(m, lhs, x+y)
     @fact getValue(x)+getValue(y) --> roughly(1.0, 1e-6)
     @fact getValue(lhs) --> roughly(1.0, 1e-6)
 
@@ -151,10 +151,10 @@ context("With solver $(typeof(nlp_solver))") do
     # Solve a problem with linear objective with quadratic
     # constraints, but force it to use the nonlinear code.
     m = Model(solver=nlp_solver)
-    @defVar(m, -2 <= x <= 2)
-    @defVar(m, -2 <= y <= 2)
-    @setNLObjective(m, Min, x - y)
-    @addConstraint(m, x + x^2 + x*y + y^2 <= 1)
+    @variable(m, -2 <= x <= 2)
+    @variable(m, -2 <= y <= 2)
+    @NLobjective(m, Min, x - y)
+    @constraint(m, x + x^2 + x*y + y^2 <= 1)
     status = solve(m)
 
     @fact status --> :Optimal
@@ -167,9 +167,9 @@ for nlp_solver in convex_nlp_solvers
 for simplify in [true,false]
 context("With solver $(typeof(nlp_solver)), simplify = $simplify") do
     m = Model(solver=nlp_solver, simplify_nonlinear_expressions=simplify)
-    @defVar(m, z)
-    @defNLParam(m, x == 1.0)
-    @setNLObjective(m, Min, (z-x)^2)
+    @variable(m, z)
+    @NLparameter(m, x == 1.0)
+    @NLobjective(m, Min, (z-x)^2)
     status = solve(m)
     @fact status --> :Optimal
     @fact getValue(z) --> roughly(1.0, 1e-3)
@@ -184,17 +184,17 @@ facts("[nonlinear] Test two-sided nonlinear constraints") do
 for nlp_solver in convex_nlp_solvers
 context("With solver $(typeof(nlp_solver))") do
     m = Model(solver=nlp_solver)
-    @defVar(m, x)
-    @setNLObjective(m, Max, x)
+    @variable(m, x)
+    @NLobjective(m, Max, x)
     l = -1
     u = 1
-    @addNLConstraint(m, l <= x <= u)
+    @NLconstraint(m, l <= x <= u)
     status = solve(m)
 
     @fact status --> :Optimal
     @fact getObjectiveValue(m) --> roughly(u, 1e-6)
 
-    @setNLObjective(m, Min, x)
+    @NLobjective(m, Min, x)
     status = solve(m)
 
     @fact status --> :Optimal
@@ -205,9 +205,9 @@ facts("[nonlinear] Quadratic equality constraints") do
 for nlp_solver in nlp_solvers
 context("With solver $(typeof(nlp_solver))") do
     m = Model(solver=nlp_solver)
-    @defVar(m, 0 <= x[1:2] <= 1)
-    @addConstraint(m, x[1]^2 + x[2]^2 == 1/2)
-    @setNLObjective(m, Max, x[1] - x[2])
+    @variable(m, 0 <= x[1:2] <= 1)
+    @constraint(m, x[1]^2 + x[2]^2 == 1/2)
+    @NLobjective(m, Max, x[1] - x[2])
     status = solve(m)
 
     @fact status --> :Optimal
@@ -224,10 +224,10 @@ context("With solver $(typeof(minlp_solver))") do
      # problem synthes1 in the MacMINLP test set.
     m = Model(solver=minlp_solver)
     x_U = [2,2,1]
-    @defVar(m, x_U[i] >= x[i=1:3] >= 0)
-    @defVar(m, y[4:6], Bin)
-    @setNLObjective(m, Min, 10 + 10*x[1] - 7*x[3] + 5*y[4] + 6*y[5] + 8*y[6] - 18*log(x[2]+1) - 19.2*log(x[1]-x[2]+1))
-    @addNLConstraints(m, begin
+    @variable(m, x_U[i] >= x[i=1:3] >= 0)
+    @variable(m, y[4:6], Bin)
+    @NLobjective(m, Min, 10 + 10*x[1] - 7*x[3] + 5*y[4] + 6*y[5] + 8*y[6] - 18*log(x[2]+1) - 19.2*log(x[1]-x[2]+1))
+    @NLconstraints(m, begin
         0.8*log(x[2] + 1) + 0.96*log(x[1] - x[2] + 1) - 0.8*x[3] >= 0
         log(x[2] + 1) + 1.2*log(x[1] - x[2] + 1) - x[3] - 2*y[6] >= -2
         x[2] - x[1] <= 0
@@ -254,11 +254,11 @@ context("With solver $(typeof(nlp_solver))") do
      # Introduce auxiliary nonnegative variable for the x[1]-x[2]+1 term
     m = Model(solver=nlp_solver)
     x_U = [2,2,1]
-    @defVar(m, x_U[i] >= x[i=1:3] >= 0)
-    @defVar(m, 1 >= y[4:6] >= 0)
-    @defVar(m, z >= 0, start=1)
-    @setNLObjective(m, Min, 10 + 10*x[1] - 7*x[3] + 5*y[4] + 6*y[5] + 8*y[6] - 18*log(x[2]+1) - 19.2*log(z))
-    @addNLConstraints(m, begin
+    @variable(m, x_U[i] >= x[i=1:3] >= 0)
+    @variable(m, 1 >= y[4:6] >= 0)
+    @variable(m, z >= 0, start=1)
+    @NLobjective(m, Min, 10 + 10*x[1] - 7*x[3] + 5*y[4] + 6*y[5] + 8*y[6] - 18*log(x[2]+1) - 19.2*log(z))
+    @NLconstraints(m, begin
         0.8*log(x[2] + 1) + 0.96*log(z) - 0.8*x[3] >= 0
         log(x[2] + 1) + 1.2*log(z) - x[3] - 2*y[6] >= -2
         x[2] - x[1] <= 0
@@ -281,10 +281,10 @@ for nlp_solver in convex_nlp_solvers
 context("With solver $(typeof(nlp_solver))") do
     # Solve a simple problem with a maximization objective
     m = Model(solver=nlp_solver)
-    @defVar(m, -2 <= x <= 2); setValue(x, -1.8)
-    @defVar(m, -2 <= y <= 2); setValue(y,  1.5)
-    @setNLObjective(m, Max, y - x)
-    @addConstraint(m, x + x^2 + x*y + y^2 <= 1)
+    @variable(m, -2 <= x <= 2); setValue(x, -1.8)
+    @variable(m, -2 <= y <= 2); setValue(y,  1.5)
+    @NLobjective(m, Max, y - x)
+    @constraint(m, x + x^2 + x*y + y^2 <= 1)
 
     @fact solve(m) --> :Optimal
     @fact getObjectiveValue(m) --> roughly(1+4/sqrt(3), 1e-6)
@@ -296,19 +296,19 @@ for nlp_solver in convex_nlp_solvers
 for simplify in [true,false]
 context("With solver $(typeof(nlp_solver)), simplify = $simplify") do
     m = Model(solver=nlp_solver, simplify_nonlinear_expressions=simplify)
-    @defVar(m, -2 <= x <= 2); setValue(x, -1.8)
-    @defVar(m, -2 <= y <= 2); setValue(y,  1.5)
-    @setNLObjective(m, Max, y - x)
-    @defNLExpr(m, quadexpr, x + x^2 + x*y + y^2)
-    @addNLConstraint(m, quadexpr <= 1)
+    @variable(m, -2 <= x <= 2); setValue(x, -1.8)
+    @variable(m, -2 <= y <= 2); setValue(y,  1.5)
+    @NLobjective(m, Max, y - x)
+    @NLexpression(m, quadexpr, x + x^2 + x*y + y^2)
+    @NLconstraint(m, quadexpr <= 1)
 
     @fact solve(m) --> :Optimal
     @fact getObjectiveValue(m) --> roughly(1+4/sqrt(3), 1e-6)
     @fact getValue(x) + getValue(y) --> roughly(-1/3, 1e-3)
     @fact getValue(quadexpr) --> roughly(1, 1e-5)
-    @defNLExpr(quadexpr2, x + x^2 + x*y + y^2)
+    @NLexpression(quadexpr2, x + x^2 + x*y + y^2)
     @fact getValue(quadexpr2) --> roughly(1, 1e-5)
-    quadexpr3 = @defNLExpr(x + x^2 + x*y + y^2)
+    quadexpr3 = @NLexpression(x + x^2 + x*y + y^2)
     @fact getValue(quadexpr3) --> roughly(1, 1e-5)
 end; end; end; end
 
@@ -320,10 +320,10 @@ context("With solver $(typeof(nlp_solver))") do
     # (Attempt to) solve an infeasible problem
     m = Model(solver=nlp_solver)
     n = 10
-    @defVar(m, 0 <= x[i=1:n] <= 1)
-    @setNLObjective(m, Max, x[n])
+    @variable(m, 0 <= x[i=1:n] <= 1)
+    @NLobjective(m, Max, x[n])
     for i in 1:n-1
-        @addNLConstraint(m, x[i+1]-x[i] == 0.15)
+        @NLconstraint(m, x[i+1]-x[i] == 0.15)
     end
     @fact solve(m, suppress_warnings=true) --> :Infeasible
 end; end; end
@@ -335,9 +335,9 @@ contains(string(typeof(nlp_solver)),"NLoptSolver") && continue
 context("With solver $(typeof(nlp_solver))") do
     # (Attempt to) solve an unbounded problem
     m = Model(solver=nlp_solver)
-    @defVar(m, x >= 0)
-    @setNLObjective(m, Max, x)
-    @addNLConstraint(m, x >= 5)
+    @variable(m, x >= 0)
+    @NLobjective(m, Max, x)
+    @NLconstraint(m, x >= 5)
     @fact solve(m, suppress_warnings=true) --> :Unbounded
 end; end; end
 
@@ -346,10 +346,10 @@ for nlp_solver in convex_nlp_solvers
 context("With solver $(typeof(nlp_solver))") do
     m = Model(solver=nlp_solver)
     N = 3
-    @defVar(m, x[1:N] >= 0, start = 1)
-    @defNLExpr(m, entropy[i=1:N], -x[i]*log(x[i]))
-    @setNLObjective(m, Max, sum{entropy[i], i = 1:N})
-    @addConstraint(m, sum(x) == 1)
+    @variable(m, x[1:N] >= 0, start = 1)
+    @NLexpression(m, entropy[i=1:N], -x[i]*log(x[i]))
+    @NLobjective(m, Max, sum{entropy[i], i = 1:N})
+    @constraint(m, sum(x) == 1)
 
     @fact solve(m) --> :Optimal
     @fact norm(getValue(x)[:] - [1/3,1/3,1/3]) --> roughly(0.0, 1e-4)
@@ -360,19 +360,19 @@ for nlp_solver in convex_nlp_solvers
 context("With solver $(typeof(nlp_solver))") do
     m = Model(solver=nlp_solver)
     idx = [1,2,3,4]
-    @defVar(m, x[idx] >= 0, start = 1)
-    @defVar(m, z[1:4], start = 0)
-    @defNLExpr(m, entropy[i=idx], -x[i]*log(x[i]))
-    @setNLObjective(m, Max, sum{z[i], i = 1:2} + sum{z[i]/2, i=3:4})
-    @addNLConstraint(m, z_constr1[i=1], z[i] <= entropy[i])
-    @addNLConstraint(m, z_constr1[i=2], z[i] <= entropy[i]) # duplicate expressions
-    @addNLConstraint(m, z_constr2[i=3:4], z[i] <= 2*entropy[i])
-    @addConstraint(m, sum(x) == 1)
+    @variable(m, x[idx] >= 0, start = 1)
+    @variable(m, z[1:4], start = 0)
+    @NLexpression(m, entropy[i=idx], -x[i]*log(x[i]))
+    @NLobjective(m, Max, sum{z[i], i = 1:2} + sum{z[i]/2, i=3:4})
+    @NLconstraint(m, z_constr1[i=1], z[i] <= entropy[i])
+    @NLconstraint(m, z_constr1[i=2], z[i] <= entropy[i]) # duplicate expressions
+    @NLconstraint(m, z_constr2[i=3:4], z[i] <= 2*entropy[i])
+    @constraint(m, sum(x) == 1)
 
     @fact solve(m) --> :Optimal
     @fact norm([getValue(x[i]) for i in idx] - [1/4,1/4,1/4,1/4]) --> roughly(0.0, 1e-4)
     @fact getValue(entropy[1]) --> roughly(-(1/4)*log(1/4), 1e-4)
-    @defNLExpr(m, zexpr[i=1:4], z[i])
+    @NLexpression(m, zexpr[i=1:4], z[i])
     @fact getValue(zexpr[1]) --> roughly(-(1/4)*log(1/4), 1e-4)
 end; end; end
 
@@ -380,8 +380,8 @@ facts("[nonlinear] Test derivatives of x^4, x < 0") do
 for nlp_solver in convex_nlp_solvers
 context("With solver $(typeof(nlp_solver))") do
     m = Model(solver=nlp_solver)
-    @defVar(m, x >= -1, start = -0.5)
-    @setNLObjective(m, Min, x^4)
+    @variable(m, x >= -1, start = -0.5)
+    @NLobjective(m, Min, x^4)
     status = solve(m)
 
     @fact status --> :Optimal
@@ -394,14 +394,14 @@ for simplify in [true,false]
 applicable(MathProgBase.getconstrduals, MathProgBase.NonlinearModel(nlp_solver)) || continue
 context("With solver $(typeof(nlp_solver)), simplify = $simplify") do
     modA = Model(solver=nlp_solver, simplify_nonlinear_expressions=simplify)
-    @defVar(modA, x >= 0)
-    @defVar(modA, y <= 5)
-    @defVar(modA, 2 <= z <= 4)
-    @defVar(modA, 0 <= r[i=3:6] <= i)
-    @setNLObjective(modA, Min, -((x + y)/2.0 + 3.0)/3.0 - z - r[3])
-    @addConstraint(modA, cons1, x+y >= 2)
-    @addConstraint(modA, cons2, sum{r[i],i=3:5} <= (2 - x)/2.0)
-    @addNLConstraint(modA, cons3, 7.0*y <= z + r[6]/1.9)
+    @variable(modA, x >= 0)
+    @variable(modA, y <= 5)
+    @variable(modA, 2 <= z <= 4)
+    @variable(modA, 0 <= r[i=3:6] <= i)
+    @NLobjective(modA, Min, -((x + y)/2.0 + 3.0)/3.0 - z - r[3])
+    @constraint(modA, cons1, x+y >= 2)
+    @constraint(modA, cons2, sum{r[i],i=3:5} <= (2 - x)/2.0)
+    @NLconstraint(modA, cons3, 7.0*y <= z + r[6]/1.9)
 
     # Solution
     @fact solve(modA) --> :Optimal
@@ -434,14 +434,14 @@ for nlp_solver in nlp_solvers
 applicable(MathProgBase.getconstrduals, MathProgBase.NonlinearModel(nlp_solver)) || continue
 context("With solver $(typeof(nlp_solver))") do
     modA = Model(solver=nlp_solver)
-    @defVar(modA, x >= 0)
-    @defVar(modA, y <= 5)
-    @defVar(modA, 2 <= z <= 4)
-    @defVar(modA, 0 <= r[i=3:6] <= i)
-    @setNLObjective(modA, Max, ((x + y)/2.0 + 3.0)/3.0 + z + r[3])
-    @addConstraint(modA, cons1, x+y >= 2)
-    @addConstraint(modA, cons2, sum{r[i],i=3:5} <= (2 - x)/2.0)
-    @addNLConstraint(modA, cons3, 7.0*y <= z + r[6]/1.9)
+    @variable(modA, x >= 0)
+    @variable(modA, y <= 5)
+    @variable(modA, 2 <= z <= 4)
+    @variable(modA, 0 <= r[i=3:6] <= i)
+    @NLobjective(modA, Max, ((x + y)/2.0 + 3.0)/3.0 + z + r[3])
+    @constraint(modA, cons1, x+y >= 2)
+    @constraint(modA, cons2, sum{r[i],i=3:5} <= (2 - x)/2.0)
+    @NLconstraint(modA, cons3, 7.0*y <= z + r[6]/1.9)
 
     # Solution
     @fact solve(modA) --> :Optimal
@@ -473,8 +473,8 @@ facts("[nonlinear] Test Hessian chunking code") do
 for nlp_solver in nlp_solvers
 context("With solver $(typeof(nlp_solver))") do
     m = Model(solver=nlp_solver)
-    @defVar(m, x[1:18] >= 1, start = 1.2)
-    @setNLObjective(m, Min, prod{x[i],i=1:18})
+    @variable(m, x[1:18] >= 1, start = 1.2)
+    @NLobjective(m, Min, prod{x[i],i=1:18})
     @fact solve(m) --> :Optimal
     @fact getValue(x) --> roughly(ones(18),1e-4)
 end; end; end
@@ -514,24 +514,24 @@ MathProgBase.getsolution(m::DummyNLPModel) = [1.0,1.0]
 MathProgBase.setvartype!(m::DummyNLPModel,vartype) = @fact any(vartype .== :Fixed) --> false
 function test_nl_mpb()
     m = Model(solver=DummyNLPSolver())
-    @defVar(m, x == 1)
-    @defVar(m, y, Bin)
-    @setObjective(m, Min, -x+y)
-    @addConstraint(m, 2x+y <= 1)
-    @addConstraint(m, 2x+y <= 0)
-    @addConstraint(m, -5 <= 2x+y <= 5)
+    @variable(m, x == 1)
+    @variable(m, y, Bin)
+    @objective(m, Min, -x+y)
+    @constraint(m, 2x+y <= 1)
+    @constraint(m, 2x+y <= 0)
+    @constraint(m, -5 <= 2x+y <= 5)
     #solve(m) # FIXME maybe?
     lb,ub = getConstraintBounds(m)
     @fact lb --> [-Inf,-Inf,-5.0]
     @fact ub --> [1.0,-0.0,5.0]
 
-    @addConstraint(m, 2x^2+y >= 2)
-    @addNLConstraint(m, sin(x)*cos(y) == 5)
-    @addNLConstraint(m, nlconstr[i=1:2], i*x^2 == i)
-    @addNLConstraint(m, -0.5 <= sin(x) <= 0.5)
+    @constraint(m, 2x^2+y >= 2)
+    @NLconstraint(m, sin(x)*cos(y) == 5)
+    @NLconstraint(m, nlconstr[i=1:2], i*x^2 == i)
+    @NLconstraint(m, -0.5 <= sin(x) <= 0.5)
     solve(m)
 
-    @setNLObjective(m, Min, x^y)
+    @NLobjective(m, Min, x^y)
     solve(m)
 
     lb,ub = getConstraintBounds(m)
@@ -542,9 +542,9 @@ test_nl_mpb()
 
 facts("[nonlinear] Expression graph for linear problem") do
     m = Model()
-    @defVar(m, x)
-    @addConstraint(m, 0 <= x <= 1)
-    @setObjective(m, Max, x)
+    @variable(m, x)
+    @constraint(m, 0 <= x <= 1)
+    @objective(m, Max, x)
     d = JuMPNLPEvaluator(m)
     MathProgBase.initialize(d, [:ExprGraph])
     @fact MathProgBase.obj_expr(d) --> :(+(1.0 * x[1]))
@@ -553,13 +553,13 @@ end
 facts("[nonlinear] Hessians through MPB") do
     # Issue 435
     m = Model()
-    @defVar(m, a, start = 1)
-    @defVar(m, b, start = 2)
-    @defVar(m, c, start = 3)
+    @variable(m, a, start = 1)
+    @variable(m, b, start = 2)
+    @variable(m, c, start = 3)
 
-    @defNLExpr(m, foo, a * b + c^2)
+    @NLexpression(m, foo, a * b + c^2)
 
-    @setNLObjective(m, Min, foo)
+    @NLobjective(m, Min, foo)
     d = JuMPNLPEvaluator(m)
     MathProgBase.initialize(d, [:Hess])
     I,J = MathProgBase.hesslag_structure(d)
@@ -571,7 +571,7 @@ facts("[nonlinear] Hessians through MPB") do
     @fact hess_sparse --> roughly([0.0 1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 2.0])
 
     # make sure we don't get NaNs in this case
-    @setNLObjective(m, Min, a * b + 3*c^2)
+    @NLobjective(m, Min, a * b + 3*c^2)
     d = JuMPNLPEvaluator(m)
     MathProgBase.initialize(d, [:Hess])
     setValue(c, -1.0)
@@ -592,13 +592,13 @@ end
 
 facts("[nonlinear] Hess-vec through MPB") do
     m = Model()
-    @defVar(m, a, start = 1)
-    @defVar(m, b, start = 2)
-    @defVar(m, c, start = 3)
+    @variable(m, a, start = 1)
+    @variable(m, b, start = 2)
+    @variable(m, c, start = 3)
 
-    @setNLObjective(m, Min, a*b + c^2)
-    @addConstraint(m, c*b <= 1)
-    @addNLConstraint(m, a^2/2 <= 1)
+    @NLobjective(m, Min, a*b + c^2)
+    @constraint(m, c*b <= 1)
+    @NLconstraint(m, a^2/2 <= 1)
     d = JuMPNLPEvaluator(m)
     MathProgBase.initialize(d, [:HessVec])
     h = ones(3) # test that input values are overwritten
@@ -614,10 +614,10 @@ facts("[nonlinear] NaN corner case (#695)") do
     x0 = 0.0
     y0 = 0.0
 
-    @defVar(m, x >= -1, start = 1.0)
-    @defVar(m, y, start = 2.0)
+    @variable(m, x >= -1, start = 1.0)
+    @variable(m, y, start = 2.0)
 
-    @setNLObjective(m, Min, (x - x0) /(sqrt(y0) + sqrt(y)))
+    @NLobjective(m, Min, (x - x0) /(sqrt(y0) + sqrt(y)))
 
     d = JuMPNLPEvaluator(m)
     MathProgBase.initialize(d, [:HessVec])
@@ -631,8 +631,8 @@ end
 if length(convex_nlp_solvers) > 0
     facts("[nonlinear] Error on NLP resolve") do
         m = Model(solver=convex_nlp_solvers[1])
-        @defVar(m, x, start = 1)
-        @setNLObjective(m, Min, x^2)
+        @variable(m, x, start = 1)
+        @NLobjective(m, Min, x^2)
         solve(m)
         setValue(x, 2)
         @fact_throws ErrorException solve(m)
@@ -657,8 +657,8 @@ if length(convex_nlp_solvers) > 0
 
         m = Model(solver=convex_nlp_solvers[1])
 
-        @defVar(m, x[1:2] >= 0.5)
-        @setNLObjective(m, Min, myf(x[1],mysquare(x[2])))
+        @variable(m, x[1:2] >= 0.5)
+        @NLobjective(m, Min, myf(x[1],mysquare(x[2])))
 
         d = JuMPNLPEvaluator(m)
         MathProgBase.initialize(d, [:Grad])
@@ -672,7 +672,7 @@ if length(convex_nlp_solvers) > 0
 
         @fact getValue(x) --> roughly(xval)
 
-        @setNLObjective(m, Min, myf_2(x[1],mysquare_2(x[2])))
+        @NLobjective(m, Min, myf_2(x[1],mysquare_2(x[2])))
 
         d = JuMPNLPEvaluator(m)
         MathProgBase.initialize(d, [:Grad])
@@ -689,7 +689,7 @@ if length(convex_nlp_solvers) > 0
 
         # Test just univariate functions because hessians are disabled
         # if any multivariate functions are present.
-        @setNLObjective(m, Min, mysquare(x[1]-1) + mysquare_2(x[2]-2) + mysquare_3(x[1]))
+        @NLobjective(m, Min, mysquare(x[1]-1) + mysquare_2(x[2]-2) + mysquare_3(x[1]))
         @fact solve(m) --> :Optimal
         @fact getValue(x) --> roughly([0.5,2.0],1e-4)
 

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -22,10 +22,10 @@ const sub2 = JuMP.repl[:sub2]
 
 facts("[operator] Testing basic operator overloads") do
     m = Model()
-    @defVar(m, w)
-    @defVar(m, x)
-    @defVar(m, y)
-    @defVar(m, z)
+    @variable(m, w)
+    @variable(m, x)
+    @variable(m, y)
+    @variable(m, z)
     aff = 7.1 * x + 2.5
     @fact affToStr(aff) --> "7.1 x + 2.5"
     aff2 = 1.2 * y + 1.2
@@ -401,11 +401,11 @@ end
 facts("[operator] Higher-level operators") do
 context("sum") do
     sum_m = Model()
-    @defVar(sum_m, 0 ≤ matrix[1:3,1:3] ≤ 1, start = 1)
+    @variable(sum_m, 0 ≤ matrix[1:3,1:3] ≤ 1, start = 1)
     # sum(j::JuMPArray{Variable})
     @fact affToStr(sum(matrix)) --> "matrix[1,1] + matrix[2,1] + matrix[3,1] + matrix[1,2] + matrix[2,2] + matrix[3,2] + matrix[1,3] + matrix[2,3] + matrix[3,3]"
     # sum(j::JuMPArray{Variable}) in a macro
-    @setObjective(sum_m, Max, sum(matrix))
+    @objective(sum_m, Max, sum(matrix))
     @fact quadToStr(sum_m.obj) --> "matrix[1,1] + matrix[2,1] + matrix[3,1] + matrix[1,2] + matrix[2,2] + matrix[3,2] + matrix[1,3] + matrix[2,3] + matrix[3,3]"
 
     # sum{T<:Real}(j::JuMPArray{T})
@@ -416,7 +416,7 @@ context("sum") do
     @fact affToStr(sum([2*matrix[i,j] for i in 1:3, j in 1:3])) --> "2 matrix[1,1] + 2 matrix[2,1] + 2 matrix[3,1] + 2 matrix[1,2] + 2 matrix[2,2] + 2 matrix[3,2] + 2 matrix[1,3] + 2 matrix[2,3] + 2 matrix[3,3]"
 
     S = [1,3]
-    @defVar(sum_m, x[S], start=1)
+    @variable(sum_m, x[S], start=1)
     # sum(j::JuMPDict{Variable})
     @fact length(affToStr(sum(x))) --> 11 # order depends on hashing
     @fact contains(affToStr(sum(x)),"x[1]") --> true
@@ -427,22 +427,22 @@ end
 
 context("dot") do
     dot_m = Model()
-    @defVar(dot_m, 0 ≤ x[1:3] ≤ 1)
+    @variable(dot_m, 0 ≤ x[1:3] ≤ 1)
     c = vcat(1:3)
     @fact affToStr(dot(c,x)) --> "x[1] + 2 x[2] + 3 x[3]"
     @fact affToStr(dot(x,c)) --> "x[1] + 2 x[2] + 3 x[3]"
 
     A = [1 3 ; 2 4]
-    @defVar(dot_m, 1 ≤ y[1:2,1:2] ≤ 1)
+    @variable(dot_m, 1 ≤ y[1:2,1:2] ≤ 1)
     @fact affToStr(vecdot(A,y)) --> "y[1,1] + 2 y[2,1] + 3 y[1,2] + 4 y[2,2]"
     @fact affToStr(vecdot(y,A)) --> "y[1,1] + 2 y[2,1] + 3 y[1,2] + 4 y[2,2]"
 
     B = ones(2,2,2)
-    @defVar(dot_m, 0 ≤ z[1:2,1:2,1:2] ≤ 1)
+    @variable(dot_m, 0 ≤ z[1:2,1:2,1:2] ≤ 1)
     @fact affToStr(vecdot(B,z)) --> "z[1,1,1] + z[2,1,1] + z[1,2,1] + z[2,2,1] + z[1,1,2] + z[2,1,2] + z[1,2,2] + z[2,2,2]"
     @fact affToStr(vecdot(z,B)) --> "z[1,1,1] + z[2,1,1] + z[1,2,1] + z[2,2,1] + z[1,1,2] + z[2,1,2] + z[1,2,2] + z[2,2,2]"
 
-    @setObjective(dot_m, Max, dot(x, ones(3)) - vecdot(y, ones(2,2)) )
+    @objective(dot_m, Max, dot(x, ones(3)) - vecdot(y, ones(2,2)) )
     #solve(dot_m)
     for i in 1:3
         setValue(x[i], 1)
@@ -455,7 +455,7 @@ context("dot") do
 
     # https://github.com/JuliaOpt/JuMP.jl/issues/656
     issue656 = Model()
-    @defVar(issue656, x)
+    @variable(issue656, x)
     floats = Float64[i for i in 1:2]
     anys   = Array(Any, 2)
     anys[1] = 10
@@ -500,9 +500,9 @@ facts("Vectorized operations") do
 
 context("Transpose") do
     m = Model()
-    @defVar(m, x[1:3])
-    @defVar(m, y[1:2,1:3])
-    @defVar(m, z[2:5])
+    @variable(m, x[1:3])
+    @variable(m, y[1:2,1:3])
+    @variable(m, z[2:5])
     @fact TestHelper.vec_eq(x', [x[1] x[2] x[3]]) --> true
     @fact TestHelper.vec_eq(transpose(x), [x[1] x[2] x[3]]) --> true
     @fact TestHelper.vec_eq(y', [y[1,1] y[2,1]
@@ -518,7 +518,7 @@ end
 
 context("Vectorized arithmetic") do
     m = Model()
-    @defVar(m, x[1:3])
+    @variable(m, x[1:3])
     A = [2 1 0
          1 2 1
          0 1 2]
@@ -588,7 +588,7 @@ end
 
 context("Dot-ops") do
     m = Model()
-    @defVar(m, x[1:2,1:2])
+    @variable(m, x[1:2,1:2])
     A = [1 2;
          3 4]
     B = sparse(A)
@@ -643,22 +643,22 @@ end
 
 context("Vectorized comparisons") do
     m = Model()
-    @defVar(m, x[1:3])
+    @variable(m, x[1:3])
     A = [1 2 3
          0 4 5
          6 0 7]
     B = sparse(A)
-    @addConstraint(m, x'*A*x .>= 1)
+    @constraint(m, x'*A*x .>= 1)
     @fact TestHelper.vec_eq(m.quadconstr[1].terms, [x[1]*x[1] + 2x[1]*x[2] + 4x[2]*x[2] + 9x[1]*x[3] + 5x[2]*x[3] + 7x[3]*x[3] - 1]) --> true
     @fact m.quadconstr[1].sense --> :(>=)
-    @addConstraint(m, x'*A*x .>= 1)
+    @constraint(m, x'*A*x .>= 1)
     @fact TestHelper.vec_eq(m.quadconstr[1].terms, m.quadconstr[2].terms) --> true
 
     mat = [ 3x[1] + 12x[3] +  4x[2]
             2x[1] + 12x[2] + 10x[3]
            15x[1] +  5x[2] + 21x[3]]
 
-    @addConstraint(m, (x'A)' + 2A*x .<= 1)
+    @constraint(m, (x'A)' + 2A*x .<= 1)
     terms = map(v->v.terms, m.linconstr[1:3])
     lbs   = map(v->v.lb,    m.linconstr[1:3])
     ubs   = map(v->v.ub,    m.linconstr[1:3])
@@ -673,7 +673,7 @@ context("Vectorized comparisons") do
     @fact TestHelper.vec_eq((x'A)' + 2A*x, @JuMP.Expression((x'A)' + 2B*x)) --> true
     @fact TestHelper.vec_eq((x'A)' + 2A*x, @JuMP.Expression((x'B)' + 2B*x)) --> true
 
-    @addConstraint(m, -1 .<= (x'A)' + 2A*x .<= 1)
+    @constraint(m, -1 .<= (x'A)' + 2A*x .<= 1)
     terms = map(v->v.terms, m.linconstr[4:6])
     lbs   = map(v->v.lb,    m.linconstr[4:6])
     ubs   = map(v->v.ub,    m.linconstr[4:6])
@@ -681,7 +681,7 @@ context("Vectorized comparisons") do
     @fact lbs --> fill(-1, 3)
     @fact ubs --> fill( 1, 3)
 
-    @addConstraint(m, -[1:3;] .<= (x'A)' + 2A*x .<= 1)
+    @constraint(m, -[1:3;] .<= (x'A)' + 2A*x .<= 1)
     terms = map(v->v.terms, m.linconstr[7:9])
     lbs   = map(v->v.lb,    m.linconstr[7:9])
     ubs   = map(v->v.ub,    m.linconstr[7:9])
@@ -689,7 +689,7 @@ context("Vectorized comparisons") do
     @fact lbs --> -[1:3;]
     @fact ubs --> fill( 1, 3)
 
-    @addConstraint(m, -[1:3;] .<= (x'A)' + 2A*x .<= [3:-1:1;])
+    @constraint(m, -[1:3;] .<= (x'A)' + 2A*x .<= [3:-1:1;])
     terms = map(v->v.terms, m.linconstr[10:12])
     lbs   = map(v->v.lb,    m.linconstr[10:12])
     ubs   = map(v->v.ub,    m.linconstr[10:12])
@@ -697,7 +697,7 @@ context("Vectorized comparisons") do
     @fact lbs --> -[1:3;]
     @fact ubs --> [3:-1:1;]
 
-    @addConstraint(m, -[1:3;] .<= (x'A)' + 2A*x .<= 3)
+    @constraint(m, -[1:3;] .<= (x'A)' + 2A*x .<= 3)
     terms = map(v->v.terms, m.linconstr[13:15])
     lbs   = map(v->v.lb,    m.linconstr[13:15])
     ubs   = map(v->v.ub,    m.linconstr[13:15])
@@ -710,10 +710,10 @@ end
 
 facts("[operator] JuMPArray concatenation") do
     m = Model()
-    @defVar(m, x[1:3])
-    @defVar(m, y[1:3,1:3])
-    @defVar(m, z[1:1])
-    @defVar(m, w[1:1,1:3])
+    @variable(m, x[1:3])
+    @variable(m, y[1:3,1:3])
+    @variable(m, z[1:1])
+    @variable(m, w[1:1,1:3])
 
     @fact TestHelper.vec_eq([x y], [x[1] y[1,1] y[1,2] y[1,3]
                                     x[2] y[2,1] y[2,2] y[2,3]
@@ -755,12 +755,12 @@ end
 # The behavior in this test is no longer well-defined
 #let
 #    dot_m = Model()
-#    @defVar(dot_m, 0 <= v[1:3,1:4] <= 1)
-#    @defVar(dot_m, 0 <= w[3:2:7,7:-2:1] <= 1)
+#    @variable(dot_m, 0 <= v[1:3,1:4] <= 1)
+#    @variable(dot_m, 0 <= w[3:2:7,7:-2:1] <= 1)
 #    @fact quadToStr(dot(v,w)) --> "v[1,1]*w[3,7] + v[1,2]*w[3,5] + v[1,3]*w[3,3] + v[1,4]*w[3,1] + v[2,1]*w[5,7] + v[2,2]*w[5,5] + v[2,3]*w[5,3] + v[2,4]*w[5,1] + v[3,1]*w[7,7] + v[3,2]*w[7,5] + v[3,3]*w[7,3] + v[3,4]*w[7,1]"
 #
-#    @addConstraint(dot_m, sum(v) + sum(w) --> 2)
-#    @setObjective(dot_m, :Max, v[2,3] + w[5,3])
+#    @constraint(dot_m, sum(v) + sum(w) --> 2)
+#    @objective(dot_m, :Max, v[2,3] + w[5,3])
 #    solve(dot_m)
 #    @fact dot(getValue(v),getValue(w)) --> 1.0
 #end
@@ -769,7 +769,7 @@ end
 #let
 #    slice_m = Model()
 #    C = [:cat,:dog]
-#    @defVar(slice_m, x[-1:1,C])
+#    @variable(slice_m, x[-1:1,C])
 #    catcoef = [1,2,3]
 #    dogcoef = [3,4,5]
 #

--- a/test/print.jl
+++ b/test/print.jl
@@ -35,15 +35,15 @@ facts("[print] JuMPContainer{Variable}") do
     #------------------------------------------------------------------
     # Test bound printing
     context("bound printing") do
-    @defVar(m,      bnd_free[2:5])
-    @defVar(m,      bnd_lowb[2:5] >= 2)
-    @defVar(m,      bnd_high[2:5] <= 5)
-    @defVar(m, 2 <= bnd_both[2:5] <= 5)
-    @defVar(m,      bnd_difflo[i=2:5] >= i)
-    @defVar(m,      bnd_diffup[i=2:5] <= i)
-    @defVar(m, i <= bnd_diffbo[i=2:5] <= 2i)
-    @defVar(m, i <= bnd_difflo_with_up[i=2:5] <= 5)
-    @defVar(m, 2 <= bnd_diffup_with_lo[i=2:5] <= i)
+    @variable(m,      bnd_free[2:5])
+    @variable(m,      bnd_lowb[2:5] >= 2)
+    @variable(m,      bnd_high[2:5] <= 5)
+    @variable(m, 2 <= bnd_both[2:5] <= 5)
+    @variable(m,      bnd_difflo[i=2:5] >= i)
+    @variable(m,      bnd_diffup[i=2:5] <= i)
+    @variable(m, i <= bnd_diffbo[i=2:5] <= 2i)
+    @variable(m, i <= bnd_difflo_with_up[i=2:5] <= 5)
+    @variable(m, 2 <= bnd_diffup_with_lo[i=2:5] <= i)
 
     io_test(REPLMode, bnd_free, "bnd_free[i] free $fa i $inset {2,3,4,5}")
     io_test(REPLMode, bnd_lowb, "bnd_lowb[i] $ge 2 $fa i $inset {2,3,4,5}")
@@ -69,20 +69,20 @@ facts("[print] JuMPContainer{Variable}") do
     #------------------------------------------------------------------
     # Test index set printing
     context("index set printing") do
-    @defVar(m, rng_unit1[1:10])  # Array{Variable}
-    @defVar(m, rng_unit2[-2:3])  # JuMPArray
-    @defVar(m, rng_unit3[[1:10;]])  # JuMPDict
-    @defVar(m, rng_step1[1:2:10])
-    @defVar(m, rng_step2[-2:5:10])
-    @defVar(m, rng_step3[1:5:3])
-    @defVar(m, rng_step4[0:2:2])
-    @defVar(m, arr_1[[:a,:b,:c]])
-    @defVar(m, arr_2[[:a,1,"test"]])
-    @defVar(m, arr_3[[:apple,:banana,:carrot,:diamonds]])
-    @defVar(m, rng2_1[1:10,[:a,:b,:c]])
-    @defVar(m, tri_1[i=1:3,j=i:3])
-    @defVar(m, tri_2[i=1:3,j=-i])
-    @defVar(m, tri_3[(i,j)=[(i,i+2) for i in 1:5],k=i:j])
+    @variable(m, rng_unit1[1:10])  # Array{Variable}
+    @variable(m, rng_unit2[-2:3])  # JuMPArray
+    @variable(m, rng_unit3[[1:10;]])  # JuMPDict
+    @variable(m, rng_step1[1:2:10])
+    @variable(m, rng_step2[-2:5:10])
+    @variable(m, rng_step3[1:5:3])
+    @variable(m, rng_step4[0:2:2])
+    @variable(m, arr_1[[:a,:b,:c]])
+    @variable(m, arr_2[[:a,1,"test"]])
+    @variable(m, arr_3[[:apple,:banana,:carrot,:diamonds]])
+    @variable(m, rng2_1[1:10,[:a,:b,:c]])
+    @variable(m, tri_1[i=1:3,j=i:3])
+    @variable(m, tri_2[i=1:3,j=-i])
+    @variable(m, tri_3[(i,j)=[(i,i+2) for i in 1:5],k=i:j])
 
     io_test(REPLMode, rng_unit1, "rng_unit1[i] free $fa i $inset {1,2,$dots,9,10}")
     io_test(REPLMode, rng_unit2, "rng_unit2[i] free $fa i $inset {-2,-1,$dots,2,3}")
@@ -118,17 +118,17 @@ facts("[print] JuMPContainer{Variable}") do
     #------------------------------------------------------------------
     # Test category printing
     context("category printing") do
-    @defVar(m, cat_bin[1:3], Bin)
-    @defVar(m, 2 <= cat_int[1:3] <= 5, Int)
-    @defVar(m, cat_semiint_both[2:3] >= 2, SemiInt)
-    @defVar(m, i <= cat_semiint_difflow[i=2:3] <= 4, SemiInt)
-    @defVar(m, 2 <= cat_semiint_diffup[i=2:3] <= i, SemiInt)
-    @defVar(m, i <= cat_semiint_none[i=2:3] <= 2i, SemiInt)
-    @defVar(m, cat_semicont_both[2:3] >= 2, SemiCont)
-    @defVar(m, i <= cat_semicont_difflow[i=2:3] <= 4, SemiCont)
-    @defVar(m, 2 <= cat_semicont_diffup[i=2:3] <= i, SemiCont)
-    @defVar(m, i <= cat_semicont_none[i=2:3] <= 2i, SemiCont)
-    @defVar(m, fixed_var[i=2:3] == i)
+    @variable(m, cat_bin[1:3], Bin)
+    @variable(m, 2 <= cat_int[1:3] <= 5, Int)
+    @variable(m, cat_semiint_both[2:3] >= 2, SemiInt)
+    @variable(m, i <= cat_semiint_difflow[i=2:3] <= 4, SemiInt)
+    @variable(m, 2 <= cat_semiint_diffup[i=2:3] <= i, SemiInt)
+    @variable(m, i <= cat_semiint_none[i=2:3] <= 2i, SemiInt)
+    @variable(m, cat_semicont_both[2:3] >= 2, SemiCont)
+    @variable(m, i <= cat_semicont_difflow[i=2:3] <= 4, SemiCont)
+    @variable(m, 2 <= cat_semicont_diffup[i=2:3] <= i, SemiCont)
+    @variable(m, i <= cat_semicont_none[i=2:3] <= 2i, SemiCont)
+    @variable(m, fixed_var[i=2:3] == i)
 
     io_test(REPLMode, cat_bin, "cat_bin[i] $inset {0,1} $fa i $inset {1,2,3}")
     io_test(REPLMode, cat_int, "2 $le cat_int[i] $le 5, integer, $fa i $inset {1,2,3}")
@@ -158,10 +158,10 @@ facts("[print] JuMPContainer{Variable}") do
     #------------------------------------------------------------------
     # Tests for particular issues
     context("Empty JuMPContainer printing (#124)") do
-    @defVar(m, empty_free[1:0])
+    @variable(m, empty_free[1:0])
     io_test(REPLMode, empty_free, "Empty Array{Variable} (no indices)")
     io_test(IJuliaMode, empty_free, "Empty Array{Variable} (no indices)")
-    @defVar(m, empty_set[[]])
+    @variable(m, empty_set[[]])
     io_test(REPLMode, empty_set, "empty_set (no indices)")
     io_test(IJuliaMode, empty_set, "empty_set (no indices)")
     end
@@ -172,10 +172,10 @@ end
 facts("[print] JuMPContainer{Number}") do
     # The same output for REPL and IJulia, so only testing one
     mod = Model()
-    @defVar(mod, i*j <= w[i=9:10, [:Apple,5,:Banana], j=-1:+1] <= i*j)
-    @defVar(mod, i*j*k <= x[i=9:11,j=99:101,k=3:4] <= i*j*k)
-    @defVar(mod, i*j <= y[i=9:11,j=i:11] <= i*j)
-    @defVar(mod, j <= z[i=[:a,'b'],j=1:3] <= j)
+    @variable(mod, i*j <= w[i=9:10, [:Apple,5,:Banana], j=-1:+1] <= i*j)
+    @variable(mod, i*j*k <= x[i=9:11,j=99:101,k=3:4] <= i*j*k)
+    @variable(mod, i*j <= y[i=9:11,j=i:11] <= i*j)
+    @variable(mod, j <= z[i=[:a,'b'],j=1:3] <= j)
     solve(mod)
 
     # Deal with hashing variations
@@ -303,7 +303,7 @@ end
 facts("[print] SOS constraints") do
     modS = Model()
     a = [1,2,3]
-    @defVar(modS, x[1:3], Bin)
+    @variable(modS, x[1:3], Bin)
     addSOS1(modS, [a[i]x[i] for i in 1:3])
     s1 = JuMP.SOSConstraint([x[i] for i in 1:3],
                             [a[i] for i in 1:3], :SOS1)
@@ -311,7 +311,7 @@ facts("[print] SOS constraints") do
     io_test(IJuliaMode, s1, "SOS1: \\{1 x[1], 2 x[2], 3 x[3]\\}")
 
     b = [5,4,7,2,1]
-    @defVar(modS, y[1:5], Bin)
+    @variable(modS, y[1:5], Bin)
     s2 = JuMP.SOSConstraint([y[i] for i in 1:5],
                             [b[i] for i in 1:5], :SOS2)
     io_test(REPLMode, s2, "SOS2: {5 y[1], 4 y[2], 7 y[3], 2 y[4], 1 y[5]}")
@@ -329,24 +329,24 @@ facts("[print] Model") do
     #------------------------------------------------------------------
 
     mod_1 = Model()
-    @defVar(mod_1, a>=1)
-    @defVar(mod_1, b<=1)
-    @defVar(mod_1, -1<=c<=1)
-    @defVar(mod_1, a1>=1,Int)
-    @defVar(mod_1, b1<=1,Int)
-    @defVar(mod_1, -1<=c1<=1,Int)
-    @defVar(mod_1, x, Bin)
-    @defVar(mod_1, y)
-    @defVar(mod_1, z, Int)
-    @defVar(mod_1, sos[1:3], Bin)
-    @defVar(mod_1, 2 <= si <= 3, SemiInt)
-    @defVar(mod_1, 2 <= sc <= 3, SemiCont)
-    @defVar(mod_1, fi == 9)
-    @setObjective(mod_1, Max, a - b + 2a1 - 10x)
-    @addConstraint(mod_1, a + b - 10c - 2x + c1 <= 1)
-    @addConstraint(mod_1, a*b <= 2)
+    @variable(mod_1, a>=1)
+    @variable(mod_1, b<=1)
+    @variable(mod_1, -1<=c<=1)
+    @variable(mod_1, a1>=1,Int)
+    @variable(mod_1, b1<=1,Int)
+    @variable(mod_1, -1<=c1<=1,Int)
+    @variable(mod_1, x, Bin)
+    @variable(mod_1, y)
+    @variable(mod_1, z, Int)
+    @variable(mod_1, sos[1:3], Bin)
+    @variable(mod_1, 2 <= si <= 3, SemiInt)
+    @variable(mod_1, 2 <= sc <= 3, SemiCont)
+    @variable(mod_1, fi == 9)
+    @objective(mod_1, Max, a - b + 2a1 - 10x)
+    @constraint(mod_1, a + b - 10c - 2x + c1 <= 1)
+    @constraint(mod_1, a*b <= 2)
     addSOS1(mod_1, [i*sos[i] for i in 1:3])
-    @addConstraint(mod_1, norm(sos) + a <= 1)
+    @constraint(mod_1, norm(sos) + a <= 1)
 
     io_test(REPLMode, mod_1, """
 Max a - b + 2 a1 - 10 x
@@ -404,9 +404,9 @@ Solver is default solver""", repl=:show)
     #------------------------------------------------------------------
 
     mod_2 = Model()
-    @defVar(mod_2, x, Bin)
-    @defVar(mod_2, y, Int)
-    @addConstraint(mod_2, x*y <= 1)
+    @variable(mod_2, x, Bin)
+    @variable(mod_2, y, Int)
+    @constraint(mod_2, x*y <= 1)
 
     io_test(REPLMode, mod_2, """
 Feasibility problem with:
@@ -416,8 +416,8 @@ Feasibility problem with:
 Solver is default solver""", repl=:show)
 
     mod_2 = Model()
-    @defVar(mod_2, x)
-    @addConstraint(mod_2, x <= 3)
+    @variable(mod_2, x)
+    @constraint(mod_2, x <= 3)
 
     io_test(REPLMode, mod_2, """
 Feasibility problem with:
@@ -429,11 +429,11 @@ Solver is default solver""", repl=:show)
 
     mod_3 = Model()
 
-    @defVar(mod_3, x[1:5])
-    @addNLConstraint(mod_3, x[1]*x[2] == 1)
-    @addNLConstraint(mod_3, x[3]*x[4] == 1)
-    @addNLConstraint(mod_3, x[5]*x[1] == 1)
-    @setNLObjective(mod_3, Min, x[1]*x[3])
+    @variable(mod_3, x[1:5])
+    @NLconstraint(mod_3, x[1]*x[2] == 1)
+    @NLconstraint(mod_3, x[3]*x[4] == 1)
+    @NLconstraint(mod_3, x[5]*x[1] == 1)
+    @NLobjective(mod_3, Min, x[1]*x[3])
 
     io_test(REPLMode, mod_3, """
 Min (nonlinear expression)
@@ -461,8 +461,8 @@ facts("[print] changing variable categories") do
     infty, union = repl[:infty], repl[:union]
 
     mod = Model()
-    @defVar(mod, x[1:3])
-    @defVar(mod, y[i=1:3,i:3])
+    @variable(mod, x[1:3])
+    @variable(mod, y[i=1:3,i:3])
     setCategory(x[3], :SemiCont)
     setCategory(y[1,3], :Int)
 
@@ -502,19 +502,19 @@ facts("[print] expressions") do
 
     #------------------------------------------------------------------
     mod = Model()
-    @defVar(mod, x[1:5])
-    @defVar(mod, y[i=2:4,j=i:5])
-    @defVar(mod, z)
+    @variable(mod, x[1:5])
+    @variable(mod, y[i=2:4,j=i:5])
+    @variable(mod, z)
 
-    @addConstraint(mod, x[1] + 2*y[2,3] <= 3)
+    @constraint(mod, x[1] + 2*y[2,3] <= 3)
     io_test(REPLMode, mod.linconstr[end], "x[1] + 2 y[2,3] $le 3")
     io_test(IJuliaMode, mod.linconstr[end], "x_{1} + 2 y_{2,3} \\leq 3")
 
-    @addConstraint(mod, (x[1]+x[2])*(y[2,2]+3.0) <= 1)
+    @constraint(mod, (x[1]+x[2])*(y[2,2]+3.0) <= 1)
     io_test(REPLMode, mod.quadconstr[end], "x[1]*y[2,2] + x[2]*y[2,2] + 3 x[1] + 3 x[2] - 1 $le 0")
     io_test(IJuliaMode, mod.quadconstr[end], "x_{1}\\times y_{2,2} + x_{2}\\times y_{2,2} + 3 x_{1} + 3 x_{2} - 1 \\leq 0")
 
-    @addConstraint(mod, (y[2,2]+3.0)*(x[1]+x[2]) <= 1)
+    @constraint(mod, (y[2,2]+3.0)*(x[1]+x[2]) <= 1)
     io_test(REPLMode, mod.quadconstr[end], "x[1]*y[2,2] + x[2]*y[2,2] + 3 x[1] + 3 x[2] - 1 $le 0")
     io_test(IJuliaMode, mod.quadconstr[end], "x_{1}\\times y_{2,2} + x_{2}\\times y_{2,2} + 3 x_{1} + 3 x_{2} - 1 \\leq 0")
 end
@@ -523,7 +523,7 @@ end
 
 facts("[print] Variable") do
     m = Model()
-    @defVar(m, 0 <= x <= 2, inconstraints=ConstraintRef{Model,LinearConstraint}[], objective=0.0, coefficients=Float64[] )
+    @variable(m, 0 <= x <= 2, inconstraints=ConstraintRef{Model,LinearConstraint}[], objective=0.0, coefficients=Float64[] )
 
     @fact    getName(x) --> "x"
     io_test(REPLMode,   x, "x")
@@ -539,7 +539,7 @@ facts("[print] Variable") do
     io_test(REPLMode,   x, "col_1")
     io_test(IJuliaMode, x, "col_1")
 
-    @defVar(m, z[1:2,3:5])
+    @variable(m, z[1:2,3:5])
     @fact       getName(z[1,3]) --> "z[1,3]"
     io_test(REPLMode,   z[1,3],    "z[1,3]")
     io_test(IJuliaMode, z[1,3],    "z_{1,3}")
@@ -550,13 +550,13 @@ facts("[print] Variable") do
     io_test(REPLMode,   z[2,5],    "z[2,5]")
     io_test(IJuliaMode, z[2,5],    "z_{2,5}")
 
-    @defVar(m, w[3:9,["red","blue","green"]])
+    @variable(m, w[3:9,["red","blue","green"]])
     @fact    getName(w[7,"green"]) --> "w[7,green]"
     io_test(REPLMode,   w[7,"green"], "w[7,green]")
     io_test(IJuliaMode, w[7,"green"], "w_{7,green}")
 
     rng = 2:5
-    @defVar(m, v[rng,rng,rng,rng,rng,rng,rng])
+    @variable(m, v[rng,rng,rng,rng,rng,rng,rng])
     a_v = v[4,5,2,3,2,2,4]
     @fact    getName(a_v) --> "v[4,5,2,3,2,2,4]"
     io_test(REPLMode,   a_v, "v[4,5,2,3,2,2,4]")
@@ -565,8 +565,8 @@ end
 
 facts("[print] User-created Array{Variable}") do
     m = Model()
-    @defVar(m, x)
-    @defVar(m, y)
+    @variable(m, x)
+    @variable(m, y)
 
     v = [x,y,x]
     A = [x y; y x]
@@ -585,12 +585,12 @@ end
 
 facts("[print] basename keyword argument") do
     m = Model()
-    @defVar(m, x, basename="foo")
-    @defVar(m, y[1:3], basename=:bar)
+    @variable(m, x, basename="foo")
+    @variable(m, y[1:3], basename=:bar)
     num = 123
-    @defVar(m, z[[:red,:blue]], basename="color_$num")
-    @defVar(m, v[1:2,1:2], SDP, basename=string("i","$num",num))
-    @defVar(m, w[1:3,1:3], Symmetric, basename="symm")
+    @variable(m, z[[:red,:blue]], basename="color_$num")
+    @variable(m, v[1:2,1:2], SDP, basename=string("i","$num",num))
+    @variable(m, w[1:3,1:3], Symmetric, basename="symm")
 
     io_test(REPLMode,   x, "foo")
     io_test(IJuliaMode, x, "foo")

--- a/test/probmod.jl
+++ b/test/probmod.jl
@@ -28,10 +28,10 @@ context("With solver $(typeof(solver))") do
     #     1 <= y <= 3
     # x* = 2, y* = 1
     m = Model(solver=solver)
-    @defVar(m, 0 <= x <= 3)
-    @defVar(m, 1 <= y <= 3)
-    @setObjective(m, :Max, 1.1x + 1.0y)
-    maincon = @addConstraint(m, x + y <= 3)
+    @variable(m, 0 <= x <= 3)
+    @variable(m, 1 <= y <= 3)
+    @objective(m, :Max, 1.1x + 1.0y)
+    maincon = @constraint(m, x + y <= 3)
     @fact solve(m) --> :Optimal
     @fact m.internalModelLoaded --> true
     @fact getValue(x) --> roughly(2.0, TOL)
@@ -44,7 +44,7 @@ context("With solver $(typeof(solver))") do
     #     1 <= y <= 3
     #     0 <= z <= 5
     # x* = 0, y* = 1, z* = 2
-    @defVar(m, 0 <= z <= 5, objective=100.0, inconstraints=[maincon], coefficients=[1.0])
+    @variable(m, 0 <= z <= 5, objective=100.0, inconstraints=[maincon], coefficients=[1.0])
     @fact solve(m) --> :Optimal
     @fact getValue(x) --> roughly(0.0, TOL)
     @fact getValue(y) --> roughly(1.0, TOL)
@@ -80,11 +80,11 @@ context("With solver $(typeof(solver))") do
     #     1 <= y <= 3
     #     0 <= z <= 0
     m = Model(solver=solver)
-    @defVar(m, 0 <= x <= 3)
-    @defVar(m, 0 <= y <= 3)
-    @defVar(m, 0 <= z <= 0)
-    @setObjective(m, :Max, 1.1x + 1.0y + 100.0z)
-    maincon = @addConstraint(m, x + y + z <= 3)
+    @variable(m, 0 <= x <= 3)
+    @variable(m, 0 <= y <= 3)
+    @variable(m, 0 <= z <= 0)
+    @objective(m, :Max, 1.1x + 1.0y + 100.0z)
+    maincon = @constraint(m, x + y + z <= 3)
     @fact solve(m) --> :Optimal
 
     # Test changing problem type
@@ -122,7 +122,7 @@ context("With solver $(typeof(solver))") do
     #     0 <= y <= 3
     #     0 <= z <= 1.5, Integer
     # x* = 0, y* = 2, z* = 0
-    xz0ref = @addConstraint(m, x + z <=0)
+    xz0ref = @constraint(m, x + z <=0)
     @fact solve(m) --> :Optimal
     @fact getValue(x) --> roughly(0.0, TOL)
     @fact getValue(y) --> roughly(2.0, TOL)
@@ -138,7 +138,7 @@ context("With solver $(typeof(solver))") do
     #     0 <= z <= 1.5, Integer
     # x* = 1, y* = 0, z* = 1
     chgConstrRHS(xz0ref, 2.0)
-    xyg0ref = @addConstraint(m, x + y >= 0)
+    xyg0ref = @constraint(m, x + y >= 0)
     @fact solve(m) --> :Optimal
     chgConstrRHS(xyg0ref, 1)
     @fact solve(m) --> :Optimal
@@ -152,8 +152,8 @@ end
 
 facts("[probmod] Test adding a range constraint and modifying it") do
     m = Model()
-    @defVar(m, x)
-    rangeref = @addConstraint(m, -10 <= x <= 10)
+    @variable(m, x)
+    rangeref = @constraint(m, -10 <= x <= 10)
     @fact_throws chgConstrRHS(rangeref, 11)
 end
 
@@ -162,12 +162,12 @@ facts("[probmod] Test adding a 'decoupled' variable (#205)") do
 for solver in lp_solvers
 context("With solver $(typeof(solver))") do
     m = Model(solver=solver)
-    @defVar(m, x >= 0)
-    @setObjective(m, Min, x)
+    @variable(m, x >= 0)
+    @objective(m, Min, x)
     solve(m)
-    @defVar(m, y >= 0)
-    @addConstraint(m, x + y == 1)
-    @setObjective(m, Min, 2x+y)
+    @variable(m, y >= 0)
+    @constraint(m, x + y == 1)
+    @objective(m, Min, 2x+y)
     solve(m)
     @fact getValue(x) --> roughly(0.0, TOL)
     @fact getValue(y) --> roughly(1.0, TOL)
@@ -180,10 +180,10 @@ facts("[probmod] Test buildInternalModel") do
 for solver in lp_solvers
 context("With solver $(typeof(solver))") do
     m = Model(solver=solver)
-    @defVar(m, x >= 0)
-    @defVar(m, y >= 0)
-    @addConstraint(m, x + y == 1)
-    @setObjective(m, Max, y)
+    @variable(m, x >= 0)
+    @variable(m, y >= 0)
+    @constraint(m, x + y == 1)
+    @objective(m, Max, y)
     buildInternalModel(m)
     @fact getInternalModel(m) --> not(nothing)
     @fact m.internalModelLoaded --> true
@@ -203,10 +203,10 @@ facts("[probmod] Test buildInternalModel with MIP") do
 for solver in ip_solvers
 context("With solver $(typeof(solver))") do
     m = Model(solver=solver)
-    @defVar(m, x >= 0, Int)
-    @defVar(m, y, Bin)
-    @addConstraint(m, x + y == 1)
-    @setObjective(m, Max, y)
+    @variable(m, x >= 0, Int)
+    @variable(m, y, Bin)
+    @constraint(m, x + y == 1)
+    @objective(m, Max, y)
     buildInternalModel(m)
     @fact getInternalModel(m) --> not(nothing)
     @fact m.internalModelLoaded --> true
@@ -224,12 +224,12 @@ facts("[probmod] Test adding empty constraints") do
 for solver in lp_solvers
 context("With solver $(typeof(solver))") do
     m = Model(solver=solver)
-    @defVar(m, 0 <= x <= 9)
-    @setObjective(m, Max, x)
-    @addConstraint(m, x <= 5)
-    @addConstraint(m, 0 <= 1)
+    @variable(m, 0 <= x <= 9)
+    @objective(m, Max, x)
+    @constraint(m, x <= 5)
+    @constraint(m, 0 <= 1)
     solve(m)
-    @addConstraint(m, 0 <= 1)
+    @constraint(m, 0 <= 1)
     @fact solve(m) --> :Optimal
     @fact getValue(x) --> roughly(5.0, TOL)
 end
@@ -244,8 +244,8 @@ context("With solver $(typeof(solver))") do
     # Variables should be restricted to the intersection of
     # {0,1} and their bounds.
     mod = Model(solver=solver)
-    @defVar(mod, x, Bin)
-    @setObjective(mod, Max, x)
+    @variable(mod, x, Bin)
+    @objective(mod, Max, x)
     solve(mod)
     @fact getValue(x) --> roughly(1.0)
     setUpper(x, 2.0)
@@ -256,8 +256,8 @@ context("With solver $(typeof(solver))") do
     @fact getValue(x) --> roughly(0.0)
     # same thing, other direction
     mod = Model(solver=solver)
-    @defVar(mod, x, Bin)
-    @setObjective(mod, Min, x)
+    @variable(mod, x, Bin)
+    @objective(mod, Min, x)
     solve(mod)
     @fact getValue(x) --> roughly(0.0)
     setLower(x, -1.0)
@@ -274,8 +274,8 @@ facts("[probmod] Applicable regressions") do
 
 function methods_test(solvername, solverobj, supp)
     mod = Model(solver=solverobj)
-    @defVar(mod, x >= 0)
-    @addConstraint(mod, 2x == 2)
+    @variable(mod, x >= 0)
+    @constraint(mod, 2x == 2)
     solve(mod, suppress_warnings=true)
     internal_mod = getInternalModel(mod)
     context(solvername) do

--- a/test/qcqpmodel.jl
+++ b/test/qcqpmodel.jl
@@ -21,65 +21,65 @@ for solver in quad_mip_solvers
 context("With solver $(typeof(solver))") do
 
     modQ = Model(solver=solver)
-    @defVar(modQ, 1.1*i <= x[i=1:3] <= 2.5*i, Int)
-    @setObjective(modQ, Min, 10*x[1]*x[1] + 3*x[1]*x[2] + 5*x[2]*x[2] + 9*x[3]*x[3])
-    @addConstraint(modQ, x[2] <= 1.7*x[3])
-    @addConstraint(modQ, x[2] >= 0.5*x[1])
+    @variable(modQ, 1.1*i <= x[i=1:3] <= 2.5*i, Int)
+    @objective(modQ, Min, 10*x[1]*x[1] + 3*x[1]*x[2] + 5*x[2]*x[2] + 9*x[3]*x[3])
+    @constraint(modQ, x[2] <= 1.7*x[3])
+    @constraint(modQ, x[2] >= 0.5*x[1])
     @fact solve(modQ) --> :Optimal
     @fact modQ.objVal --> roughly( 247.0, 1e-5)
     @fact getValue(x)[:] --> roughly([2.0, 3.0, 4.0], 1e-6)
 
     # vectorized version
     modV = Model(solver=solver)
-    @defVar(modV, 1.1*i <= x[i=1:3] <= 2.5*i, Int)
+    @variable(modV, 1.1*i <= x[i=1:3] <= 2.5*i, Int)
     obj = x'*[10 1.5 0; 1.5 5 0; 0 0 9]*x
-    @setObjective(modV, Min, obj[1])
+    @objective(modV, Min, obj[1])
     A = [  0  1 -1.7
          0.5 -1    0]
-    @addConstraint(modV, A*x .<= zeros(2))
+    @constraint(modV, A*x .<= zeros(2))
     @fact solve(modV) --> :Optimal
     @fact modV.objVal --> roughly( 247.0, 1e-5)
     @fact getValue(x)[:] --> roughly([2.0, 3.0, 4.0], 1e-6)
 
     modQ = Model(solver=solver)
-    @defVar(modQ, 1.1*i <= x[i=1:3] <= 2.5*i, Int)
-    @setObjective(modQ, :Max, -10*x[1]*x[1] - 3*x[1]*x[2] - 5*x[2]*x[2] - 9*x[3]*x[3])
-    @addConstraint(modQ, x[2] <= 1.7*x[3])
-    @addConstraint(modQ, x[2] >= 0.5*x[1])
+    @variable(modQ, 1.1*i <= x[i=1:3] <= 2.5*i, Int)
+    @objective(modQ, :Max, -10*x[1]*x[1] - 3*x[1]*x[2] - 5*x[2]*x[2] - 9*x[3]*x[3])
+    @constraint(modQ, x[2] <= 1.7*x[3])
+    @constraint(modQ, x[2] >= 0.5*x[1])
     @fact solve(modQ) --> :Optimal
     @fact modQ.objVal --> roughly(-247.0, 1e-5)
     @fact getValue(x)[:] --> roughly([2.0, 3.0, 4.0], 1e-6)
 
     # sparse vectorized version
     modV = Model(solver=solver)
-    @defVar(modV, 1.1*i <= x[i=1:3] <= 2.5*i, Int)
+    @variable(modV, 1.1*i <= x[i=1:3] <= 2.5*i, Int)
     obj = x'*sparse([10 1.5 0; 1.5 5 0; 0 0 9])*x
-    @setObjective(modV, Min, obj[1])
+    @objective(modV, Min, obj[1])
     A = sparse([  0  1 -1.7
                 0.5 -1    0])
-    @addConstraint(modV, A*x .<= zeros(2))
+    @constraint(modV, A*x .<= zeros(2))
     @fact solve(modV) --> :Optimal
     @fact modV.objVal --> roughly( 247.0, 1e-5)
     @fact getValue(x)[:] --> roughly([2.0, 3.0, 4.0], 1e-6)
 
     modQ = Model(solver=solver)
-    @defVar(modQ, 1.1*i <= x[i=1:3] <= 2.5*i, Int)
-    @setObjective(modQ, :Max, -10*x[1]*x[1] - 3*x[1]*x[2] - 5*x[2]*x[2] - 9*x[3]*x[3])
-    @addConstraint(modQ, x[2] <= 1.7*x[3])
-    @addConstraint(modQ, x[2] >= 0.5*x[1])
+    @variable(modQ, 1.1*i <= x[i=1:3] <= 2.5*i, Int)
+    @objective(modQ, :Max, -10*x[1]*x[1] - 3*x[1]*x[2] - 5*x[2]*x[2] - 9*x[3]*x[3])
+    @constraint(modQ, x[2] <= 1.7*x[3])
+    @constraint(modQ, x[2] >= 0.5*x[1])
     @fact solve(modQ) --> :Optimal
     @fact modQ.objVal --> roughly(-247.0, 1e-5)
     @fact getValue(x)[:] --> roughly([2.0, 3.0, 4.0], 1e-6)
 
     # vectorized version
     modV = Model(solver=solver)
-    @defVar(modV, 1.1*i <= x[i=1:3] <= 2.5*i, Int)
+    @variable(modV, 1.1*i <= x[i=1:3] <= 2.5*i, Int)
     Q = [10 3 0; 0 5 0; 0 0 9]
     obj = x'Q*x
-    @setObjective(modV, Min, obj[1])
+    @objective(modV, Min, obj[1])
     A = [   0 -1 1.7
          -0.5  1   0]
-    @addConstraint(modV, A*x .>= zeros(2))
+    @constraint(modV, A*x .>= zeros(2))
     @fact solve(modV) --> :Optimal
     @fact modV.objVal --> roughly( 247.0, 1e-5)
     @fact getValue(x)[:] --> roughly([2.0, 3.0, 4.0], 1e-6)
@@ -90,32 +90,32 @@ for solver in quad_solvers
 context("With solver $(typeof(solver))") do
 
     modQ = Model(solver=solver)
-    @defVar(modQ, 0.5 <= x <= 2 )
-    @defVar(modQ, 0 <= y <= 30 )
-    @setObjective(modQ, :Min, (x+y)*(x+y) )
-    @addConstraint(modQ, x + y >= 1 )
+    @variable(modQ, 0.5 <= x <= 2 )
+    @variable(modQ, 0 <= y <= 30 )
+    @objective(modQ, :Min, (x+y)*(x+y) )
+    @constraint(modQ, x + y >= 1 )
     @fact solve(modQ) --> :Optimal
     @fact modQ.objVal --> roughly(1.0, 1e-6)
     @fact (getValue(x) + getValue(y)) --> roughly(1.0, 1e-6)
 
     # Vectorized version
     modV = Model(solver=solver)
-    @defVar(modV, 0.5 <= x <= 2 )
-    @defVar(modV, 0 <= y <= 30 )
+    @variable(modV, 0.5 <= x <= 2 )
+    @variable(modV, 0 <= y <= 30 )
     obj = [x y]*ones(2,2)*[x,y]
-    @setObjective(modV, Min, obj[1])
-    @addConstraint(modV, ones(1,2)*[x,y] .>= 1)
+    @objective(modV, Min, obj[1])
+    @constraint(modV, ones(1,2)*[x,y] .>= 1)
     @fact solve(modV) --> :Optimal
     @fact modV.objVal --> roughly(1.0, 1e-6)
     @fact (getValue(x) + getValue(y)) --> roughly(1.0, 1e-6)
 
     # Sparse vectorized version
     modV = Model(solver=solver)
-    @defVar(modV, 0.5 <= x <= 2 )
-    @defVar(modV, 0 <= y <= 30 )
+    @variable(modV, 0.5 <= x <= 2 )
+    @variable(modV, 0 <= y <= 30 )
     obj = [x y]*sparse(ones(2,2))*[x,y]
-    @setObjective(modV, Min, obj[1])
-    @addConstraint(modV, sparse(ones(1,2))*[x,y] .>= 1)
+    @objective(modV, Min, obj[1])
+    @constraint(modV, sparse(ones(1,2))*[x,y] .>= 1)
     @fact solve(modV) --> :Optimal
     @fact modV.objVal --> roughly(1.0, 1e-6)
     @fact (getValue(x) + getValue(y)) --> roughly(1.0, 1e-6)
@@ -128,10 +128,10 @@ for solver in quad_solvers
 context("With solver $(typeof(solver))") do
 
     modQ = Model(solver=solver)
-    @defVar(modQ, -2 <= x <= 2 )
-    @defVar(modQ, -2 <= y <= 2 )
-    @setObjective(modQ, Min, x - y )
-    @addConstraint(modQ, x + x*x + x*y + y*y <= 1 )
+    @variable(modQ, -2 <= x <= 2 )
+    @variable(modQ, -2 <= y <= 2 )
+    @objective(modQ, Min, x - y )
+    @constraint(modQ, x + x*x + x*y + y*y <= 1 )
     @fact MathProgBase.numquadconstr(modQ) --> 1
     @fact MathProgBase.numlinconstr(modQ) --> 0
     @fact MathProgBase.numconstr(modQ) --> 1
@@ -143,12 +143,12 @@ context("With solver $(typeof(solver))") do
 
     # Vectorized version
     modV = Model(solver=solver)
-    @defVar(modV, -2 <= x <= 2 )
-    @defVar(modV, -2 <= y <= 2 )
+    @variable(modV, -2 <= x <= 2 )
+    @variable(modV, -2 <= y <= 2 )
     obj = [1 -1]*[x,y]
-    @setObjective(modV, Min, obj[1])
+    @objective(modV, Min, obj[1])
     A = [1 0.5; 0.5 1]
-    @addConstraint(modV, [x y]*A*[x,y] + [x] .<= [1])
+    @constraint(modV, [x y]*A*[x,y] + [x] .<= [1])
     @fact MathProgBase.numquadconstr(modV) --> 1
     @fact MathProgBase.numlinconstr(modV) --> 0
     @fact MathProgBase.numconstr(modV) --> 1
@@ -159,12 +159,12 @@ context("With solver $(typeof(solver))") do
 
     # Sparse vectorized version
     modV = Model(solver=solver)
-    @defVar(modV, -2 <= x <= 2 )
-    @defVar(modV, -2 <= y <= 2 )
+    @variable(modV, -2 <= x <= 2 )
+    @variable(modV, -2 <= y <= 2 )
     obj = [1 -1]*[x,y]
-    @setObjective(modV, Min, obj[1])
+    @objective(modV, Min, obj[1])
     A = sparse([1 0.5; 0.5 1])
-    @addConstraint(modV, [x y]*A*[x,y] + [x] .<= [1])
+    @constraint(modV, [x y]*A*[x,y] + [x] .<= [1])
     @fact MathProgBase.numquadconstr(modV) --> 1
     @fact MathProgBase.numlinconstr(modV) --> 0
     @fact MathProgBase.numconstr(modV) --> 1
@@ -179,12 +179,12 @@ for solver in soc_solvers
 context("With solver $(typeof(solver))") do
 
     modQ = Model(solver=solver)
-    @defVar(modQ, x)
-    @defVar(modQ, y)
-    @defVar(modQ, t >= 0)
-    @setObjective(modQ, Min, t)
-    @addConstraint(modQ, x+y >= 1)
-    @addConstraint(modQ, x^2 + y^2 <= t^2)
+    @variable(modQ, x)
+    @variable(modQ, y)
+    @variable(modQ, t >= 0)
+    @objective(modQ, Min, t)
+    @constraint(modQ, x+y >= 1)
+    @constraint(modQ, x^2 + y^2 <= t^2)
     @fact JuMP.isquadsoc(modQ) --> true
 
     @fact solve(modQ) --> :Optimal
@@ -193,15 +193,15 @@ context("With solver $(typeof(solver))") do
 
     # Vectorized version
     modV = Model(solver=solver)
-    @defVar(modV, x)
-    @defVar(modV, y)
-    @defVar(modV, t >= 0)
-    @setObjective(modV, Min, t)
-    @addConstraint(modV, [1 1 0]*[x,y,t] .>= 1)
+    @variable(modV, x)
+    @variable(modV, y)
+    @variable(modV, t >= 0)
+    @objective(modV, Min, t)
+    @constraint(modV, [1 1 0]*[x,y,t] .>= 1)
     Q = [1 0  0
          0 1  0
          0 0 -1]
-    @addConstraint(modV, [x y t]*Q*[x,y,t] .<= 0)
+    @constraint(modV, [x y t]*Q*[x,y,t] .<= 0)
 
     @fact solve(modV) --> :Optimal
     @fact modV.objVal --> roughly(sqrt(1/2), 1e-6)
@@ -209,15 +209,15 @@ context("With solver $(typeof(solver))") do
 
     # Sparse vectorized version
     modV = Model(solver=solver)
-    @defVar(modV, x)
-    @defVar(modV, y)
-    @defVar(modV, t >= 0)
-    @setObjective(modV, Min, t)
-    @addConstraint(modV, sparse([1 1 0])*[x,y,t] .>= 1)
+    @variable(modV, x)
+    @variable(modV, y)
+    @variable(modV, t >= 0)
+    @objective(modV, Min, t)
+    @constraint(modV, sparse([1 1 0])*[x,y,t] .>= 1)
     Q = sparse([1 0  0
                 0 1  0
                 0 0 -1])
-    @addConstraint(modV, [x y t]*Q*[x,y,t] .<= 0)
+    @constraint(modV, [x y t]*Q*[x,y,t] .<= 0)
 
     @fact solve(modV) --> :Optimal
     @fact modV.objVal --> roughly(sqrt(1/2), 1e-6)
@@ -225,12 +225,12 @@ context("With solver $(typeof(solver))") do
 
     # SOC version 1
     modN = Model(solver=solver)
-    @defVar(modN, x)
-    @defVar(modN, y)
-    @defVar(modN, t >= 0)
-    @setObjective(modN, Min, t)
-    @addConstraint(modN, x + y >= 1)
-    @addConstraint(modN, norm([x,y]) <= t)
+    @variable(modN, x)
+    @variable(modN, y)
+    @variable(modN, t >= 0)
+    @objective(modN, Min, t)
+    @constraint(modN, x + y >= 1)
+    @constraint(modN, norm([x,y]) <= t)
 
     @fact solve(modN) --> :Optimal
     @fact modN.objVal --> roughly(sqrt(1/2), 1e-6)
@@ -238,13 +238,13 @@ context("With solver $(typeof(solver))") do
 
     # SOC version 2
     modN = Model(solver=solver)
-    @defVar(modN, x)
-    @defVar(modN, y)
-    @defVar(modN, t >= 0)
-    @setObjective(modN, Min, t)
-    @addConstraint(modN, x + y >= 1)
+    @variable(modN, x)
+    @variable(modN, y)
+    @variable(modN, t >= 0)
+    @objective(modN, Min, t)
+    @constraint(modN, x + y >= 1)
     tmp = [x,y]
-    @addConstraint(modN, norm2{tmp[i], i=1:2} <= t)
+    @constraint(modN, norm2{tmp[i], i=1:2} <= t)
 
     @fact solve(modN) --> :Optimal
     @fact modN.objVal --> roughly(sqrt(1/2), 1e-6)
@@ -257,12 +257,12 @@ contains("$(typeof(solver))", "MosekSolver") && continue # Mosek doesn't support
 context("With solver $(typeof(solver))") do
 
     modQ = Model(solver=solver)
-    @defVar(modQ, x >= 0)
-    @defVar(modQ, y)
-    @defVar(modQ, z)
-    @setObjective(modQ, Min, -y-z)
-    @addConstraint(modQ, eq, x <= 1)
-    @addConstraint(modQ, y^2 + z^2 <= x^2)
+    @variable(modQ, x >= 0)
+    @variable(modQ, y)
+    @variable(modQ, z)
+    @objective(modQ, Min, -y-z)
+    @constraint(modQ, eq, x <= 1)
+    @constraint(modQ, y^2 + z^2 <= x^2)
 
     @fact solve(modQ) --> :Optimal
     @fact modQ.objVal --> roughly(-sqrt(2), 1e-6)
@@ -270,7 +270,7 @@ context("With solver $(typeof(solver))") do
     @fact getValue(z) --> roughly(1/sqrt(2), 1e-6)
     @fact getDual(eq) --> roughly(-sqrt(2), 1e-6)
 
-    @setObjective(modQ, Max, y+z)
+    @objective(modQ, Max, y+z)
     @fact solve(modQ) --> :Optimal
     @fact modQ.objVal --> roughly(sqrt(2), 1e-6)
     @fact getValue(y) --> roughly(1/sqrt(2), 1e-6)
@@ -279,13 +279,13 @@ context("With solver $(typeof(solver))") do
 
     # # SOC syntax version
     # modN = Model(solver=solver)
-    # @defVar(modN, x >= 0)
-    # @defVar(modN, y)
-    # @defVar(modN, z)
-    # @setObjective(modN, Min, -y-z)
-    # @addConstraint(modN, eq, x <= 1)
-    # # @addConstraint(modN, y^2 + z^2 <= x^2)
-    # @addConstraint(modN, (1/4)*norm([4.0y,4.0z]) <= x)
+    # @variable(modN, x >= 0)
+    # @variable(modN, y)
+    # @variable(modN, z)
+    # @objective(modN, Min, -y-z)
+    # @constraint(modN, eq, x <= 1)
+    # # @constraint(modN, y^2 + z^2 <= x^2)
+    # @constraint(modN, (1/4)*norm([4.0y,4.0z]) <= x)
     #
     # @fact solve(modN) --> :Optimal
     # @fact modN.objVal --> roughly(-sqrt(2), 1e-6)
@@ -293,7 +293,7 @@ context("With solver $(typeof(solver))") do
     # @fact getValue(z) --> roughly(1/sqrt(2), 1e-6)
     # @fact getDual(eq) --> roughly(-sqrt(2), 1e-6)
     #
-    # @setObjective(modN, Max, y+z)
+    # @objective(modN, Max, y+z)
     # @fact solve(modN) --> :Optimal
     # @fact modN.objVal --> roughly(sqrt(2), 1e-6)
     # @fact getValue(y) --> roughly(1/sqrt(2), 1e-6)
@@ -306,10 +306,10 @@ facts("[qcqpmodel] Test quad constraints (discrete)") do
 for solver in quad_mip_solvers
 context("With solver $(typeof(solver))") do
     modQ = Model(solver=solver)
-    @defVar(modQ, -2 <= x <= 2, Int )
-    @defVar(modQ, -2 <= y <= 2, Int )
-    @setObjective(modQ, Min, x - y )
-    @addConstraint(modQ, x + x*x + x*y + y*y <= 1 )
+    @variable(modQ, -2 <= x <= 2, Int )
+    @variable(modQ, -2 <= y <= 2, Int )
+    @objective(modQ, Min, x - y )
+    @constraint(modQ, x + x*x + x*y + y*y <= 1 )
 
     @fact solve(modQ) --> :Optimal
     @fact modQ.objVal --> roughly(-3, 1e-6)
@@ -321,9 +321,9 @@ facts("[qcqpmodel] Test simple normed problem") do
 for solver in soc_solvers
 context("With solver $(typeof(solver))") do
     m = Model(solver=solver);
-    @defVar(m, x[1:3]);
-    @addConstraint(m, 2norm2{x[i]-1, i=1:3} <= 2)
-    @setObjective(m, Max, x[1]+x[2])
+    @variable(m, x[1:3]);
+    @constraint(m, 2norm2{x[i]-1, i=1:3} <= 2)
+    @objective(m, Max, x[1]+x[2])
 
     @fact solve(m) --> :Optimal
     @fact getObjectiveValue(m) --> roughly(2+sqrt(2), 1e-5)
@@ -337,20 +337,20 @@ for solver in quad_solvers
 context("With solver $(typeof(solver))") do
 
     modQ = Model(solver=solver)
-    @defVar(modQ, x >= 0)
-    @addConstraint(modQ, x*x <= 1)
-    @setObjective(modQ, Max, x)
+    @variable(modQ, x >= 0)
+    @constraint(modQ, x*x <= 1)
+    @objective(modQ, Max, x)
     @fact solve(modQ) --> :Optimal
     @fact getObjectiveValue(modQ) --> roughly(1.0, 1e-6)
 
-    @addConstraint(modQ, 2x*x <= 1)
+    @constraint(modQ, 2x*x <= 1)
     @fact modQ.internalModelLoaded --> true
     @fact solve(modQ) --> :Optimal
     @fact getObjectiveValue(modQ) --> roughly(sqrt(0.5), 1e-6)
 
     modQ = Model(solver=solver)
-    @defVar(modQ,   0 <= x <= 1)
-    @defVar(modQ, 1/2 <= y <= 1)
+    @variable(modQ,   0 <= x <= 1)
+    @variable(modQ, 1/2 <= y <= 1)
     setObjective(modQ, :Min, x*x - y)
     @fact solve(modQ) --> :Optimal
     @fact getObjectiveValue(modQ) --> roughly(-1.0, 1e-6)
@@ -366,14 +366,14 @@ for solver in rsoc_solvers
 context("With solver $(typeof(solver))") do
     mod = Model(solver=solver)
 
-    @defVar(mod, x[1:5] >= 0)
-    @defVar(mod, 0 <= u <= 5)
-    @defVar(mod, v)
+    @variable(mod, x[1:5] >= 0)
+    @variable(mod, 0 <= u <= 5)
+    @variable(mod, v)
 
-    @setObjective(mod, Max, v)
+    @objective(mod, Max, v)
 
-    @addConstraint(mod, norm(x) <= 1)
-    @addConstraint(mod, v^2 <= u * x[1])
+    @constraint(mod, norm(x) <= 1)
+    @constraint(mod, v^2 <= u * x[1])
 
     @fact solve(mod) --> :Optimal
     @fact getValue(x) --> roughly([1,0,0,0,0], 1e-2)

--- a/test/socduals.jl
+++ b/test/socduals.jl
@@ -10,12 +10,12 @@ for solver in conic_solvers_with_duals
 context("With solver $(typeof(solver))") do
     m = Model(solver=solver)
 
-    @defVar(m, x[1:5])
-    @setObjective(m, Max, x[1] + x[2] + x[3] + x[4] + 2*x[5])
-    @addConstraint(m, constrcon1, norm(x[2:5]) <= x[1])
-    @addConstraint(m, constrlin1, x[1] <= 5)
-    @addConstraint(m, constrlin2, x[1]+2*x[2] - x[3] <= 10)
-    @addConstraint(m, constrcon2, norm([2 3;1 1]*x[2:3]-[3;4]) <= x[5] - 2)
+    @variable(m, x[1:5])
+    @objective(m, Max, x[1] + x[2] + x[3] + x[4] + 2*x[5])
+    @constraint(m, constrcon1, norm(x[2:5]) <= x[1])
+    @constraint(m, constrlin1, x[1] <= 5)
+    @constraint(m, constrlin2, x[1]+2*x[2] - x[3] <= 10)
+    @constraint(m, constrcon2, norm([2 3;1 1]*x[2:3]-[3;4]) <= x[5] - 2)
 
     solve(m)
     @fact length(getDual(constrcon1)) --> 5
@@ -36,11 +36,11 @@ for lp_solver in lp_solvers
 context("With LP solver $(typeof(lp_solver))") do
 
     m1 = Model(solver=lp_solver)
-    @defVar(m1, x1[1:2] >= 0)
-    @setObjective(m1, Max, x1[1] + 2x1[2])
-    @addConstraint(m1, c11, 3x1[1] + x1[2] <= 4)
-    @addConstraint(m1, c12, x1[1] + 2x1[2] >= 1)
-    @addConstraint(m1, c13, -x1[1] + x1[2] == 0.5)
+    @variable(m1, x1[1:2] >= 0)
+    @objective(m1, Max, x1[1] + 2x1[2])
+    @constraint(m1, c11, 3x1[1] + x1[2] <= 4)
+    @constraint(m1, c12, x1[1] + 2x1[2] >= 1)
+    @constraint(m1, c13, -x1[1] + x1[2] == 0.5)
 
     solve(m1)
 
@@ -54,12 +54,12 @@ for  conic_solver in conic_solvers_with_duals
 context("With conic solver $(typeof(conic_solver))") do
 
     m2 = Model(solver=conic_solver)
-    @defVar(m2, x2[1:2] >= 0)
-    @setObjective(m2, Max, x2[1] + 2x2[2])
-    @addConstraint(m2, c21, 3x2[1] + x2[2] <= 4)
-    @addConstraint(m2, c22, x2[1] + 2x2[2] >= 1)
-    @addConstraint(m2, c23, -x2[1] + x2[2] == 0.5)
-    @addConstraint(m2, norm(x2[1]) <= x2[2])
+    @variable(m2, x2[1:2] >= 0)
+    @objective(m2, Max, x2[1] + 2x2[2])
+    @constraint(m2, c21, 3x2[1] + x2[2] <= 4)
+    @constraint(m2, c22, x2[1] + 2x2[2] >= 1)
+    @constraint(m2, c23, -x2[1] + x2[2] == 0.5)
+    @constraint(m2, norm(x2[1]) <= x2[2])
 
     solve(m2)
 
@@ -76,11 +76,11 @@ for lp_solver in lp_solvers
 context("With LP solver $(typeof(lp_solver))") do
 
     m1 = Model(solver=lp_solver)
-    @defVar(m1, x1[1:2] >= 0)
-    @setObjective(m1, Min, -x1[1] - 2x1[2])
-    @addConstraint(m1, c11, 3x1[1] + x1[2] <= 4)
-    @addConstraint(m1, c12, x1[1] + 2x1[2] >= 1)
-    @addConstraint(m1, c13, -x1[1] + x1[2] == 0.5)
+    @variable(m1, x1[1:2] >= 0)
+    @objective(m1, Min, -x1[1] - 2x1[2])
+    @constraint(m1, c11, 3x1[1] + x1[2] <= 4)
+    @constraint(m1, c12, x1[1] + 2x1[2] >= 1)
+    @constraint(m1, c13, -x1[1] + x1[2] == 0.5)
 
     solve(m1)
 
@@ -94,12 +94,12 @@ for  conic_solver in conic_solvers_with_duals
 context("With conic solver $(typeof(conic_solver))") do
 
     m2 = Model(solver=conic_solver)
-    @defVar(m2, x2[1:2] >= 0)
-    @setObjective(m2, Min, -x2[1] - 2x2[2])
-    @addConstraint(m2, c21, 3x2[1] + x2[2] <= 4)
-    @addConstraint(m2, c22, x2[1] + 2x2[2] >= 1)
-    @addConstraint(m2, c23, -x2[1] + x2[2] == 0.5)
-    @addConstraint(m2, norm(x2[1]) <= x2[2])
+    @variable(m2, x2[1:2] >= 0)
+    @objective(m2, Min, -x2[1] - 2x2[2])
+    @constraint(m2, c21, 3x2[1] + x2[2] <= 4)
+    @constraint(m2, c22, x2[1] + 2x2[2] >= 1)
+    @constraint(m2, c23, -x2[1] + x2[2] == 0.5)
+    @constraint(m2, norm(x2[1]) <= x2[2])
 
     solve(m2)
     @fact getDual(c21) --> roughly(-0.75, TOL)
@@ -116,10 +116,10 @@ context("With LP solver $(typeof(lp_solver))") do
 
     m1 = Model(solver=lp_solver)
 
-    @defVar(m1, x1 >= 0)
-    @defVar(m1, y1 >= 0)
-    @addConstraint(m1, x1 + y1 == 1)
-    @setObjective(m1, Max, y1)
+    @variable(m1, x1 >= 0)
+    @variable(m1, y1 >= 0)
+    @constraint(m1, x1 + y1 == 1)
+    @objective(m1, Max, y1)
 
     solve(m1)
 
@@ -130,9 +130,9 @@ context("With LP solver $(typeof(lp_solver))") do
 
     m1 = Model(solver=lp_solver)
 
-    @defVar(m1, x1 >= 0)
-    @addConstraint(m1, x1 <= 1)
-    @setObjective(m1, Max, x1)
+    @variable(m1, x1 >= 0)
+    @constraint(m1, x1 <= 1)
+    @objective(m1, Max, x1)
 
     solve(m1)
 
@@ -145,10 +145,10 @@ context("With LP solver $(typeof(lp_solver))") do
 
     m1 = Model(solver=lp_solver)
 
-    @defVar(m1, x1 >= X_LB)
-    @defVar(m1, y1 <= Y_UB)
-    @addConstraint(m1, c1,  x1 + y1 == RHS)
-    @setObjective(m1, Max, 0.8*y1 + 0.1*x1)
+    @variable(m1, x1 >= X_LB)
+    @variable(m1, y1 <= Y_UB)
+    @constraint(m1, c1,  x1 + y1 == RHS)
+    @objective(m1, Max, 0.8*y1 + 0.1*x1)
 
     solve(m1)
 
@@ -168,11 +168,11 @@ context("With conic solver $(typeof(conic_solver))") do
 
     m2 = Model(solver=conic_solver)
 
-    @defVar(m2, x2 >= 0)
-    @defVar(m2, y2 >= 0)
-    @addConstraint(m2, x2 + y2 == 1)
-    @setObjective(m2, Max, y2)
-    @addConstraint(m2, norm(x2) <= y2)
+    @variable(m2, x2 >= 0)
+    @variable(m2, y2 >= 0)
+    @constraint(m2, x2 + y2 == 1)
+    @objective(m2, Max, y2)
+    @constraint(m2, norm(x2) <= y2)
 
     solve(m2)
 
@@ -183,10 +183,10 @@ context("With conic solver $(typeof(conic_solver))") do
 
     m2 = Model(solver=conic_solver)
 
-    @defVar(m2, x2 >= 0)
-    @addConstraint(m2, x2 <= 1)
-    @setObjective(m2, Max, x2)
-    @addConstraint(m2, norm(x2) <= x2)
+    @variable(m2, x2 >= 0)
+    @constraint(m2, x2 <= 1)
+    @objective(m2, Max, x2)
+    @constraint(m2, norm(x2) <= x2)
 
     solve(m2)
 
@@ -199,11 +199,11 @@ context("With conic solver $(typeof(conic_solver))") do
 
     m2 = Model(solver=conic_solver)
 
-    @defVar(m2, x2 >= X_LB)
-    @defVar(m2, y2 <= Y_UB)
-    @addConstraint(m2, c2, x2 + y2 == RHS)
-    @setObjective(m2, Max, 0.8*y2 + 0.1*x2)
-    @addConstraint(m2, norm(x2) <= y2)
+    @variable(m2, x2 >= X_LB)
+    @variable(m2, y2 <= Y_UB)
+    @constraint(m2, c2, x2 + y2 == RHS)
+    @objective(m2, Max, 0.8*y2 + 0.1*x2)
+    @constraint(m2, norm(x2) <= y2)
 
     solve(m2)
 
@@ -231,10 +231,10 @@ context("With conic solver $(typeof(conic_solver))") do
 
     m2 = Model(solver=conic_solver)
 
-    @defVar(m2, x2 >= 0)
-    @addConstraint(m2, x2 <= 1)
-    @setObjective(m2, Max, x2)
-    @addConstraint(m2, c2, norm(x2) <= x2 - 1)
+    @variable(m2, x2 >= 0)
+    @constraint(m2, x2 <= 1)
+    @objective(m2, Max, x2)
+    @constraint(m2, c2, norm(x2) <= x2 - 1)
 
     status = solve(m2)
 

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -15,26 +15,26 @@ using JuMP, FactCheck
 facts("[variable] constructors") do
     # Constructors
     mcon = Model()
-    @defVar(mcon, nobounds)
-    @defVar(mcon, lbonly >= 0)
-    @defVar(mcon, ubonly <= 1)
-    @defVar(mcon, 0 <= bothb <= 1)
-    @defVar(mcon, 0 <= onerange[-5:5] <= 10)
-    @defVar(mcon, onerangeub[-7:1] <= 10, Int)
-    @defVar(mcon, manyrangelb[0:1,10:20,1:1] >= 2)
+    @variable(mcon, nobounds)
+    @variable(mcon, lbonly >= 0)
+    @variable(mcon, ubonly <= 1)
+    @variable(mcon, 0 <= bothb <= 1)
+    @variable(mcon, 0 <= onerange[-5:5] <= 10)
+    @variable(mcon, onerangeub[-7:1] <= 10, Int)
+    @variable(mcon, manyrangelb[0:1,10:20,1:1] >= 2)
     @fact getLower(manyrangelb[0,15,1]) --> 2
     s = ["Green","Blue"]
-    @defVar(mcon, x[i=-10:10,s] <= 5.5, Int, start=i+1)
+    @variable(mcon, x[i=-10:10,s] <= 5.5, Int, start=i+1)
     @fact getUpper(x[-4,"Green"]) --> 5.5
     @fact getValue(x[-3,"Blue"]) --> -2
     @fact isequal(getVar(mcon, :lbonly),lbonly) --> true
     @fact isequal(getVar(mcon, :ubonly),ubonly) --> true
     @fact isequal(getVar(mcon, :onerangeub)[-7],onerangeub[-7]) --> true
-    @defVar(mcon, lbonly)
+    @variable(mcon, lbonly)
     @fact_throws ErrorException getVar(mcon, :lbonly)
     @fact_throws ErrorException getVar(mcon, :foo)
     d = Dict()
-    @defVar(mcon, d["bar"][1:10] == 1)
+    @variable(mcon, d["bar"][1:10] == 1)
     @fact getValue(d["bar"][1]) --> 1
     @fact typeof(zero(nobounds)) --> AffExpr
     @fact typeof(one(nobounds)) --> AffExpr
@@ -42,20 +42,20 @@ end
 
 facts("[variable] get and set bounds") do
     m = Model()
-    @defVar(m, 0 <= x <= 2)
+    @variable(m, 0 <= x <= 2)
     @fact getLower(x) --> 0
     @fact getUpper(x) --> 2
     setLower(x, 1)
     @fact getLower(x) --> 1
     setUpper(x, 3)
     @fact getUpper(x) --> 3
-    @defVar(m, y, Bin)
+    @variable(m, y, Bin)
     @fact getLower(y) --> 0
     @fact getUpper(y) --> 1
-    @defVar(m, 0 <= y <= 1, Bin)
+    @variable(m, 0 <= y <= 1, Bin)
     @fact getLower(y) --> 0
     @fact getUpper(y) --> 1
-    @defVar(m, fixedvar == 2)
+    @variable(m, fixedvar == 2)
     @fact getValue(fixedvar) --> 2
     @fact getLower(fixedvar) --> 2
     @fact getUpper(fixedvar) --> 2
@@ -67,19 +67,19 @@ end
 
 facts("[variable] get and set values") do
     m = Model()
-    @defVar(m, x[1:3])
+    @variable(m, x[1:3])
     x0 = collect(1:3)
     setValue(x, x0)
     @fact getValue(x) --> x0
     @fact getValue([x[1],x[2],x[3]]) --> x0
 
-    @defVar(m, y[1:3,1:2])
+    @variable(m, y[1:3,1:2])
     @fact_throws DimensionMismatch setValue(y, collect(1:6))
 end
 
 facts("[variable] get and set category") do
     m = Model()
-    @defVar(m, x[1:3])
+    @variable(m, x[1:3])
     setCategory(x[2], :Int)
     @fact getCategory(x[3]) --> :Cont
     @fact getCategory(x[2]) --> :Int
@@ -88,7 +88,7 @@ end
 facts("[variable] repeated elements in index set (issue #199)") do
     repeatmod = Model()
     s = [:x,:x,:y]
-    @defVar(repeatmod, x[s])
+    @variable(repeatmod, x[s])
     @fact MathProgBase.numvar(repeatmod) --> 3
 end
 
@@ -99,19 +99,19 @@ if VERSION >= v"0.4-"
 
     facts("[variable] condition in indexing") do
         condmod = Model()
-        @defVar(condmod, x[i=1:10; iseven(i)])
-        @defVar(condmod, y[j=1:10,k=3:2:9; isodd(j+k) && k <= 8])
+        @variable(condmod, x[i=1:10; iseven(i)])
+        @variable(condmod, y[j=1:10,k=3:2:9; isodd(j+k) && k <= 8])
         @fact length(x.tupledict) --> 5
         @fact length(y.tupledict) --> 15
         @fact string(condmod) --> "Min 0\nSubject to\n x[i] free $fa i $inset {1,2,$dots,9,10} s.t. iseven(i)\n y[j,k] free $fa j $inset {1,2,$dots,9,10}, k $inset {3,5,7,9} s.t. isodd(j + k) and k <= 8\n"
     end
 end
 
-facts("[variable] @defVar returning Array{Variable}") do
+facts("[variable] @variable returning Array{Variable}") do
     m = Model()
-    @defVar(m, x[1:3,1:4,1:2])
-    @defVar(m, y[1:0])
-    @defVar(m, z[1:4])
+    @variable(m, x[1:3,1:4,1:2])
+    @variable(m, y[1:0])
+    @variable(m, z[1:4])
 
     @fact typeof(x) --> Array{Variable,3}
     @fact typeof(y) --> Array{Variable,1}
@@ -124,9 +124,9 @@ end
 
 facts("[variable] getValue on empty things") do
     m = Model()
-    @defVar(m, x[1:4,  1:0,1:3])   # Array{Variable}
-    @defVar(m, y[1:4,  2:1,1:3]) # JuMPArray
-    @defVar(m, z[1:4,Set(),1:3]) # JuMPDict
+    @variable(m, x[1:4,  1:0,1:3])   # Array{Variable}
+    @variable(m, y[1:4,  2:1,1:3]) # JuMPArray
+    @variable(m, z[1:4,Set(),1:3]) # JuMPDict
 
     @fact getValue(x) --> Array(Float64, 4, 0, 3)
     @fact typeof(getValue(y)) <: JuMP.JuMPArray{Float64} --> true
@@ -173,10 +173,10 @@ end
 
 facts("[variable] Slices of JuMPArray (#684)") do
     m = Model()
-    @defVar(m, x[1:3, 1:4,1:2])
-    @defVar(m, y[1:3,-1:2,3:4])
-    @defVar(m, z[1:3,-1:2:4,3:4])
-    @defVar(m, w[1:3,-1:2,[:red,"blue"]])
+    @variable(m, x[1:3, 1:4,1:2])
+    @variable(m, y[1:3,-1:2,3:4])
+    @variable(m, z[1:3,-1:2:4,3:4])
+    @variable(m, w[1:3,-1:2,[:red,"blue"]])
 
     @fact x[:] --> vec(sliceof(x, 1:3, 1:4, 1:2, 0, 0, 0))
     @fact x[:,:,:] --> sliceof(x, 1:3, 1:4, 1:2, 0, 0, 0)


### PR DESCRIPTION
We're getting rid of camelCase, it's happening. 

So far I've implemented the change for the main macros.
``@defVar`` -> ``@variable``
``@addConstraint`` -> ``@constraint``
``@setObjective`` -> ``@objective``
``@setNLObjective`` -> ``@NLobjective``
``@addNLConstraint`` -> ``@NLconstraint``
``@addSDPConstraint`` -> ``@SDconstraint``
``@defVars`` -> ``@variables``
``@addConstraints`` -> ``@constraints``
``@addNLConstraints`` -> ``@NLconstraints``

HS109 now looks like:
```julia
m = Model()
@variables m begin
    L[i] <= x[i=1:9] <= U[i], (start = 0.0)
end

@NLobjective(m, Min, 3 * x[1] + 1e-6 * x[1]^3 + 2 * x[2] + .522074e-6 * x[2]^3)

@NLconstraints(m, begin
    x[4] - x[3] + 0.55 >= 0
    x[3] - x[4] + 0.55 >= 0
    2250000 - x[1]^2 - x[8]^2 >= 0
    2250000 - x[2]^2 - x[9]^2 >= 0
    x[5] * x[6] * sin(-x[3] - .25) + x[5] * x[7] * sin(-x[4] - .25) +
        2 * b * x[5]^2 - a * x[1] + 400 * a == 0

    x[5] * x[6] * sin(x[3] - .25) + x[6] * x[7] * sin(x[3] - x[4] - .25) +
        2 * b * x[6]^2 - a * x[2] + 400 * a == 0

    x[5] * x[7] * sin(x[4] - .25) + x[6] * x[7] * sin(x[4] - x[3] - .25) +
        2 * b * x[7]^2 + 881.779 * a == 0

    a * x[8] + x[5] * x[6] * cos(-x[3] - .25) +
        x[5] * x[7] * cos(-x[4] - .25) - 200 * a - 2 * c * x[5]^2 +
        .7533e-3 * a * x[5]^2 == 0

    a * x[9] + x[5] * x[6] * cos(x[3] - .25) +
        x[6] * x[7] * cos(x[3] - x[4] - .25) - 2 * c * x[6]^2 +
        .7533e-3 * a * x[6]^2 - 200 * a == 0

    x[5] * x[7] * cos(x[4] - .25) + x[6] * x[7] * cos(x[4] - x[3] - .25) -
        2 * c * x[7]^2 + 22.938 * a + .7533e-3 * a * x[7] ^2 == 0
end)
```