### PR TITLE
disable unsafe 'end' syntax

### DIFF
--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -135,9 +135,16 @@ Base.length(x::JuMPDict) = length(x.tupledict)
 
 Base.ndims{T,N}(x::JuMPDict{T,N}) = N
 Base.abs(x::JuMPDict) = map(abs, x)
+# avoid dangerous behavior with "end" (#730)
+Base.endof(x::JuMPArray) = error("endof() (and \"end\" syntax) not implemented for JuMPArray objects.")
+Base.size(x::JuMPArray) = error("size (and \"end\" syntax) not implemented for JuMPArray objects. Use JuMP.size if you want to access the dimensions.")
+Base.size(x::JuMPArray,k) = error("size (and \"end\" syntax) not implemented for JuMPArray objects. Use JuMP.size if you want to access the dimensions.")
+size(x::JuMPArray) = size(x.innerArray)
+size(x::JuMPArray,k) = size(x.innerArray,k)
+# for uses of size() within JuMP
+size(x) = Base.size(x)
+size(x,k) = Base.size(x,k)
 # delegate one-argument functions
-Base.size(x::JuMPArray)   = size(x.innerArray)
-Base.size(x::JuMPArray,k) = size(x.innerArray,k)
 Compat.issymmetric(x::JuMPArray) = Compat.issymmetric(x.innerArray)
 
 Base.eltype{T}(x::JuMPContainer{T}) = T

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -130,7 +130,7 @@ facts("[variable] getvalue on empty things") do
 
     @fact getvalue(x) --> Array(Float64, 4, 0, 3)
     @fact typeof(getvalue(y)) <: JuMP.JuMPArray{Float64} --> true
-    @fact size(getvalue(y)) --> (4,0,3)
+    @fact JuMP.size(getvalue(y)) --> (4,0,3)
     @fact typeof(getvalue(z)) --> JuMP.JuMPArray{Float64,3,Tuple{UnitRange{Int},Set{Any},UnitRange{Int}}}
     @fact length(getvalue(z)) --> 0
 end
@@ -213,11 +213,13 @@ end
 
 facts("[variable] Can't use end for indexing a JuMPContainer") do
     m = Model()
-    @defVar(m, x[0:2,1:4])
-    @defVar(m, y[i=1:4,j=1:4;true])
+    @variable(m, x[0:2,1:4])
+    @variable(m, y[i=1:4,j=1:4;true])
+    @variable(m, z[0:2])
     @fact_throws x[end,1]
     @fact_throws x[end-1]
-    @fact x[0,end-1] --> x[0,3]
+    @fact_throws x[0,end-1]
     @fact_throws y[end,end-1]
     @fact_throws y[end,1]
+    @fact_throws z[end]
 end


### PR DESCRIPTION
We can reimplement ``size`` once https://github.com/JuliaLang/julia/issues/16104 is resolved, but in the meantime I don't think we have a choice but to turn ``end`` into an error because it can lead to surprisingly incorrect user code.

Ref #730