### PR TITLE
Remove loud popup in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Our documentation includes an installation guide, quick-start guide, and referen
 
 
 **Development version**:
-  * [Documentation](https://jump.readthedocs.org/en/latest)
+  * [Documentation](https://jump.readthedocs.io/en/latest)
   * [Examples](https://github.com/JuliaOpt/JuMP.jl/tree/master/examples)
   * Testing status:
     * TravisCI: [![Build Status](https://travis-ci.org/JuliaOpt/JuMP.jl.svg?branch=master)](https://travis-ci.org/JuliaOpt/JuMP.jl)

--- a/doc/warn.rst
+++ b/doc/warn.rst
@@ -1,7 +1,7 @@
 
 .. raw:: html
 
-    <div id="officialwarn" class="admonition warning" style="position: fixed; top: 1em; right: 1em;">
+    <div id="officialwarn" class="admonition warning">
     <p class="first admonition-title">Warning</p>
     <p class="last">This documentation tracks the development branch of JuMP. For the documentation of the latest JuMP release, see <a href="http://www.juliaopt.org/JuMP.jl/0.13/">here</a>.</p>
     </div>


### PR DESCRIPTION
Given the usability issues with https://github.com/JuliaOpt/JuMP.jl/pull/745 and that there's no longer a big divergence between the release and dev docs, I think we can make this less annoying.