### PR TITLE
handling the "local cuts" variant for lazy constraints and user cuts

### DIFF
--- a/doc/callbacks.rst
+++ b/doc/callbacks.rst
@@ -32,6 +32,8 @@ to the callback management code inside JuMP. Next you will do whatever
 analysis of the solution you need to inside your function to generate the new
 constraint before adding it to the model with
 ``@lazyconstraint(cb, myconstraint)``.
+There is an optional keyword option ``localcut`` to ``@lazyconstraint``, which indicates if the lazy constraint that will be added will only apply at the current node and the tree rooted at that node.
+For example, ``@lazyconstraint(cb, myconstraint, localcut=true)``. By default, ``localcut`` is set to ``false``.
 Finally we notify JuMP that this function should be used for lazy constraint
 generation using the ``addlazycallback(m, myLazyConGenerator)`` function
 before we call ``solve(m)``.
@@ -131,8 +133,10 @@ single argument, e.g. ``function myUserCutGenerator(cb)``, where cb is a referen
 to the callback management code inside JuMP. Next you will do whatever
 analysis of the solution you need to inside your function to generate the new
 constraint before adding it to the model with the JuMP macro
-``@addusercut(cb, myconstraint)`` (same limitations as addConstraint).
-Finally we notify JuMP that this function should be used for lazy constraint
+``@usercut(cb, myconstraint)`` (same limitations as addConstraint).
+There is an optional keyword option ``localcut`` to ``@usercut``, which indicates if the user cut that will be added will only apply at the current node and the tree rooted at that node.
+For example, ``@usercut(cb, myconstraint, localcut=true)``. By default, ``localcut`` is set to ``false``.
+Finally we notify JuMP that this function should be used for user cut
 generation using the ``addcutcallback(m, myUserCutGenerator)`` function
 before we call ``solve(m)``.
 

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -160,8 +160,23 @@ const sensemap = Dict(:(<=) => '<', :(==) => '=', :(>=) => '>')
 ## Lazy constraints
 export @lazyconstraint
 
-macro lazyconstraint(cbdata, x)
-    cbdata = esc(cbdata)
+macro lazyconstraint(args...)
+    cbdata = esc(args[1])
+    x = args[2]
+    extra = vcat(args[3:end]...)
+    # separate out keyword arguments
+    kwargs = filter(ex->isexpr(ex,:kw), extra) # filtering expressions corresponding to kw args specs
+    extra = filter(ex->!isexpr(ex,:kw), extra) # others
+
+    localcut_val = false # by default, the lazy constraint is global
+    for ex in kwargs
+        kwarg = ex.args[1]
+        if kwarg == :localcut
+            localcut_val = esc(ex.args[2])   # excepted if otherwise specified ...
+        else error("in @lazyconstraint($(join(args,','))), invalid keyword argument: $(kwarg)")
+        end
+    end
+
     if VERSION < v"0.5.0-dev+3231"
         x = comparison_to_call(x)
     end
@@ -174,14 +189,14 @@ macro lazyconstraint(cbdata, x)
             aff = zero(AffExpr)
             $parsecode
             constr = constructconstraint!($newaff, $(quot(sense)))
-            addlazyconstraint($cbdata, constr)
+            addlazyconstraint($cbdata, constr, localcut=$localcut_val)
         end
     else
         error("Syntax error in @lazyconstraint, expected one-sided comparison.")
     end
 end
 
-function addlazyconstraint(cbdata::MathProgBase.MathProgCallbackData, constr::LinearConstraint)
+function addlazyconstraint(cbdata::MathProgBase.MathProgCallbackData, constr::LinearConstraint; localcut::Bool=false)
     if length(constr.terms.vars) == 0
         MathProgBase.cbaddlazy!(cbdata, Cint[], Float64[], sensemap[sense(constr)], rhs(constr))
         return
@@ -189,17 +204,38 @@ function addlazyconstraint(cbdata::MathProgBase.MathProgCallbackData, constr::Li
     assert_isfinite(constr.terms)
     m::Model = constr.terms.vars[1].m
     indices, coeffs = merge_duplicates(Cint, constr.terms, m.indexedVector, m)
-    MathProgBase.cbaddlazy!(cbdata, indices, coeffs, sensemap[sense(constr)], rhs(constr))
+    if localcut
+        MathProgBase.cbaddlazylocal!(cbdata, indices, coeffs, sensemap[sense(constr)], rhs(constr))
+    else
+        MathProgBase.cbaddlazy!(cbdata, indices, coeffs, sensemap[sense(constr)], rhs(constr))
+    end
+
 end
 
-addlazyconstraint(cbdata::MathProgBase.MathProgCallbackData,constr::QuadConstraint) = error("Quadratic lazy constraints are not supported.")
+addlazyconstraint(cbdata::MathProgBase.MathProgCallbackData,constr::QuadConstraint; localcut::Bool=false) = error("Quadratic lazy constraints are not supported.")
 
 ## User cuts
 export addusercut
 export @usercut
 
-macro usercut(cbdata, x)
-    cbdata = esc(cbdata)
+macro usercut(args...)
+    cbdata = esc(args[1])
+    x = args[2]
+    extra = vcat(args[3:end]...)
+    # separate out keyword arguments
+    kwargs = filter(ex->isexpr(ex,:kw), extra) # filtering expressions corresponding to kw args specs
+    extra = filter(ex->!isexpr(ex,:kw), extra) # others
+
+    localcut_val = false # by default, the user cut is global
+    for ex in kwargs
+        kwarg = ex.args[1]
+        if kwarg == :localcut
+            localcut_val = esc(ex.args[2])   # excepted if otherwise specified ...
+        else error("in @usercut($(join(args,','))), invalid keyword argument: $(kwarg)")
+        end
+    end
+
+    #cbdata = esc(cbdata)
     if VERSION < v"0.5.0-dev+3231"
         x = comparison_to_call(x)
     end
@@ -212,14 +248,14 @@ macro usercut(cbdata, x)
             aff = zero(AffExpr)
             $parsecode
             constr = constructconstraint!($newaff, $(quot(sense)))
-            addusercut($cbdata, constr)
+            addusercut($cbdata, constr, localcut=$localcut_val)
         end
     else
         error("Syntax error in @usercut, expected one-sided comparison.")
     end
 end
 
-function addusercut(cbdata::MathProgBase.MathProgCallbackData, constr::LinearConstraint)
+function addusercut(cbdata::MathProgBase.MathProgCallbackData, constr::LinearConstraint; localcut::Bool=false)
     if length(constr.terms.vars) == 0
         MathProgBase.cbaddcut!(cbdata, Cint[], Float64[], sensemap[sense(constr)], rhs(constr))
         return
@@ -227,7 +263,11 @@ function addusercut(cbdata::MathProgBase.MathProgCallbackData, constr::LinearCon
     assert_isfinite(constr.terms)
     m::Model = constr.terms.vars[1].m
     indices, coeffs = merge_duplicates(Cint, constr.terms, m.indexedVector, m)
-    MathProgBase.cbaddcut!(cbdata, indices, coeffs, sensemap[sense(constr)], rhs(constr))
+    if localcut
+        MathProgBase.cbaddcutlocal!(cbdata, indices, coeffs, sensemap[sense(constr)], rhs(constr))
+    else
+        MathProgBase.cbaddcut!(cbdata, indices, coeffs, sensemap[sense(constr)], rhs(constr))
+    end
 end
 
 ## User heuristic

--- a/test/callback.jl
+++ b/test/callback.jl
@@ -42,6 +42,38 @@ context("With solver $(typeof(lazysolver))") do
     @fact getvalue(y) --> roughly(2.0, 1e-6)
 end; end; end
 
+facts("[callback] Test local lazy constraints") do
+for lazylocalsolver in lazylocal_solvers
+context("With solver $(typeof(lazylocalsolver))") do
+    entered = [false,false, false]
+
+    weights = [24714888; 21118272; 5063487; 23450813; 5598179; 4049178; 13516450; 8385365; 9684076; 31317634; 14084148; 21750211; 29261668; 17996589; 12115244]
+    values = weights
+    W = floor(sum(weights)/2) # knsapsack instance generated according to criteria in 'Hard knapsack Instances' (Chvatal, Op. Res., 1980), with weights composed of random integers in [1:10^(nbItems / 2)]
+    mod = Model(solver=lazylocalsolver)
+    @variable(mod, 0 <= x[1:length(weights)] <= 1, Int)
+    @objective(mod, Max, dot(x, values))
+    @constraint(mod, dot(x, weights) <=  W)
+
+    function mycb_localzero(cb)
+        nodesexpl = MathProgBase.cbgetexplorednodes(cb)
+        if  entered[1] == false && nodesexpl >= 1
+            # the following lazy cut  constrains all x[i] to be zero, but applies only locally at the node of the first feasible solution found: it doesn't preclude the existence of "optimal" non-trival solutions
+            @lazyconstraint(cb, sum{x[i], i=1:length(weights)} <= 0, localcut=true)
+            # @lazyconstraint(cb, sum{x[i], i=1:length(weights)} <= 0) # applying the cut globally would lead the solver to x=0 as the optimal solution
+            @fact macroexpand(:(@lazyconstraint(cb, sum{x[i], i=1:length(weights)} <= 0, badkwarg=true))).head --> :error
+            entered[1] = true
+        end
+        entered[2] = true
+    end
+    addlazycallback(mod, mycb_localzero)
+    addlazycallback(mod, cb -> (entered[3] = true))
+    @fact solve(mod) --> :Optimal
+    @fact entered --> [true,true,true]
+    @fact sum(getvalue(x)) --> greater_than(0)
+end; end; end
+
+
 facts("[callback] Test user cuts") do
 for cutsolver in cut_solvers
 context("With solver $(typeof(cutsolver))") do
@@ -65,6 +97,38 @@ context("With solver $(typeof(cutsolver))") do
     @fact entered --> [true,true]
     @fact find(getvalue(x)[:]) --> [35,38,283,305,359,397,419,426,442,453,526,553,659,751,840,865,878,978]
 end; end; end
+
+facts("[callback] Test local user cuts") do
+for cutlocalsolver in cutlocal_solvers
+context("With solver $(typeof(cutlocalsolver))") do
+    entered = [false,false, false]
+
+    weights = [24714888; 21118272; 5063487; 23450813; 5598179; 4049178; 13516450; 8385365; 9684076; 31317634; 14084148; 21750211; 29261668; 17996589; 12115244]
+    values = weights
+    W = floor(sum(weights)/2) # knsapsack instance generated according to criteria in 'Hard knapsack Instances' (Chvatal, Op. Res., 1980), with weights composed of random integers in [1:10^(nbItems / 2)]
+    mod = Model(solver=cutlocalsolver)
+    @variable(mod, 0 <= x[1:length(weights)] <= 1, Int)
+    @objective(mod, Max, dot(x, values))
+    @constraint(mod, dot(x, weights) <=  W)
+
+    function mycb_localzero(cb)
+        nodesexpl = MathProgBase.cbgetexplorednodes(cb)
+        if  entered[1] == false && nodesexpl >= 1
+            # the following user cut  constrains all x[i] to be zero, but applies only locally at the first node after the root node, and doesn't preclude the existence non-trival "optimal" solutions
+            @usercut(cb, sum{x[i], i=1:length(weights)} <= 0, localcut=true)
+            # @usercut(cb, sum{x[i], i=1:length(weights)} <= 0) # applying the cut globally would lead the solver to x=0 as the optimal solution
+            @fact macroexpand(:(@usercut(cb, sum{x[i], i=1:length(weights)} <= 0, badkwarg=true))).head --> :error
+            entered[1] = true
+        end
+        entered[2] = true
+    end
+    addcutcallback(mod, mycb_localzero)
+    addcutcallback(mod, cb -> (entered[3] = true))
+    @fact solve(mod) --> :Optimal
+    @fact entered --> [true,true,true]
+    @fact sum(getvalue(x)) --> greater_than(0)
+end; end; end
+
 
 facts("[callback] Test heuristics") do
 for heursolver in heur_solvers

--- a/test/solvers.jl
+++ b/test/solvers.jl
@@ -71,7 +71,7 @@ eco && push!(conic_solvers_with_duals, ECOS.ECOSSolver(verbose=false))
 scs && push!(conic_solvers_with_duals, SCS.SCSSolver(eps=1e-6,verbose=0))
 #mos && push!(conic_solvers_with_duals, Mosek.MosekSolver(LOG=0))
 # Callback solvers
-lazy_solvers, cut_solvers, heur_solvers, info_solvers = Any[], Any[], Any[], Any[]
+lazy_solvers, lazylocal_solvers, cut_solvers, cutlocal_solvers, heur_solvers, info_solvers = Any[], Any[], Any[], Any[], Any[], Any[]
 if grb
     push!(lazy_solvers, Gurobi.GurobiSolver(OutputFlag=0, Presolve=0))
     push!( cut_solvers, Gurobi.GurobiSolver(PreCrush=1, Cuts=0, Presolve=0, Heuristics=0.0, OutputFlag=0))
@@ -81,7 +81,9 @@ if grb
 end
 if cpx
     push!(lazy_solvers, CPLEX.CplexSolver(CPX_PARAM_PRELINEAR=0, CPX_PARAM_PREIND=0, CPX_PARAM_ADVIND=0, CPX_PARAM_MIPSEARCH=1,CPX_PARAM_MIPCBREDLP=0,CPX_PARAM_SCRIND=0))
+    push!(lazylocal_solvers, CPLEX.CplexSolver(CPX_PARAM_PRELINEAR=0, CPX_PARAM_PREIND=0, CPX_PARAM_ADVIND=0, CPX_PARAM_MIPSEARCH=1,CPX_PARAM_MIPCBREDLP=0,CPX_PARAM_SCRIND=0, CPX_PARAM_FRACCUTS=-1, CPX_PARAM_EACHCUTLIM=0, CPX_PARAM_HEURFREQ=-1))
     push!( cut_solvers, CPLEX.CplexSolver(CPX_PARAM_PRELINEAR=0, CPX_PARAM_PREIND=0, CPX_PARAM_ADVIND=0, CPX_PARAM_MIPSEARCH=1,CPX_PARAM_MIPCBREDLP=0,CPX_PARAM_SCRIND=0))
+    push!(cutlocal_solvers, CPLEX.CplexSolver(CPX_PARAM_PRELINEAR=0, CPX_PARAM_PREIND=0, CPX_PARAM_ADVIND=0, CPX_PARAM_MIPSEARCH=1,CPX_PARAM_MIPCBREDLP=0,CPX_PARAM_SCRIND=0, CPX_PARAM_FRACCUTS=-1, CPX_PARAM_EACHCUTLIM=0, CPX_PARAM_HEURFREQ=-1))
     push!(heur_solvers, CPLEX.CplexSolver(CPX_PARAM_PRELINEAR=0, CPX_PARAM_PREIND=0, CPX_PARAM_ADVIND=0, CPX_PARAM_MIPSEARCH=1,CPX_PARAM_MIPCBREDLP=0,CPX_PARAM_SCRIND=0))
     push!(info_solvers, CPLEX.CplexSolver(CPX_PARAM_PRELINEAR=0, CPX_PARAM_PREIND=0, CPX_PARAM_ADVIND=0, CPX_PARAM_MIPSEARCH=1,CPX_PARAM_MIPCBREDLP=0,CPX_PARAM_SCRIND=0))
 end


### PR DESCRIPTION
@mlubin

Thanks for the follow-up about local cuts. Here is the suggestion with an optional keyword arg for the lazyconstraint/usercut macros, to specify if the cuts are local or not. The corresponding suggestions in MathProgBase/CPLEX follow but are indeed identical to the previous ones (first pull request). Apologies for having created a new pull request instead of updating the last one.

I gave it a try here starting from the latest master branches today and reusing what is done in the @variable macro in case other (optional) kw args should be added later. The suggestions are really minor, and it works (provided that CPLEX does the job on its side). However, it may not fit everyone's taste regarding names, etc. 

N.B. A small encoutered issue is related to the deprecation of 'MathProgBase.updatemodel!' which is still needed with the current release of the CPLEX package 'as is', so it has been temporarily added back (one line in MathProgBase/LinearQuadratic.jl) to focus on the locally valid cuts question...

--> Many thanks in advance for any modifications/comments.

