### PR TITLE
avoid generating rows for variables already in varcones

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
-MathProgBase 0.5 0.6
+MathProgBase 0.5.1 0.6
 ReverseDiffSparse 0.5.3 0.6
 ForwardDiff 0.1 0.2
 Calculus

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -528,7 +528,7 @@ function getdual(c::LinConstrRef)
     return c.m.linconstrDuals[c.idx]
 end
 
-# Returns the number of non-infinity bounds on variables
+# Returns the number of non-infinity and nonzero bounds on variables
 function getNumBndRows(m::Model)
     numBounds = 0
     for i in 1:m.numCols
@@ -543,10 +543,10 @@ function getNumBndRows(m::Model)
         end
 
         if !seen
-            if lb != -Inf
+            if lb != -Inf && lb != 0
                 numBounds += 1
             end
-            if ub != Inf
+            if ub != Inf && ub != 0
                 numBounds += 1
             end
         end

--- a/test/sdp.jl
+++ b/test/sdp.jl
@@ -176,8 +176,8 @@ context("With solver $(typeof(solver))") do
     n = 100
 
     mod = Model(solver=solver)
-    @variable(mod, x[j=1:p] >= 0, Int)
-    @variable(mod, u[i=1:q] >= 0)
+    @variable(mod, x[j=1:p] >= 1, Int)
+    @variable(mod, u[i=1:q] >= 1)
     @objective(mod, Min, sum(u))
     @constraint(mod, sum(x) <= n)
     for i=1:q
@@ -187,7 +187,7 @@ context("With solver $(typeof(solver))") do
     @fact length(f) --> 8
     @fact size(A) --> (23,8)
     @fact length(b) --> 23
-    @fact var_cones --> [(:NonNeg,[1,2,3,4,5,6,7,8])]
+    @fact var_cones --> [(:Free,[1,2,3,4,5,6,7,8])]
     @fact con_cones --> [(:NonNeg,[1]),(:NonPos,[2,3,4,5,6,7,8,9]),(:SDP,10:15),(:Zero,16:16),(:SDP,17:22),(:Zero,23:23)]
 end; end; end
 

--- a/test/socduals.jl
+++ b/test/socduals.jl
@@ -240,7 +240,7 @@ context("With conic solver $(typeof(conic_solver))") do
 
     inf_ray = getdual(c2)
     @fact status --> :Infeasible
-    @fact (-inf_ray[1] - inf_ray[2]) --> less_than_or_equal(-TOL)
+    @fact inf_ray[1] ≥ abs(inf_ray[2]) - TOL --> true
     @fact -(-inf_ray[1]) --> greater_than_or_equal(TOL)
 
 end

--- a/test/solvers.jl
+++ b/test/solvers.jl
@@ -69,7 +69,7 @@ cbc && push!(sos_solvers, Cbc.CbcSolver())
 conic_solvers_with_duals = Any[]
 eco && push!(conic_solvers_with_duals, ECOS.ECOSSolver(verbose=false))
 scs && push!(conic_solvers_with_duals, SCS.SCSSolver(eps=1e-6,verbose=0))
-#mos && push!(conic_solvers_with_duals, Mosek.MosekSolver(LOG=0))
+mos && push!(conic_solvers_with_duals, Mosek.MosekSolver(LOG=0))
 # Callback solvers
 lazy_solvers, lazylocal_solvers, cut_solvers, cutlocal_solvers, heur_solvers, info_solvers = Any[], Any[], Any[], Any[], Any[], Any[]
 if grb


### PR DESCRIPTION
JuMP currently generates varcones **and** constraint rows when bounds are zero, which doesn't make any sense.
This is still a WIP because it breaks reduced costs. We now need to get the duals for the var cones when computing the reduced costs.

CC @chriscoey @emreyamangil 