### PR TITLE
Work around potentially undefined variables with symmetric variables

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -931,7 +931,7 @@ macro variable(args...)
 
     if isa(var,Symbol)
         # Easy case - a single variable
-    sdp && variable_error(args, "Cannot add a semidefinite scalar variable")
+        sdp && variable_error(args, "Cannot add a semidefinite scalar variable")
         @assert !anonvar
         return assert_validmodel(m, quote
             $variable = Variable($m,$lb,$ub,$(quot(t)),utf8(string($quotvarname)),$value)
@@ -965,8 +965,8 @@ macro variable(args...)
                 variable_error(args, "Index sets for SDP variables must be ranges of the form 1:N")
         end
 
-        if sdp && !(lb == -Inf && ub == Inf)
-            variable_error(args, "Semidefinite variables cannot be provided bounds")
+        if !(lb == -Inf && ub == Inf)
+            variable_error(args, "Semidefinite or symmetric variables cannot be provided bounds")
         end
         return assert_validmodel(m, quote
             $(esc(idxsets[1].args[1].args[2])) == $(esc(idxsets[2].args[1].args[2])) || error("Cannot construct symmetric variables with nonsquare dimensions")

--- a/test/sdp.jl
+++ b/test/sdp.jl
@@ -133,8 +133,8 @@ facts("[sdp] Nonsensical SDPs") do
     @fact macroexpand(:(@variable(m, threeD[1:5,1:5,1:5], SDP))).head --> :error
     @fact macroexpand(:(@variable(m, psd[2] <= rand(2,2), SDP))).head --> :error
     @fact macroexpand(:(@variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), SDP))).head --> :error
-    @fact_throws @variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), Symmetric)
-    @fact_throws @variable(m, -ones(4,4) <= foo[1:4,1:4] <= ones(4,5), Symmetric)
+    @fact macroexpand(:(@variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), Symmetric))).head --> :error
+    @fact macroexpand(:(@variable(m, -ones(4,4) <= foo[1:4,1:4] <= ones(4,5), Symmetric))).head --> :error
     @fact_throws @variable(m, -rand(5,5) <= nonsymmetric[1:5,1:5] <= rand(5,5), Symmetric)
 end
 

--- a/test/sdp.jl
+++ b/test/sdp.jl
@@ -135,7 +135,7 @@ facts("[sdp] Nonsensical SDPs") do
     @fact macroexpand(:(@variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), SDP))).head --> :error
     @fact macroexpand(:(@variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), Symmetric))).head --> :error
     @fact macroexpand(:(@variable(m, -ones(4,4) <= foo[1:4,1:4] <= ones(4,5), Symmetric))).head --> :error
-    @fact_throws @variable(m, -rand(5,5) <= nonsymmetric[1:5,1:5] <= rand(5,5), Symmetric)
+    @fact macroexpand(:(@variable(m, -rand(5,5) <= nonsymmetric[1:5,1:5] <= rand(5,5), Symmetric))).head --> :error
 end
 
 facts("[sdp] SDP with quadratics") do


### PR DESCRIPTION
Not sure if there's an easy fix for this:
```jl
julia> @variable(m, X[i=1:3,j=1:3], Symmetric, lowerbound = eye(3)[i,j])
ERROR: UndefVarError: i not defined
 [inlined code] from /Users/huchette/.julia/v0.4/JuMP/src/macros.jl:973
 in anonymous at no file:0

julia> @variable(m, X[i=1:3,j=1:3] <= eye(3)[i,j], Symmetric)
ERROR: UndefVarError: i not defined
 [inlined code] from /Users/huchette/.julia/v0.4/JuMP/src/macros.jl:973
 in anonymous at no file:0
```