### PR TITLE
disallow colons in variable index sets

### DIFF
--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -63,6 +63,14 @@ end
 
 Base.isempty(d::JuMPContainer) = isempty(_innercontainer(d))
 
+coloncheck(args::Number...) = nothing
+
+function coloncheck(args...)
+    if any(t -> t == Colon(), args)
+        error("Colons not allowed as keys in JuMP containers.")
+    end
+end
+
 # generate and instantiate a type which is indexed by the given index sets
 # the following types of index sets are allowed:
 # 0:K -- range with compile-time starting index

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -985,6 +985,8 @@ macro variable(args...)
             $(anonvar ? variable : :($escvarname = $variable))
         end)
     else
+        coloncheckcode = Expr(:call,:coloncheck,refcall.args[2:end]...)
+        code = :($coloncheckcode; $code)
         return assert_validmodel(m, quote
             $(getloopedcode(variable, code, condition, idxvars, idxsets, idxpairs, :Variable))
             isa($variable, JuMPContainer) && pushmeta!($variable, :model, $m)

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -581,3 +581,9 @@ facts("[macros] Anonymous versions of macros") do
     @fact e[2] --> e[2]
     @fact f[:red] --> f[:red]
 end
+
+facts("[macros] Colons in index sets") do
+    m = Model()
+    S = [:]
+    @fact_throws ErrorException @variable(m, x[S])
+end


### PR DESCRIPTION
I feel like there's a mental block on the indexing with colon issue, hopefully this pushes us forward. Letting people index with colons as keys just seems like a terrible idea in any case, given the syntax confusion.

We can even merge and let it hang around for a release before we implement slicing.

Ref https://github.com/JuliaOpt/JuMP.jl/issues/643