### PR TITLE
small fix for addtoexpr

### DIFF
--- a/src/parseExpr_staged.jl
+++ b/src/parseExpr_staged.jl
@@ -58,7 +58,7 @@ end
 
 addtoexpr(ex::Number, c::Variable, x::Variable) = QuadExpr([c],[x],[1.0],zero(AffExpr))
 
-function addtoexpr(ex::Number, c::GenericAffExpr, x::GenericAffExpr)
+function addtoexpr{T<:GenericAffExpr}(ex::Number, c::T, x::T)
     q = c*x
     q.aff.constant += ex
     q


### PR DESCRIPTION
This code made a false assumption that multiplying two GenericAffExprs would create a quadratic expression, which is only true if the two AffExprs are of the same type. Test for this is here: https://github.com/mlubin/JuMPChance.jl/commit/6bb5db1dcedd6739d9eaab8f1ddb106df2c36871