### PR TITLE
Copy extension dictionaries

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -273,7 +273,14 @@ function Base.copy(source::Model)
 
     # variable/extension dicts
     if !isempty(source.ext)
-        error("Copying of extension dictionaries is not currently supported")
+        dest.ext = similar(source.ext)
+        for (key, val) in source.ext
+            dest.ext[key] = try
+                copy(source.ext[key])
+            catch
+                error("Error copying extension dictionary. Is `copy` defined for all your user types?")
+            end
+        end
     end
     dest.varDict = Dict{Symbol,Any}()
     for (symb,v) in source.varDict
@@ -447,6 +454,7 @@ function verify_ownership(m::Model, vec::Vector{Variable})
 end
 
 Base.copy(v::Variable, new_model::Model) = Variable(new_model, v.col)
+Base.copy(x::Void, new_model::Model) = nothing
 function Base.copy(v::Array{Variable}, new_model::Model)
     ret = similar(v, Variable, size(v))
     for I in eachindex(v)

--- a/test/model.jl
+++ b/test/model.jl
@@ -480,6 +480,26 @@ facts("[model] Test model copying") do
 
     addlazycallback(source, cb -> 3)
     @fact_throws copy(source)
+
+    # Test copying model with multiple variables of same name
+    @variable(source, x)
+    dest3 = copy(source)
+    @fact_throws getvariable(dest3, :x)
+    @fact dest3.varDict[:x] --> nothing
+end
+
+type TemporaryExtensionTestType
+    x::Int
+end
+facts("[model] Test extension copy") do
+    source = Model()
+    source.ext[:extensiontype] = TemporaryExtensionTestType(1)
+    @fact_throws copy(source)
+    source.ext[:extensiontype] = 1
+    dest = copy(source)
+    source.ext[:extensiontype] = 2
+    @fact haskey(dest.ext, :extensiontype) --> true
+    @fact dest.ext[:extensiontype] --> 1
 end
 
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -478,14 +478,14 @@ facts("[model] Test model copying") do
     dest2 = copy(source)
     @fact dest2.printhook(dest2) --> 2
 
-    addlazycallback(source, cb -> 3)
-    @fact_throws copy(source)
-
     # Test copying model with multiple variables of same name
     @variable(source, x)
     dest3 = copy(source)
     @fact_throws getvariable(dest3, :x)
     @fact dest3.varDict[:x] --> nothing
+
+    addlazycallback(source, cb -> 3)
+    @fact_throws copy(source)
 end
 
 type TemporaryExtensionTestType


### PR DESCRIPTION
This pull request enables the copying of extension dictionaries. It also fixes (and adds a test for) a missing definition that is needed when copying a model with multiple variables of the same name.

Closes https://github.com/JuliaOpt/JuMP.jl/issues/790