### PR TITLE
support for generators instead of curly syntax in Julia 0.5

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -17,6 +17,12 @@ function comparison_to_call(ex)
     end
 end
 
+function flatten_error(ex)
+    isexpr(ex, :flatten) || return
+    error("The generator syntax \"$ex\" with multiple \"for\" statements is not yet supported. For JuMP, you should contract statements like \"for i in 1:N for j in 1:i\" into \"for i in 1:N, j in 1:i\"")
+end
+
+
 include("parseExpr_staged.jl")
 
 ###############################################################################

--- a/src/nlpmacros.jl
+++ b/src/nlpmacros.jl
@@ -66,6 +66,9 @@ function parseNLExpr(m, x, tapevar, parent, values)
         end
         return codeblock
     end
+    if isexpr(x,:call) && length(x.args) >= 2 && isexpr(x.args[2],:flatten)
+        flatten_error(x.args[2])
+    end
 
     if isexpr(x, :call)
         if length(x.args) == 2 # univariate

--- a/src/nlpmacros.jl
+++ b/src/nlpmacros.jl
@@ -11,6 +11,62 @@
 # values is the name of the list of constants which appear in the expression
 function parseNLExpr(m, x, tapevar, parent, values)
 
+    if isexpr(x,:call) && length(x.args) >= 2 && isexpr(x.args[2],:generator)
+        header = x.args[1]
+        if issum(header)
+            operatorid = operator_to_id[:+]
+        elseif isprod(header)
+            operatorid = operator_to_id[:*]
+        else
+            error("Unrecognized expression $header(...)")
+        end
+        codeblock = :(let; end)
+        block = codeblock.args[1]
+        push!(block.args, :(push!($tapevar, NodeData(CALL, $operatorid, $parent))))
+        parentvar = gensym()
+        push!(block.args, :($parentvar = length($tapevar)))
+
+        # we have a filter condition
+        if isexpr(x.args[2].args[2],:filter)
+            cond = x.args[2].args[2].args[1]
+            # generate inner loop code first and then wrap in for loops
+            innercode = parseNLExpr(m, x.args[2].args[1], tapevar, parentvar, values)
+            code = quote
+                if $(esc(cond))
+                    $innercode
+                end
+            end
+            for level in length(x.args[2].args[2]):-1:2
+                _idxvar, idxset = parseIdxSet(x.args[2].args[2].args[level]::Expr)
+                idxvar = esc(_idxvar)
+                code = :(let
+                    $(localvar(idxvar))
+                    for $idxvar in $(esc(idxset))
+                        $code
+                    end
+                end)
+            end
+            push!(block.args, code)
+        else # no condition
+            innercode = parseNLExpr(m, x.args[2].args[1], tapevar, parentvar, values)
+            code = quote
+                $innercode
+            end
+            for level in length(x.args[2].args):-1:2
+                _idxvar, idxset = parseIdxSet(x.args[2].args[level]::Expr)
+                idxvar = esc(_idxvar)
+                code = :(let
+                    $(localvar(idxvar))
+                    for $idxvar in $(esc(idxset))
+                        $code
+                    end
+                end)
+            end
+            push!(block.args, code)
+        end
+        return codeblock
+    end
+
     if isexpr(x, :call)
         if length(x.args) == 2 # univariate
             code = :(let; end)

--- a/src/parseExpr_staged.jl
+++ b/src/parseExpr_staged.jl
@@ -670,6 +670,8 @@ function parseExpr(x, aff::Symbol, lcoeffs::Vector, rcoeffs::Vector, newaff::Sym
             return parseExpr(numerator, aff, lcoeffs,vcat(esc(:(1/$denom)),rcoeffs),newaff)
         elseif isexpr(x,:call) && length(x.args) >= 2 && isexpr(x.args[2],:generator)
             return newaff, parseGenerator(x,aff,lcoeffs,rcoeffs,newaff)
+        elseif isexpr(x,:call) && length(x.args) >= 2 && isexpr(x.args[2],:flatten)
+            flatten_error(x.args[2])
         elseif x.head == :curly
             return newaff, parseCurly(x,aff,lcoeffs,rcoeffs,newaff)
         else # at lowest level?

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -151,6 +151,8 @@ facts("[macros] sum(generator)") do
     @constraint(m, sum( 0*x[i,1] + y for i=1:3) == 0)
     @fact string(m.linconstr[end]) --> "3 y $eq 0"
 
+    @fact isexpr(macroexpand(:(@constraint(m, sum( 0*x[i,1] + y for i=1:3 for j in 1:3) == 0))),:error) --> true
+
 end"""); end
 
 facts("[macros] Problem modification") do

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -60,6 +60,31 @@ context("With solver $(typeof(nlp_solver))") do
         [1.000000, 4.742999, 3.821150, 1.379408], 1e-5)
 end; end; end
 
+if VERSION >= v"0.5-dev+5475"
+eval("""
+facts("[nonlinear] Test HS071 solves correctly (generators)") do
+    # hs071
+    # Polynomial objective and constraints
+    # min x1 * x4 * (x1 + x2 + x3) + x3
+    # st  x1 * x2 * x3 * x4 >= 25
+    #     x1^2 + x2^2 + x3^2 + x4^2 = 40
+    #     1 <= x1, x2, x3, x4 <= 5
+    # Start at (1,5,5,1)
+    # End at (1.000..., 4.743..., 3.821..., 1.379...)
+    m = Model()
+    initval = [1,5,5,1]
+    @variable(m, 1 <= x[i=1:4] <= 5, start=initval[i])
+    @NLobjective(m, Min, x[1]*x[4]*(x[1]+x[2]+x[3]) + x[3])
+    @NLconstraint(m, x[1]*x[2]*x[3]*x[4] >= 25)
+    @NLconstraint(m, sum(x[i]^2 for i=1:4) == 40)
+    @fact MathProgBase.numconstr(m) --> 2
+    status = solve(m)
+
+    @fact status --> :Optimal
+    @fact getvalue(x)[:] --> roughly(
+        [1.000000, 4.742999, 3.821150, 1.379408], 1e-5)
+end""");end
+
 
 facts("[nonlinear] Test HS071 solves correctly, epigraph") do
 for nlp_solver in nlp_solvers
@@ -497,6 +522,15 @@ context("With solver $(typeof(nlp_solver))") do
     @fact getvalue(x) --> roughly(ones(18),1e-4)
 end; end; end
 
+if VERSION >= v"0.5-dev+5475"
+eval("""
+facts("[nonlinear] Test Hessian chunking code (generators)") do
+    m = Model()
+    @variable(m, x[1:18] >= 1, start = 1.2)
+    @NLobjective(m, Min, prod(x[i] for i=1:18))
+    @fact solve(m) --> :Optimal
+    @fact getvalue(x) --> roughly(ones(18),1e-4)
+end"""); end
 
 #############################################################################
 # Test that output is produced in correct MPB form

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -83,6 +83,8 @@ facts("[nonlinear] Test HS071 solves correctly (generators)") do
     @fact status --> :Optimal
     @fact getvalue(x)[:] --> roughly(
         [1.000000, 4.742999, 3.821150, 1.379408], 1e-5)
+
+    @fact isexpr(macroexpand(:(@NLconstraint(m, sum(x[i]^2 for i=1:4) == 40))),:error) --> true
 end""");end
 
 


### PR DESCRIPTION
Now that Julia master has support for generator syntax with filters (https://github.com/JuliaLang/julia/issues/550), we can now support this:
```jl
@constriant(m, sum(x[i] for i in 1:N if i != 2) <= 1)
```
This PR enables support for generator syntax wherever we used to use curly braces. Once we drop support for Julia 0.4, we should also deprecate the curly syntax.