### PR TITLE
accept nonlinear expressions in Expr form, no macros needed

### DIFF
--- a/doc/nlp.rst
+++ b/doc/nlp.rst
@@ -263,3 +263,23 @@ which can be queried using the ``JuMP.NLPEvaluator``.
 If you are writing a "solver", we *highly encourage* use of the `MathProgBase nonlinear interface <http://mathprogbasejl.readthedocs.org/en/latest/nlp.html>`_ over querying derivatives using the above methods. These methods are provided for convenience but do not fully integrate with JuMP's solver infrastructure. In particular, they do not allow users to specify your solver to the ``Model()`` constructor nor to call it using ``solve()`` nor to populate the solution back into the model. Use of the MathProgBase interface also has the advantage of being independent of JuMP itself; users of MathProgBase solvers are free to implement their own evaluation routines instead of expressing their model in JuMP.  You may use the ``JuMP.build`` method to ask JuMP to populate the "solver" without calling ``optimize!``.
 
 .. [1] Dunning, Huchette, and Lubin, "JuMP: A Modeling Language for Mathematical Optimization", `arXiv <http://arxiv.org/abs/1508.01982>`_.
+
+
+Raw expression input
+^^^^^^^^^^^^^^^^^^^^
+
+In addition to the ``@NLobjective`` and ``@NLconstraint`` macros, it is also
+possible to provide Julia ``Expr`` objects directly by using
+``JuMP.setNLobjective`` and ``JuMP.addNLconstraint``. This input form
+may be useful if the expressions are generated programmatically.
+JuMP variables should be spliced into the expression object. For example::
+
+    @variable(m, 1 <= x[i=1:4] <= 5)
+    JuMP.setNLobjective(m, :Min, :($(x[1])*$(x[4])*($(x[1])+$(x[2])+$(x[3])) + $(x[3])))
+    JuMP.addNLconstraint(m, :($(x[1])*$(x[2])*$(x[3])*$(x[4]) >= 25))
+
+    # Equivalent form using traditional JuMP macros:
+    @NLobjective(m, Min, x[1]*x[4]*(x[1]+x[2]+x[3]) + x[3])
+    @NLconstraint(m, x[1]*x[2]*x[3]*x[4] >= 25)
+
+See the Julia documentation for more examples and description of Julia expressions.

--- a/src/parsenlp.jl
+++ b/src/parsenlp.jl
@@ -4,8 +4,6 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-
-
 # generates code which converts an expression into a NodeData array (tape)
 # parent is the index of the parent expression
 # values is the name of the list of constants which appear in the expression
@@ -251,3 +249,20 @@ macro processNLExpr(m, ex)
         NonlinearExprData(tape, values)
     end
 end
+
+# Construct a NonlinearExprData from a Julia expression.
+# Variable objects should be spliced into the expression.
+function NonlinearExprData(m::Model, ex::Expr)
+    ex = spliceref(m,ex)
+    nd, values = ReverseDiffSparse.expr_to_nodedata(ex)
+    return NonlinearExprData(nd, values)
+end
+NonlinearExprData(m::Model, ex) = NonlinearExprData(m, :($ex + 0))
+
+# recursively replace Variable(m, i) with Expr(:ref,:x,i) in ex
+spliceref(m::Model, ex::Expr) = Expr(ex.head,map(e -> spliceref(m,e), ex.args)...)
+function spliceref(m::Model, v::Variable)
+    v.m === m || error("Variable $v does not belong to this model")
+    return Expr(:ref, :x, linearindex(v))
+end
+spliceref(m::Model, ex) = ex


### PR DESCRIPTION
This provides a new way to input nonlinear expressions by providing Julia ``Expr`` objects. I can imagine this being useful for extensions or some cases of embedding JuMP where the nonlinear expressions are generated programmatically. There's no need to force expressions into macros anymore. See the new tests for examples.

CC @jalving