### PR TITLE
Fix #830

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -465,9 +465,7 @@ macro SDconstraint(m, x)
     assert_validmodel(m, quote
         q = zero(AffExpr)
         $parsecode
-        c = SDConstraint($newaff)
-        push!($(m).sdpconstr, c)
-        c
+        addconstraint($m, SDConstraint($newaff))
     end)
 end
 

--- a/test/sdp.jl
+++ b/test/sdp.jl
@@ -519,3 +519,15 @@ context("With solver $(typeof(solver))") do
     @fact getvalue(Q) --> roughly([1 0;0 0], 1e-3)
     @fact getobjectivevalue(model) --> roughly(1, TOL)
 end; end; end
+
+facts("[sdp] Internal Model not unloaded when SDP constraint added #830") do
+for solver in sdp_solvers
+context("With solver $(typeof(solver))") do
+    model = Model(solver=solver)
+    @variable(model, x)
+    solve(model)
+    T = [1 x; -x 1]
+    c = @SDconstraint(model, T ⪰ 0)
+    @fact typeof(c) --> JuMP.ConstraintRef{JuMP.Model,JuMP.SDConstraint}
+    @fact model.internalModelLoaded --> false
+end; end; end


### PR DESCRIPTION
Fixes #830 and adds a test.

I couldn't test that the model was not resolved correctly since in `solvers.jl`, there is:

        # Obtain a fresh MPB model for the solver
        # If the problem is conic, we rebuild the problem from
        # scratch every time
        m.internalModel = MathProgBase.ConicModel(m.solver)

so the fact that `m.internalModelLoaded` is not set to false when adding a new SDconstraint has no effect. Therefore  in the tests I just test that `internalModelLoaded` is set to false;

An important effect of the fixed `@SDconstraint` though is that it returns now a `JuMP.ConstraintRef{JuMP.Model,JuMP.SDConstraint}` instead of a `JuMP.SDConstraint`. This is also tested in the test.