### PR TITLE
Make it possible to write macros in extension

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -199,7 +199,7 @@ validmodel(m, name) = error("Expected $name to be a JuMP model, but it has type 
 function assert_validmodel(m, macrocode)
     # assumes m is already escaped
     quote
-        validmodel($m, $(quot(m.args[1])))
+        JuMP.validmodel($m, $(quot(m.args[1])))
         $macrocode
     end
 end

--- a/src/parseExpr_staged.jl
+++ b/src/parseExpr_staged.jl
@@ -439,7 +439,7 @@ function parseNorm(normp::Symbol, x::Expr, aff::Symbol, lcoeffs, rcoeffs, newaff
         $preblock
         $code
         $gennorm = _build_norm($param,$normexpr)
-        $newaff = $(Expr(:call, :addtoexpr_reorder, aff,lcoeffs...,gennorm,rcoeffs...))
+        $newaff = $(Expr(:call, JuMP.:addtoexpr_reorder, aff,lcoeffs...,gennorm,rcoeffs...))
     end
 end
 
@@ -585,7 +585,7 @@ function parseGeneratorNorm(normp::Symbol, x::Expr, aff::Symbol, lcoeffs, rcoeff
         $preblock
         $code
         $gennorm = _build_norm($param,$normexpr)
-        $newaff = $(Expr(:call, :addtoexpr_reorder, aff,lcoeffs...,gennorm,rcoeffs...))
+        $newaff = $(Expr(:call, JuMP.:addtoexpr_reorder, aff,lcoeffs...,gennorm,rcoeffs...))
     end
 end
 
@@ -597,7 +597,7 @@ parseExprToplevel(x, aff::Symbol) = parseExpr(x, aff, [], [])
 function parseExpr(x, aff::Symbol, lcoeffs::Vector, rcoeffs::Vector, newaff::Symbol=gensym())
     if !isa(x,Expr)
         # at the lowest level
-        callexpr = Expr(:call,:addtoexpr_reorder,aff,lcoeffs...,esc(x),rcoeffs...)
+        callexpr = Expr(:call,JuMP.:addtoexpr_reorder,aff,lcoeffs...,esc(x),rcoeffs...)
         return newaff, :($newaff = $callexpr)
     else
         if x.head == :call && x.args[1] == :+
@@ -651,7 +651,7 @@ function parseExpr(x, aff::Symbol, lcoeffs::Vector, rcoeffs::Vector, newaff::Sym
                         x.args[i] = esc(x.args[i])
                     end
                 end
-                callexpr = Expr(:call,:addtoexpr_reorder,aff,lcoeffs...,x.args[2:end]...,rcoeffs...)
+                callexpr = Expr(:call,JuMP.:addtoexpr_reorder,aff,lcoeffs...,x.args[2:end]...,rcoeffs...)
                 push!(blk.args, :($newaff = $callexpr))
                 return newaff, blk
             end
@@ -688,7 +688,7 @@ function parseExpr(x, aff::Symbol, lcoeffs::Vector, rcoeffs::Vector, newaff::Sym
             return newaff, parseCurly(x,aff,lcoeffs,rcoeffs,newaff)
         else # at lowest level?
             !isexpr(x,:comparison) || error("Unexpected comparison in expression $x")
-            callexpr = Expr(:call,:addtoexpr_reorder,aff,lcoeffs...,esc(x),rcoeffs...)
+            callexpr = Expr(:call,JuMP.:addtoexpr_reorder,aff,lcoeffs...,esc(x),rcoeffs...)
             return newaff, :($newaff = $callexpr)
         end
     end


### PR DESCRIPTION
I am writing a [JuMP extension for Sum of Squares Programming](https://github.com/blegat/SumOfSquares.jl).
All the JuMP specific code is in [the jump.jl file](https://github.com/blegat/SumOfSquares.jl/blob/master/src/jump.jl).
It adds the macros `@SOSconstraint` and `@SOSvariable` that create SOS constraint and SOS variable respectively.

They make use of the `assert_validmodel` and `parseExpr`functions.
However, since it is not called from inside the `JuMP` module, julia complains that it does not know `validmodel` and `addtoexpr_reorder`.
Adding the `JuMP.` prefix as in this pull request fixes the problem and it can also be useful for other extensions.
Of course, if you do not like this change, another solution would be to move [the jump.jl file](https://github.com/blegat/SumOfSquares.jl/blob/master/src/jump.jl) code inside the `JuMP` package.