### PR TITLE
Fixing KeyIterator used for JuMPArray to work also when index sets are non indexable.

### DIFF
--- a/src/JuMPArray.jl
+++ b/src/JuMPArray.jl
@@ -35,12 +35,25 @@ end
 end
 
 Base.getindex(d::JuMPArray, ::Colon) = d.innerArray[:]
+
+immutable JuMPKey
+    jk::Tuple
+end
+
+Base.start(x::JuMPKey) = Base.start(x.jk)
+Base.next(x::JuMPKey, i) = Base.next(x.jk, i)
+Base.done(x::JuMPKey, i) = Base.done(x.jk, i)
+Base.length(x::JuMPKey) = Base.length(x.jk)
+
 @generated function Base.getindex{T,N,NT<:NTuple}(d::JuMPArray{T,N,NT}, idx...)
     if N != length(idx)
         error("Indexed into a JuMPArray with $(length(idx)) indices (expected $N indices)")
     end
     Expr(:call, :getindex, :(d.innerArray), _to_cartesian(d,NT,idx)...)
 end
+
+Base.getindex(d::JuMPArray, x::JuMPKey) = Base.getindex(d, x.jk...)
+
 
 @generated function Base.setindex!{T,N,NT<:NTuple}(d::JuMPArray{T,N,NT}, v::T, idx...)
     if N != length(idx)

--- a/src/JuMPArray.jl
+++ b/src/JuMPArray.jl
@@ -36,8 +36,8 @@ end
 
 Base.getindex(d::JuMPArray, ::Colon) = d.innerArray[:]
 
-immutable JuMPKey
-    jk::Tuple
+immutable JuMPKey{T<:Tuple}
+    jk::T
 end
 
 Base.start(x::JuMPKey) = Base.start(x.jk)
@@ -53,7 +53,6 @@ Base.length(x::JuMPKey) = Base.length(x.jk)
 end
 
 Base.getindex(d::JuMPArray, x::JuMPKey) = Base.getindex(d, x.jk...)
-
 
 @generated function Base.setindex!{T,N,NT<:NTuple}(d::JuMPArray{T,N,NT}, v::T, idx...)
     if N != length(idx)

--- a/src/JuMPArray.jl
+++ b/src/JuMPArray.jl
@@ -36,23 +36,12 @@ end
 
 Base.getindex(d::JuMPArray, ::Colon) = d.innerArray[:]
 
-immutable JuMPKey{T<:Tuple}
-    jk::T
-end
-
-Base.start(x::JuMPKey) = Base.start(x.jk)
-Base.next(x::JuMPKey, i) = Base.next(x.jk, i)
-Base.done(x::JuMPKey, i) = Base.done(x.jk, i)
-Base.length(x::JuMPKey) = Base.length(x.jk)
-
 @generated function Base.getindex{T,N,NT<:NTuple}(d::JuMPArray{T,N,NT}, idx...)
     if N != length(idx)
         error("Indexed into a JuMPArray with $(length(idx)) indices (expected $N indices)")
     end
     Expr(:call, :getindex, :(d.innerArray), _to_cartesian(d,NT,idx)...)
 end
-
-Base.getindex(d::JuMPArray, x::JuMPKey) = Base.getindex(d, x.jk...)
 
 @generated function Base.setindex!{T,N,NT<:NTuple}(d::JuMPArray{T,N,NT}, v::T, idx...)
     if N != length(idx)

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -189,54 +189,54 @@ type KeyIterator{JA<:JuMPArray}
     state::Tuple
     done::Bool
     function KeyIterator(d)
-      t = tuple()
-      n = ndims(d.innerArray)
-      for i in 1:n
-        t = tuple(t..., start(d.indexsets[i]))
-      end
-      new(d, n, t, false)
+        t = tuple()
+        n = ndims(d.innerArray)
+        for i in 1:n
+            t = tuple(t..., start(d.indexsets[i]))
+        end
+        new(d, n, t, false)
     end
 end
 
 KeyIterator{JA}(d::JA) = KeyIterator{JA}(d)
 
 function Base.start(it::KeyIterator)
-  it.state
+    it.state
 end
 
 function Base.next(it::KeyIterator, k)
-  cartesian_key = ()
-  for i in 1:it.dim
-    cartesian_key = tuple(cartesian_key..., next(it.x.indexsets[i], k[i])[1])
-  end
-  #@show cartesian_key
-  next_k = ()
-  pos = -1
-  for i in 1:it.dim
-    if(!done(it.x.indexsets[i], next(it.x.indexsets[i], k[i])[2] ) )
-      pos = i
-      break
+    cartesian_key = ()
+    for i in 1:it.dim
+        cartesian_key = tuple(cartesian_key..., next(it.x.indexsets[i], k[i])[1])
     end
-  end
-  #@show pos
-  if pos == -1
-    it.done = true
-    return cartesian_key, nothing
-  end
-  for i in 1:it.dim
-    if i < pos
-      next_k = tuple(next_k..., start(it.x.indexsets[i]) )
-    elseif i == pos
-      next_k = tuple(next_k..., next(it.x.indexsets[i], k[i])[2])
-    else
-      next_k = tuple(next_k..., k[i])
+    #@show cartesian_key
+    next_k = ()
+    pos = -1
+    for i in 1:it.dim
+        if(!done(it.x.indexsets[i], next(it.x.indexsets[i], k[i])[2] ) )
+            pos = i
+            break
+        end
     end
-  end
-  cartesian_key, next_k
+    #@show pos
+    if pos == -1
+        it.done = true
+        return cartesian_key, nothing
+    end
+    for i in 1:it.dim
+        if i < pos
+            next_k = tuple(next_k..., start(it.x.indexsets[i]) )
+        elseif i == pos
+            next_k = tuple(next_k..., next(it.x.indexsets[i], k[i])[2])
+        else
+            next_k = tuple(next_k..., k[i])
+        end
+    end
+    cartesian_key, next_k
 end
 
 function Base.done(it::KeyIterator, k)
-  return it.done
+    return it.done
 end
 
 Base.length(it::KeyIterator)  = length(it.x.innerArray)

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -189,18 +189,18 @@ type KeyIterator{JA<:JuMPArray}
     state::Tuple
     done::Bool
     function KeyIterator(d)
-        t = tuple()
         n = ndims(d.innerArray)
-        for i in 1:n
-            t = tuple(t..., start(d.indexsets[i]))
-        end
-        new(d, n, t, false)
+        new(d, n, (), false)
     end
 end
 
 KeyIterator{JA}(d::JA) = KeyIterator{JA}(d)
 
 function Base.start(it::KeyIterator)
+    it.state = tuple()
+    for i in 1:it.dim
+        it.state = tuple(it.state..., start(it.x.indexsets[i]))
+    end
     it.state
 end
 

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -151,10 +151,10 @@ Base.ndims{T,N}(x::JuMPDict{T,N}) = N
 Base.abs(x::JuMPDict) = map(abs, x)
 # avoid dangerous behavior with "end" (#730)
 Base.endof(x::JuMPArray) = error("endof() (and \"end\" syntax) not implemented for JuMPArray objects.")
-Base.size(x::JuMPArray) = error("size (and \"end\" syntax) not implemented for JuMPArray objects.")
-#"Use JuMP.size if you want to access the dimensions.")
-Base.size(x::JuMPArray,k) = error("size (and \"end\" syntax) not implemented for JuMPArray objects.")
-#" Use JuMP.size if you want to access the dimensions.")
+Base.size(x::JuMPArray) = error(string("size (and \"end\" syntax) not implemented for JuMPArray objects.",
+"Use JuMP.size if you want to access the dimensions."))
+Base.size(x::JuMPArray,k) = error(string("size (and \"end\" syntax) not implemented for JuMPArray objects.",
+" Use JuMP.size if you want to access the dimensions."))
 size(x::JuMPArray) = size(x.innerArray)
 size(x::JuMPArray,k) = size(x.innerArray,k)
 # for uses of size() within JuMP

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -210,7 +210,7 @@ Base.start(it::KeyIterator) = _start(it.x)
 end
 
 function Base.next(it::KeyIterator, k)
-    cartesian_key = _next(it.x, k)
+    cartesian_key = JuMPKey(_next(it.x, k))
     pos = -1
     for i in 1:it.dim
         if(!done(it.x.indexsets[i], next(it.x.indexsets[i], k[i+1])[2] ) )

--- a/test/model.jl
+++ b/test/model.jl
@@ -925,3 +925,24 @@ facts("[model] Nonliteral exponents in @constraint") do
     @fact m.quadconstr[3].terms --> x^2 + x^2 + x^2 + x^2 + x^2 + x^2 + x^2 + x^2 + x^2 - 1
     @fact m.quadconstr[4].terms --> QuadExpr(x + x + x - 1)
 end
+
+facts("[model] sets used as indexsets in JuMPArray") do
+    set = IntSet()
+    for i in 4:5
+        push!(set, i)
+    end
+    set2 = IntSet()
+    for i in 21:23
+        push!(set2, i)
+    end
+    m = Model()
+    @variable(m, x[set, set2], Bin)
+    @objective(m , Max, sum{sum{x[e,p], e in set}, p in set2})
+    solve(m)
+    sol = getvalue(x)
+    checked_objval = 0
+    for i in keys(sol)
+        checked_objval += sol[i...]
+    end
+    @fact checked_objval --> 6
+end


### PR DESCRIPTION
This just a beginning to solving issues raised #646 

I think it is better to not merge it yet. Maybe just give some feedback especially I m pretty sure the iterator methods could be implemented better.

The new `KeyIterator` works fine as long as the **index sets** are iterable (including Iterators and `Set`s). They **do not need to be indexable anymore**

