### PR TITLE
Adding JuMPKey as elements of keys(::JuMPArray) and keys(::JuMPDict)

### DIFF
--- a/src/JuMPArray.jl
+++ b/src/JuMPArray.jl
@@ -36,8 +36,11 @@ end
 
 Base.getindex(d::JuMPArray, ::Colon) = d.innerArray[:]
 
-immutable JuMPKey{T<:Tuple}
-    jk::T
+# immutable JuMPKey{T<:Tuple}
+#     jk::T
+# end
+immutable JuMPKey
+    jk::Tuple
 end
 
 Base.start(x::JuMPKey) = Base.start(x.jk)

--- a/src/JuMPArray.jl
+++ b/src/JuMPArray.jl
@@ -36,12 +36,23 @@ end
 
 Base.getindex(d::JuMPArray, ::Colon) = d.innerArray[:]
 
+immutable JuMPKey{T<:Tuple}
+    jk::T
+end
+
+Base.start(x::JuMPKey) = Base.start(x.jk)
+Base.next(x::JuMPKey, i) = Base.next(x.jk, i)
+Base.done(x::JuMPKey, i) = Base.done(x.jk, i)
+Base.length(x::JuMPKey) = Base.length(x.jk)
+
 @generated function Base.getindex{T,N,NT<:NTuple}(d::JuMPArray{T,N,NT}, idx...)
     if N != length(idx)
         error("Indexed into a JuMPArray with $(length(idx)) indices (expected $N indices)")
     end
     Expr(:call, :getindex, :(d.innerArray), _to_cartesian(d,NT,idx)...)
 end
+
+Base.getindex(d::JuMPArray, x::JuMPKey) = Base.getindex(d, x.jk...)
 
 @generated function Base.setindex!{T,N,NT<:NTuple}(d::JuMPArray{T,N,NT}, v::T, idx...)
     if N != length(idx)

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -185,13 +185,13 @@ Base.next(it::ValueIterator, k) =   next(it.x, k)
 Base.done(it::ValueIterator, k) =   done(it.x, k)
 Base.length(it::ValueIterator)  = length(it.x)
 
-type JDKeyIterator{N,T}
-    x::Base.KeyIterator{Dict{NTuple{N,Any},T}}
+type JDKeyIterator{T<:Base.KeyIterator}
+    x::T
 end
 Base.start(it::JDKeyIterator)   =  start(it.x)
 function Base.next(it::JDKeyIterator, k)
-    tuple, next_k = next(it.x, k)
-    return JuMPKey(tuple), next_k
+    n = next(it.x, k)
+    JuMPKey(n[1]), n[2]
 end
 Base.done(it::JDKeyIterator, k) =   done(it.x, k)
 Base.length(it::JDKeyIterator)  = length(it.x)

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -226,7 +226,7 @@ end
 end
 
 function Base.next(it::KeyIterator, k::Tuple)
-    cartesian_key = _next(it.x, k)
+    cartesian_key = JuMPKey(_next(it.x, k))
     pos = -1
     for i in 1:it.dim
         if !done(it.x.indexsets[i], next(it.x.indexsets[i], k[i+1])[2] )
@@ -256,7 +256,7 @@ Base.done(it::KeyIterator, k::Tuple) = (k[1] == 1)
 @generated __next{T,N,NT}(x::JuMPArray{T,N,NT}, k::Integer) =
     quote
         subidx = ind2sub(size(x),k)
-        $(Expr(:tuple, [:(x.indexsets[$i][subidx[$i]]) for i in 1:N]...)), next(x.innerArray,k)[2]
+        JuMPKey($(Expr(:tuple, [:(x.indexsets[$i][subidx[$i]]) for i in 1:N]...))), next(x.innerArray,k)[2]
     end
 Base.next(it::KeyIterator, k) = __next(it.x,k::Integer)
 Base.done(it::KeyIterator, k) = done(it.x.innerArray, k::Integer)

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -46,6 +46,8 @@ end
 #    JuMPDict{T,N}(Dict{NTuple{N},T}(), name)
 
 Base.getindex(d::JuMPDict, t...) = d.tupledict[t]
+Base.getindex(d::JuMPDict, x::JuMPKey) = Base.getindex(d, x.jk...)
+
 Base.setindex!(d::JuMPDict, value, t...) = (d.tupledict[t] = value)
 
 Base.map(f::Function, d::JuMPArray) =
@@ -168,7 +170,7 @@ Base.eltype{T}(x::JuMPContainer{T}) = T
 Base.full(x::JuMPContainer) = x
 
 # keys/vals iterations for JuMPContainers
-Base.keys(d::JuMPDict)    = keys(d.tupledict)
+Base.keys(d::JuMPDict)    = JDKeyIterator(keys(d.tupledict))
 Base.values(d::JuMPDict)  = values(d.tupledict)
 
 Base.keys(d::JuMPArray)   = KeyIterator(d)
@@ -182,6 +184,17 @@ Base.start(it::ValueIterator)   =  start(it.x)
 Base.next(it::ValueIterator, k) =   next(it.x, k)
 Base.done(it::ValueIterator, k) =   done(it.x, k)
 Base.length(it::ValueIterator)  = length(it.x)
+
+type JDKeyIterator{N,T}
+    x::Base.KeyIterator{Dict{NTuple{N,Any},T}}
+end
+Base.start(it::JDKeyIterator)   =  start(it.x)
+function Base.next(it::JDKeyIterator, k)
+    tuple, next_k = next(it.x, k)
+    return JuMPKey(tuple), next_k
+end
+Base.done(it::JDKeyIterator, k) =   done(it.x, k)
+Base.length(it::JDKeyIterator)  = length(it.x)
 
 type KeyIterator{JA<:JuMPArray}
     x::JA

--- a/test/model.jl
+++ b/test/model.jl
@@ -1002,3 +1002,33 @@ facts("[model] sets used as indexsets in JuMPArray") do
     end
     @fact checked_objval --> 6
 end
+
+facts("[model] iteration on keys(::JuMPArray)") do
+    set = 4:5
+    set2 = 21:23
+    m = Model()
+    @variable(m, x[set, set2], Bin)
+    @objective(m , Max, sum{sum{x[e,p], e in set}, p in set2})
+    solve(m)
+    sol = getvalue(x)
+    checked_objval = 0
+    for i in keys(sol)
+        checked_objval += sol[i]
+    end
+    @fact checked_objval --> 6
+end
+
+facts("[model] iteration on keys(::JuMPDict)") do
+    set = 4:5
+    set2 = 21:23
+    m = Model()
+    @variable(m, x[i in set, j in set2; i < j], Bin)
+    @objective(m , Max, sum{sum{x[e,p], e in set}, p in set2})
+    solve(m)
+    sol = getvalue(x)
+    checked_objval = 0
+    for i in keys(sol)
+        checked_objval += sol[i]
+    end
+    @fact checked_objval --> 6
+end


### PR DESCRIPTION
I have added `JuMPKey` for `JuMPArray` as suggested in #646 . And I would like to add it for `JuMPDict` as well. Do you know how to make a small example returning `JuMPDict` ?
