### PR TITLE
explicit warning when multiple variables and constraints are given the same name

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -429,7 +429,7 @@ function getvalue(arr::Array{Variable})
             end
         end
     end
-    # Copy printing data from @defVar for Array{Variable} to corresponding Array{Float64} of values
+    # Copy printing data from @variable for Array{Variable} to corresponding Array{Float64} of values
     if registered
         m.varData[ret] = m.varData[arr]
     end
@@ -662,6 +662,7 @@ end
 # handle dictionary of variables
 function registervar(m::Model, varname::Symbol, value)
     if haskey(m.varDict, varname)
+        Base.warn_once("A variable named $varname is already attached to this model. If creating variables programmatically, consider using the anonymous variable syntax x = @variable(m, [1:N], ...).")
         m.varDict[varname] = nothing # indicate duplicate variable
     else
         m.varDict[varname] = value
@@ -672,7 +673,8 @@ registervar(m::Model, varname, value) = value # variable name isn't a simple sym
 
 function registercon(m::Model, conname::Symbol, value)
     if haskey(m.conDict, conname)
-        m.conDict[conname] = nothing # indicate duplicate variable
+        Base.warn_once("A constraint named $conname is already attached to this model. If creating constraints programmatically, consider using the anonymous constraint syntax con = @constraint(m, ...).")
+        m.conDict[conname] = nothing # indicate duplicate constraint
     else
         m.conDict[conname] = value
     end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -473,19 +473,19 @@ facts("[macros] Indices in macros don't leak out of scope (#582)") do
     m = Model()
     cnt = 4
     for i in 5:8
-        @variable(m, x[i=1:3,j=1:3] ≤ i)
+        x = @variable(m, [i=1:3,j=1:3], upperbound = i)
         cnt += 1
         @fact i --> cnt
     end
     cnt = 4
     for i in 5:8
-        @variable(m, y[i=2:4,j=1:3] ≤ i)
+        y = @variable(m, [i=2:4,j=1:3], upperbound = i)
         cnt += 1
         @fact i --> cnt
     end
     cnt = 4
     for i in 5:8
-        @variable(m, z[i=[1:3;],j=1:3] ≤ i)
+        z = @variable(m, [i=[1:3;],j=1:3], upperbound = i)
         cnt += 1
         @fact i --> cnt
     end
@@ -507,7 +507,7 @@ facts("[macros] Indices in macros don't leak out of scope (#582)") do
     end
     cnt = 4
     for i in 5:8
-        @constraint(m, c[i=1:3,j=1:3], x[i] == 1)
+        @constraint(m, [i=1:3,j=1:3], x[i] == 1)
         cnt += 1
         @fact i --> cnt
     end

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -437,7 +437,7 @@ context("With solver $(typeof(nlp_solver))") do
     @NLexpression(m, entropy[i=idx], -x[i]*log(x[i]))
     @NLobjective(m, Max, sum{z[i], i = 1:2} + sum{z[i]/2, i=3:4})
     @NLconstraint(m, z_constr1[i=1], z[i] <= entropy[i])
-    @NLconstraint(m, z_constr1[i=2], z[i] <= entropy[i]) # duplicate expressions
+    @NLconstraint(m, z_constr1_dup[i=2], z[i] <= entropy[i]) # duplicate expressions
     @NLconstraint(m, z_constr2[i=3:4], z[i] <= 2*entropy[i])
     @constraint(m, sum(x) == 1)
 

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -49,9 +49,9 @@ facts("[variable] get and set bounds") do
     @fact getlowerbound(x) --> 1
     setupperbound(x, 3)
     @fact getupperbound(x) --> 3
-    @variable(m, y, Bin)
-    @fact getlowerbound(y) --> 0
-    @fact getupperbound(y) --> 1
+    @variable(m, q, Bin)
+    @fact getlowerbound(q) --> 0
+    @fact getupperbound(q) --> 1
     @variable(m, 0 <= y <= 1, Bin)
     @fact getlowerbound(y) --> 0
     @fact getupperbound(y) --> 1


### PR DESCRIPTION
As suggested at https://github.com/JuliaOpt/JuMP.jl/issues/692#issuecomment-251197721, I think this is a good step to push people towards anonymous variables and reduce potential confusion. Users will now get a warning on ``@variable(m, x[1]); @variable(m, x[2])``.

CC @odow @yeesian @JackDunnNZ @davidanthoff @chriscoey @ccoffrin 