### PR TITLE
Fix #883

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -875,7 +875,7 @@ Base.show(io::IO, ::MIME"text/latex", c::SDConstraint) =
 # Generic string converter, called by mode-specific handlers
 function con_str(mode, c::SDConstraint, succeq0)
     t = c.terms
-    str = sprint(print, t)
+    str = sprint(show, MIME"text/plain"(), t)
     splitted = split(str, "\n")[2:end]
     center = ceil(Int, length(splitted)/2)
     splitted[center] *= succeq0

--- a/test/print.jl
+++ b/test/print.jl
@@ -617,3 +617,12 @@ facts("[print] basename keyword argument") do
     io_test(REPLMode,   w[1,3], "symm[1,3]")
     io_test(IJuliaMode, w[1,3], "symm_{1,3}")
 end
+
+facts("[print] SD constraints #883") do
+    m = Model()
+    A = [2.0  0.0;
+         0.0  1.0]
+    @variable(m, X[1:2,1:2], SDP)
+    s = @SDconstraint(m, X >= A)
+    io_test(REPLMode, s, " X[1,1] - 2  X[1,2]     is semidefinite\n X[1,2]      X[2,2] - 1")
+end


### PR DESCRIPTION
Now `sprint(print, ::AbstractMatrix)` prints the matrix in one line `;` separated.
If we want to keep the pretty multiline printing with "is semidefinite" at the end of the center row, we need to use the `display`-like: `sprint(show, MIME"text/plain"(), t)`