### PR TITLE
Remove zero elements in IndexedVector

### DIFF
--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -600,6 +600,7 @@ function collect_expr!(m, tmprow, terms::AffExpr)
         end
         addelt!(tmprow,vars[ind].col, coeffs[ind])
     end
+    rmz!(tmprow)
     tmprow
 end
 
@@ -818,6 +819,7 @@ function conicdata(m::Model)
             end
             addelt!(tmprow,vars[ind].col, coeffs[ind])
         end
+        rmz!(tmprow)
         nnz = tmprow.nnz
         append!(I, fill(c, nnz))
         indices = tmpnzidx[1:nnz]
@@ -1059,6 +1061,7 @@ function merge_duplicates{CoefType,IntType<:Integer}(::Type{IntType},aff::Generi
         is(var.m, m) || error("Variable does not belong to this model")
         addelt!(v, aff.vars[ind].col, aff.coeffs[ind])
     end
+    rmz!(v)
     indices = Array(IntType,v.nnz)
     coeffs = Array(CoefType,v.nnz)
     for i in 1:v.nnz

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -25,6 +25,21 @@ function addelt!{T}(v::IndexedVector{T},i::Integer,val::T)
     return nothing
 end
 
+function rmz!{T}(v::IndexedVector{T})
+    i = 1
+    while i <= v.nnz
+        j = v.nzidx[i]
+        if v.elts[j] == zero(T)
+            v.empty[j] = true
+            # If i == v.nnz then this has no effect but it would be inefficient to branch
+            v.nzidx[i] = v.nzidx[v.nnz]
+            v.nnz -= 1
+        else
+            i += 1
+        end
+    end
+end
+
 function Base.empty!{T}(v::IndexedVector{T})
     elts = v.elts
     nzidx = v.nzidx


### PR DESCRIPTION
It often happens that when taking the sum/different of linear expressions, terms cancel. While leaving zeros, e.g. in the conic sparse matrix A, may not be that bad, it still makes solvers throw warning (e.g. Mosek) which can scare the user (at least it scared me).
The `rmz!` function implemented in this PR should not occur any performance overhead at all while removing those slighly annoying issues. What do you think ?