### PR TITLE
kill curly braces

### DIFF
--- a/doc/nlp.rst
+++ b/doc/nlp.rst
@@ -14,8 +14,8 @@ performance.
 
 
 Nonlinear objectives and constraints are specified by using the ``@NLobjective``
-and ``@NLconstraint`` macros. The familiar ``sum{}`` syntax is supported within
-these macros, as well as ``prod{}`` which analogously represents the product of
+and ``@NLconstraint`` macros. The familiar ``sum()`` syntax is supported within
+these macros, as well as ``prod()`` which analogously represents the product of
 the terms within. Note that the ``@objective`` and ``@constraint``
 macros (and corresponding functions) do *not* currently support nonlinear expressions.
 However, a model can contain a mix of linear, quadratic, and nonlinear constraints or
@@ -53,7 +53,7 @@ the syntax for linear and quadratic expressions. We note some important points b
 
 - All expressions must be simple scalar operations. You cannot use ``dot``,
   matrix-vector products, vector slices, etc. Translate vector operations
-  into explicit ``sum{}`` operations or use the ``AffExpr`` plus auxiliary variable
+  into explicit ``sum()`` operations or use the ``AffExpr`` plus auxiliary variable
   trick described below.
 - There is no operator overloading provided to build up nonlinear expressions.
   For example, if ``x`` is a JuMP variable, the code ``3x`` will return an

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -83,7 +83,7 @@ macros, e.g.::
 .. note::
     The ``sense`` passed to ``@objective`` must be a `symbol <http://docs.julialang.org/en/latest/manual/metaprogramming/#symbols>`_ type: ``:Min`` or ``:Max``, although the macro accepts ``:Min`` and ``:Max``, as well as ``Min`` and ``Max`` (without the colon) directly.
 
-The ``sum()`` syntax direcly follows Julia's own generator expression syntax. You may use conditions within sums, e.g.::
+The ``sum()`` syntax directly follows Julia's own generator expression syntax. You may use conditions within sums, e.g.::
 
     sum(expression for i = I1, j = I2 if cond}
 
@@ -99,6 +99,9 @@ which is equivalent to::
             ...
         end
     end
+
+.. note::
+    JuMP previously used a special curly brace syntax for ``sum{}``, ``prod{}``, and ``norm2{}``. This has been entirely replaced by ``sum()``, ``prod()``, and ``norm()`` since Julia 0.5. The curly brace syntax is deprecated and will be removed in a future release.
 
 
 .. Walks through a simple example

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -77,31 +77,15 @@ JuMP allows users to use a natural notation to describe linear expressions. To a
 macros, e.g.::
 
     @constraint(m, x[i] - s[i] <= 0)  # Other options: <= and >=
-    @constraint(m, sum{x[i], i=1:numLocation} == 1)
+    @constraint(m, sum(x[i] for i=1:numLocation) == 1)
     @objective(m, Max, 5x + 22y + (x+y)/2) # or Min
 
 .. note::
     The ``sense`` passed to ``@objective`` must be a `symbol <http://docs.julialang.org/en/latest/manual/metaprogramming/#symbols>`_ type: ``:Min`` or ``:Max``, although the macro accepts ``:Min`` and ``:Max``, as well as ``Min`` and ``Max`` (without the colon) directly.
 
-You may have noticed a special ``sum{}`` operator above. This is defined only for
-the second kind of function. The syntax is of the form (where ``IX`` can be any iterable)::
+The ``sum()`` syntax direcly follows Julia's own generator expression syntax. You may use conditions within sums, e.g.::
 
-	sum{expression, i = I1, j = I2, ...}
-
-which is equivalent to::
-
-    a = zero(AffExpr)  # Create a new empty affine expression
-    for i = I1
-        for j = I2
-            ...
-            a += expression
-            ...
-        end
-    end
-
-You can also put a condition in::
-
-    sum{expression, i = I1, j = I2, ...; cond}
+    sum(expression for i = I1, j = I2 if cond}
 
 which is equivalent to::
 

--- a/doc/refexpr.rst
+++ b/doc/refexpr.rst
@@ -54,17 +54,17 @@ Methods
 
 * ``@expression(m::Model, ref, expr)`` - efficiently builds a linear, quadratic, or second-order cone expression but does not add to model immediately. Instead, returns the expression which can then be inserted in other constraints. For example::
 
-    @expression(m, shared, sum{i*x[i], i=1:5})
+    @expression(m, shared, sum(i*x[i] for i=1:5))
     @constraint(m, shared + y >= 5)
     @constraint(m, shared + z <= 10)
 
 The ``ref`` accepts index sets in the same way as ``@variable``, and those indices can be used in the construction of the expressions::
 
-    @expression(m, expr[i=1:3], i*sum{x[j], j=1:3})
+    @expression(m, expr[i=1:3], i*sum(x[j] for j=1:3))
 
 Anonymous syntax is also supported::
 
-    expr = @expression(m, [i=1:3], i*sum{x[j], j=1:3})
+    expr = @expression(m, [i=1:3], i*sum(x[j] for j=1:3))
 * ``@SDconstraint(m::Model, expr)`` - adds a semidefinite constraint to the model ``m``. The expression ``expr`` must be a square, two-dimensional array.
 * ``addSOS1(m::Model, coll::Vector{AffExpr})`` - adds special ordered set constraint
   of type 1 (SOS1). Specify the set as a vector of weighted variables, e.g. ``coll = [3x, y, 2z]``.
@@ -165,7 +165,7 @@ For example::
    @variable(m, x[1:2] >= 1)
    @variable(m, t)
    @objective(m, Min, t)
-   @constraint(m, soc, norm2{ x[i], i=1:2 } <= t)
+   @constraint(m, soc, norm( x[i] for i=1:2 ) <= t)
    status = solve(m)
 
    @show getvalue(x) # [1.000000000323643,1.0000000003235763]

--- a/doc/refmodel.rst
+++ b/doc/refmodel.rst
@@ -119,7 +119,7 @@ Second-order cone constraints of the form :math:`||Ax-b||_2 + a^Tx + c \le 0` ca
 
     @constraint(m, norm(A*x) <= 2w - 1)
 
-You may use generator expressions within ``norm()`` to build up normed expressions with complex indexing operations in much the same way with ``sum(...)``::
+You may use generator expressions within ``norm()`` to build up normed expressions with complex indexing operations in much the same way as with ``sum(...)``::
 
     @constraint(m, norm(2x[i] - i for i=1:n if c[i] == 1) <= 1)
 

--- a/doc/refmodel.rst
+++ b/doc/refmodel.rst
@@ -119,9 +119,9 @@ Second-order cone constraints of the form :math:`||Ax-b||_2 + a^Tx + c \le 0` ca
 
     @constraint(m, norm(A*x) <= 2w - 1)
 
-The special ``norm2{...}`` construct may be used to build up normed expressions with complex indexing operations in much the same way as the ``sum{...}`` construct::
+You may use generator expressions within ``norm()`` to build up normed expressions with complex indexing operations in much the same way with ``sum(...)``::
 
-    @constraint(m, norm2{2x[i] - i, i=1:n; c[i] == 1} <= 1)
+    @constraint(m, norm(2x[i] - i for i=1:n if c[i] == 1) <= 1)
 
 Accessing the low-level model
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/bnatt350.jl
+++ b/examples/bnatt350.jl
@@ -53,11 +53,8 @@ for i in 1:n
     setupperbound(x[i], xub[i])
     mod.colCat[x[i].col] = vtypes[i]
 end
-At = A' # transpose to get useful row-wise sparse representation
-for i in 1:At.n
-    @constraint( mod, l[i] <= sum{ At.nzval[idx]*x[At.rowval[idx]], idx = At.colptr[i]:(At.colptr[i+1]-1) } <= u[i] )
-end
-@objective(mod, Min, sum{ c[i]*x[i], i=1:n })
+@constraint( mod, l .<= A*x .<= u)
+@objective(mod, Min, dot(c,x))
 
 function myheuristic(cb)
     fp = open("data/bnatt350.sol", "r")

--- a/examples/cannery.jl
+++ b/examples/cannery.jl
@@ -36,16 +36,16 @@ function solveCannery(plants, markets, capacity, demand, distance, freight)
   @variable(cannery, ship[1:numplants, 1:nummarkets] >= 0)
 
   # Ship no more than plant capacity
-  @constraint(cannery, xyconstr[i=1:numplants],
-                   sum{ship[i,j], j=1:nummarkets}<=capacity[i])
+  @constraint(cannery, capacity_con[i=1:numplants],
+               sum(ship[i,j] for j=1:nummarkets)<=capacity[i])
 
   # Ship at least market demand
-  @constraint(cannery, xyconstr[j=1:nummarkets],
-               sum{ship[i,j], i=1:numplants}>=demand[j])
+  @constraint(cannery, demand_con[j=1:nummarkets],
+               sum(ship[i,j] for i=1:numplants)>=demand[j])
 
   # Minimize transporatation cost
   @objective(cannery, Min,
-              sum{distance[i,j]* freight * ship[i,j], i=1:numplants, j=1:nummarkets})
+              sum(distance[i,j]* freight * ship[i,j] for i=1:numplants, j=1:nummarkets))
 
   solution = solve(cannery)
   if solution == :Optimal

--- a/examples/diet.jl
+++ b/examples/diet.jl
@@ -64,7 +64,7 @@ function SolveDiet()
 
     # Nutrition constraints
     for j = 1:numCategories
-        @constraint(m, sum{nutritionValues[i,j]*buy[i], i=1:numFoods} == nutrition[j])
+        @constraint(m, sum(nutritionValues[i,j]*buy[i] for i=1:numFoods) == nutrition[j])
     end
 
     # Solve

--- a/examples/mle.jl
+++ b/examples/mle.jl
@@ -16,7 +16,7 @@ m = Model()
 @variable(m, μ, start = 0.0)
 @variable(m, σ >= 0.0, start = 1.0)
 
-@NLobjective(m, Max, (n/2)*log(1/(2π*σ^2))-sum{(data[i]-μ)^2, i=1:n}/(2σ^2))
+@NLobjective(m, Max, (n/2)*log(1/(2π*σ^2))-sum((data[i]-μ)^2 for i=1:n)/(2σ^2))
 
 solve(m)
 

--- a/examples/multi.jl
+++ b/examples/multi.jl
@@ -84,22 +84,22 @@ multi = Model()
 length(cost)
 
 @objective(multi, Max,
-              sum{sum{sum{cost[j, i, p] * Trans[i,j, p],
-                        i=1:numorig}, j=1:numdest}, p=1:numprod})
+              sum(cost[j, i, p] * Trans[i,j, p] for
+                  i=1:numorig, j=1:numdest, p=1:numprod))
 
 #  CONSTRAINTS
 
 # Supply constraint
-@constraint(multi, xyconstr[i=1:numorig, p=1:numprod],
-               sum{Trans[i,j,p], j=1:numdest} == supply[p,i])
+@constraint(multi, supply_con[i=1:numorig, p=1:numprod],
+               sum(Trans[i,j,p] for j=1:numdest) == supply[p,i])
 
 # Demand constraint
-@constraint(multi, xyconstr[j=1:numdest, p=1:numprod],
-               sum{Trans[i,j,p], i=1:numorig} == demand[p,j])
+@constraint(multi, demand_con[j=1:numdest, p=1:numprod],
+               sum(Trans[i,j,p] for i=1:numorig) == demand[p,j])
 
 # Total shipment constraint
-@constraint(multi, xyconstr[i=1:numorig, j=1:numdest],
-               sum{Trans[i,j,p], p=1:numprod} - limit[i][j] <= 0)
+@constraint(multi, total_con[i=1:numorig, j=1:numdest],
+               sum(Trans[i,j,p] for p=1:numprod) - limit[i][j] <= 0)
 limit[2][3]
 status = solve(multi)
 if status == :Optimal

--- a/examples/noswot.jl
+++ b/examples/noswot.jl
@@ -45,13 +45,12 @@ vtypes = MathProgBase.getvartype(m_internal)
 for i in 1:n
     setlowerbound(x[i], xlb[i])
     setupperbound(x[i], xub[i])
-    vtypes[i] == 'I' ? mod.colCat[x[i].col] = :Int : nothing # change vartype to integer when appropriate
+    if vtypes[i] == 'I'
+        setcategory(x[i], :Int)
+    end
 end
-At = A' # transpose to get useful row-wise sparse representation
-for i in 1:At.n
-    @constraint( mod, l[i] <= sum{ At.nzval[idx]*x[At.rowval[idx]], idx = At.colptr[i]:(At.colptr[i+1]-1) } <= u[i] )
-end
-@objective(mod, Min, sum{ c[i]*x[i], i=1:n })
+@constraint(mod, l .<= A*x .<= u)
+@objective(mod, Min, dot(c,x))
 
 function mycutgenerator(cb) # valid cuts
     x_val = getvalue(x)

--- a/examples/optcontrol.jl
+++ b/examples/optcontrol.jl
@@ -31,7 +31,7 @@ let
     @variable(m, -0.05 <= x[1:(ni+1)] <= 0.05)
     @variable(m, u[1:(ni+1)])
 
-    @NLobjective(m, Min, sum{ 0.5*h*(u[i+1]^2 + u[i]^2) + 0.5*alpha*h*(cos(t[i+1]) + cos(t[i])), i = 1:ni})
+    @NLobjective(m, Min, sum( 0.5*h*(u[i+1]^2 + u[i]^2) + 0.5*alpha*h*(cos(t[i+1]) + cos(t[i])) for i = 1:ni))
 
     # cons1
     for i in 1:ni

--- a/examples/steelT3.jl
+++ b/examples/steelT3.jl
@@ -61,34 +61,32 @@ print(market["coils"]["west"][1])
 @variable(Prod, Inv[p=prod, t=0:T] >= 0); # tons inventoried
 @variable(Prod, market[p][a][t] >= Sell[p=prod, a=area[p],t=1:T] >= 0); # tons sold
 
-@constraint(Prod, triconstr[p=prod, a=area[p], t=1:T],
+@constraint(Prod, [p=prod, a=area[p], t=1:T],
                Sell[p, a, t] - market[p][a][t] <= 0)
 
 
-@constraint(Prod, xyconst[t=1:T],
-               sum{(1/rate[p]) * Make[p,t], p=prod} <= avail[t])
+@constraint(Prod, [t=1:T],
+               sum((1/rate[p]) * Make[p,t] for p=prod) <= avail[t])
 
 # Total of hours used by all products
 # may not exceed hours available, in each week
 
-@constraint(Prod, xyconst[p=prod],
+@constraint(Prod, [p=prod],
                Inv[p,0] == inv0[p])
 # Initial inventory must equal given value
 
-@constraint(Prod, xyconst[p=prod, t=1:T],
-               Make[p,t] + Inv[p, t-1] == sum{Sell[p,a,t], a=area[p]} + Inv[p,t])
+@constraint(Prod, [p=prod, t=1:T],
+               Make[p,t] + Inv[p, t-1] == sum(Sell[p,a,t] for a=area[p]) + Inv[p,t])
 
 # Tons produced and taken from inventory
 # must equal tons sold and put into inventory
 
 
 @objective(Prod, Max,
-              sum{
-                sum{revenue[p][a][t] * Sell[p, a, t] -
-                      prodcost[p] * Make[p,t] -
-                      invcost[p]*Inv[p,t],
-                    a = area[p]},
-                p=prod, t=1:T})
+              sum( sum(
+                   revenue[p][a][t] * Sell[p, a, t] -
+                   prodcost[p] * Make[p,t] -
+                   invcost[p]*Inv[p,t] for a in area[p]) for p=prod, t=1:T))
 #maximize Total_Profit:
 # Total revenue less costs for all products in all weeks
 

--- a/examples/transp.jl
+++ b/examples/transp.jl
@@ -34,11 +34,11 @@ m = Model();
 @variable(m, Trans[i=1:length(ORIG), j=1:length(DEST)] >= 0);
 
 
-@objective(m, Min, sum{cost[i,j] * Trans[i,j], i=1:length(ORIG), j=1:length(DEST)});
+@objective(m, Min, sum(cost[i,j] * Trans[i,j] for i=1:length(ORIG), j=1:length(DEST)));
 
-@constraint(m, xyconstr[i=1:1:length(ORIG)], sum{Trans[i,j], j=1:length(DEST)} == supply[i]);
+@constraint(m, [i=1:1:length(ORIG)], sum(Trans[i,j] for j=1:length(DEST)) == supply[i]);
 
-@constraint(m, xyconstr[j = 1:length(DEST)], sum{Trans[i,j], i=1:length(ORIG)} == demand[j]);
+@constraint(m, [j = 1:length(DEST)], sum(Trans[i,j] for i=1:length(ORIG)) == demand[j]);
 
 println("Solving original problem...")
 status = solve(m);

--- a/examples/tsp.jl
+++ b/examples/tsp.jl
@@ -117,7 +117,7 @@ function solveTSP(n, cities)
     @variable(m, x[1:n,1:n], Bin)
 
     # Minimize length of tour
-    @objective(m, Min, sum{dist[i,j]*x[i,j], i=1:n,j=i:n})
+    @objective(m, Min, sum(dist[i,j]*x[i,j] for i=1:n for j=i:n))
 
     # Make x_ij and x_ji be the same thing (undirectional)
     # Don't allow self-arcs
@@ -130,7 +130,7 @@ function solveTSP(n, cities)
 
     # We must enter and leave every city once and only once
     for i = 1:n
-        @constraint(m, sum{x[i,j], j=1:n} == 2)
+        @constraint(m, sum(x[i,j] for j=1:n) == 2)
     end
 
     function subtour(cb)

--- a/examples/urbanplan.jl
+++ b/examples/urbanplan.jl
@@ -30,36 +30,36 @@ function SolveUrban()
     @variable(m, 0 <= y[rowcol,points,i=1:5] <= 1, Int)
 
     # Objective - combine the positive and negative parts
-    @objective(m, Max, sum{
+    @objective(m, Max, sum(
       3*(y["R", 3,i] + y["C", 3,i])
     + 1*(y["R", 4,i] + y["C", 4,i])
     + 1*(y["R", 5,i] + y["C", 5,i])
     - 3*(y["R",-3,i] + y["C",-3,i])
     - 1*(y["R",-4,i] + y["C",-4,i])
-    - 1*(y["R",-5,i] + y["C",-5,i]), i=1:5})
+    - 1*(y["R",-5,i] + y["C",-5,i]) for i=1:5))
 
     # Constrain the number of residential lots
-    @constraint(m, sum{x[i,j], i=1:5, j=1:5} == 12)
+    @constraint(m, sum(x[i,j] for i=1:5, j=1:5) == 12)
 
     # Add the constraints that link the auxiliary y variables
     # to the x variables
     # Rows
     for i = 1:5
-        @constraint(m, y["R", 5,i] <=   1/5*sum{x[i,j], j=1:5}) # sum = 5
-        @constraint(m, y["R", 4,i] <=   1/4*sum{x[i,j], j=1:5}) # sum = 4
-        @constraint(m, y["R", 3,i] <=   1/3*sum{x[i,j], j=1:5}) # sum = 3
-        @constraint(m, y["R",-3,i] >= 1-1/3*sum{x[i,j], j=1:5}) # sum = 2
-        @constraint(m, y["R",-4,i] >= 1-1/2*sum{x[i,j], j=1:5}) # sum = 1
-        @constraint(m, y["R",-5,i] >= 1-1/1*sum{x[i,j], j=1:5}) # sum = 0
+        @constraint(m, y["R", 5,i] <=   1/5*sum(x[i,j] for j=1:5)) # sum = 5
+        @constraint(m, y["R", 4,i] <=   1/4*sum(x[i,j] for j=1:5)) # sum = 4
+        @constraint(m, y["R", 3,i] <=   1/3*sum(x[i,j] for j=1:5)) # sum = 3
+        @constraint(m, y["R",-3,i] >= 1-1/3*sum(x[i,j] for j=1:5)) # sum = 2
+        @constraint(m, y["R",-4,i] >= 1-1/2*sum(x[i,j] for j=1:5)) # sum = 1
+        @constraint(m, y["R",-5,i] >= 1-1/1*sum(x[i,j] for j=1:5)) # sum = 0
     end
     # Columns
     for j = 1:5
-        @constraint(m, y["C", 5,j] <=   1/5*sum{x[i,j], i=1:5}) # sum = 5
-        @constraint(m, y["C", 4,j] <=   1/4*sum{x[i,j], i=1:5}) # sum = 4
-        @constraint(m, y["C", 3,j] <=   1/3*sum{x[i,j], i=1:5}) # sum = 3
-        @constraint(m, y["C",-3,j] >= 1-1/3*sum{x[i,j], i=1:5}) # sum = 2
-        @constraint(m, y["C",-4,j] >= 1-1/2*sum{x[i,j], i=1:5}) # sum = 1
-        @constraint(m, y["C",-5,j] >= 1-1/1*sum{x[i,j], i=1:5}) # sum = 0
+        @constraint(m, y["C", 5,j] <=   1/5*sum(x[i,j] for i=1:5)) # sum = 5
+        @constraint(m, y["C", 4,j] <=   1/4*sum(x[i,j] for i=1:5)) # sum = 4
+        @constraint(m, y["C", 3,j] <=   1/3*sum(x[i,j] for i=1:5)) # sum = 3
+        @constraint(m, y["C",-3,j] >= 1-1/3*sum(x[i,j] for i=1:5)) # sum = 2
+        @constraint(m, y["C",-4,j] >= 1-1/2*sum(x[i,j] for i=1:5)) # sum = 1
+        @constraint(m, y["C",-5,j] >= 1-1/1*sum(x[i,j] for i=1:5)) # sum = 0
     end
 
     # Solve it with the default solver (CBC)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -10,10 +10,14 @@ isprod(s::Symbol) = (s == :prod) || (s == :∏)
 
 function curly_to_generator(x)
     # we have a filter condition
+    x = copy(x)
     @assert isexpr(x,:curly)
     if isexpr(x.args[2],:parameters)
         cond = x.args[2].args[1]
         body = x.args[3]
+        if length(x.args) == 3 # no iteration set!
+            push!(x.args,:(_ in 1))
+        end
         for i in length(x.args):-1:4
             if i == length(x.args)
                 body = Expr(:generator,body,Expr(:filter,cond,x.args[i]))
@@ -24,6 +28,9 @@ function curly_to_generator(x)
     else
         cond = nothing
         body = x.args[2]
+        if length(x.args) == 2 # no iteration set!
+            push!(x.args,:(_ in 1))
+        end
         for i in length(x.args):-1:3
             body = Expr(:generator,body,x.args[i])
         end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -8,12 +8,6 @@ using Base.Meta
 issum(s::Symbol) = (s == :sum) || (s == :∑) || (s == :Σ)
 isprod(s::Symbol) = (s == :prod) || (s == :∏)
 
-function flatten_error(ex)
-    isexpr(ex, :flatten) || return
-    error("The generator syntax \"$ex\" with multiple \"for\" statements is not yet supported. For JuMP, you should contract statements like \"for i in 1:N for j in 1:i\" into \"for i in 1:N, j in 1:i\"")
-end
-
-
 include("parseExpr_staged.jl")
 
 ###############################################################################

--- a/src/parseExpr_staged.jl
+++ b/src/parseExpr_staged.jl
@@ -622,6 +622,7 @@ function parseExpr(x, aff::Symbol, lcoeffs::Vector, rcoeffs::Vector, newaff::Sym
         elseif isexpr(x,:call) && length(x.args) >= 2 && isexpr(x.args[2],:flatten)
             flatten_error(x.args[2])
         elseif x.head == :curly
+            warn_curly(x)
             return newaff, parseCurly(x,aff,lcoeffs,rcoeffs,newaff)
         else # at lowest level?
             !isexpr(x,:comparison) || error("Unexpected comparison in expression $x")

--- a/src/parsenlp.jl
+++ b/src/parsenlp.jl
@@ -9,7 +9,7 @@
 # values is the name of the list of constants which appear in the expression
 function parseNLExpr(m, x, tapevar, parent, values)
 
-    if isexpr(x,:call) && length(x.args) >= 2 && isexpr(x.args[2],:generator)
+    if isexpr(x,:call) && length(x.args) >= 2 && (isexpr(x.args[2],:generator) || isexpr(x.args[2],:flatten))
         header = x.args[1]
         if issum(header)
             operatorid = operator_to_id[:+]
@@ -28,9 +28,6 @@ function parseNLExpr(m, x, tapevar, parent, values)
         code = parsegen(x.args[2], t -> parseNLExpr(m, t, tapevar, parentvar, values))
         push!(block.args, code)
         return codeblock
-    end
-    if isexpr(x,:call) && length(x.args) >= 2 && isexpr(x.args[2],:flatten)
-        flatten_error(x.args[2])
     end
 
     if isexpr(x, :call)

--- a/src/parsenlp.jl
+++ b/src/parsenlp.jl
@@ -24,44 +24,9 @@ function parseNLExpr(m, x, tapevar, parent, values)
         parentvar = gensym()
         push!(block.args, :($parentvar = length($tapevar)))
 
-        # we have a filter condition
-        if isexpr(x.args[2].args[2],:filter)
-            cond = x.args[2].args[2].args[1]
-            # generate inner loop code first and then wrap in for loops
-            innercode = parseNLExpr(m, x.args[2].args[1], tapevar, parentvar, values)
-            code = quote
-                if $(esc(cond))
-                    $innercode
-                end
-            end
-            for level in length(x.args[2].args[2]):-1:2
-                _idxvar, idxset = parseIdxSet(x.args[2].args[2].args[level]::Expr)
-                idxvar = esc(_idxvar)
-                code = :(let
-                    $(localvar(idxvar))
-                    for $idxvar in $(esc(idxset))
-                        $code
-                    end
-                end)
-            end
-            push!(block.args, code)
-        else # no condition
-            innercode = parseNLExpr(m, x.args[2].args[1], tapevar, parentvar, values)
-            code = quote
-                $innercode
-            end
-            for level in length(x.args[2].args):-1:2
-                _idxvar, idxset = parseIdxSet(x.args[2].args[level]::Expr)
-                idxvar = esc(_idxvar)
-                code = :(let
-                    $(localvar(idxvar))
-                    for $idxvar in $(esc(idxset))
-                        $code
-                    end
-                end)
-            end
-            push!(block.args, code)
-        end
+
+        code = parsegen(x.args[2], t -> parseNLExpr(m, t, tapevar, parentvar, values))
+        push!(block.args, code)
         return codeblock
     end
     if isexpr(x,:call) && length(x.args) >= 2 && isexpr(x.args[2],:flatten)

--- a/src/parsenlp.jl
+++ b/src/parsenlp.jl
@@ -124,6 +124,7 @@ function parseNLExpr(m, x, tapevar, parent, values)
         return code
     end
     if isexpr(x, :curly)
+        warn_curly(x)
         header = x.args[1]
         if length(x.args) < 3
             error("Need at least two arguments for $header")

--- a/test/callback.jl
+++ b/test/callback.jl
@@ -122,9 +122,9 @@ context("With solver $(typeof(lazylocalsolver))") do
         nodesexpl = MathProgBase.cbgetexplorednodes(cb)
         if  entered[1] == false && nodesexpl >= 1
             # the following lazy cut  constrains all x[i] to be zero, but applies only locally at the node of the first feasible solution found: it doesn't preclude the existence of "optimal" non-trival solutions
-            @lazyconstraint(cb, sum{x[i], i=1:length(weights)} <= 0, localcut=true)
-            # @lazyconstraint(cb, sum{x[i], i=1:length(weights)} <= 0) # applying the cut globally would lead the solver to x=0 as the optimal solution
-            @fact macroexpand(:(@lazyconstraint(cb, sum{x[i], i=1:length(weights)} <= 0, badkwarg=true))).head --> :error
+            @lazyconstraint(cb, sum(x) <= 0, localcut=true)
+            # @lazyconstraint(cb, sum(x) <= 0) # applying the cut globally would lead the solver to x=0 as the optimal solution
+            @fact macroexpand(:(@lazyconstraint(cb, sum(x) <= 0, badkwarg=true))).head --> :error
             entered[1] = true
         end
         entered[2] = true
@@ -151,7 +151,7 @@ context("With solver $(typeof(cutsolver))") do
     @constraint(mod, c[i=1:10], dot(r2[i],x) <= rhs[i]*N/10)
     function mycutgenerator(cb)
         # add a trivially valid cut
-        @usercut(cb, sum{x[i], i=1:N} <= N)
+        @usercut(cb, sum(x[i] for i=1:N) <= N)
         entered[1] = true
     end
     addcutcallback(mod, mycutgenerator)
@@ -178,9 +178,9 @@ context("With solver $(typeof(cutlocalsolver))") do
         nodesexpl = MathProgBase.cbgetexplorednodes(cb)
         if  entered[1] == false && nodesexpl >= 1
             # the following user cut  constrains all x[i] to be zero, but applies only locally at the first node after the root node, and doesn't preclude the existence non-trival "optimal" solutions
-            @usercut(cb, sum{x[i], i=1:length(weights)} <= 0, localcut=true)
-            # @usercut(cb, sum{x[i], i=1:length(weights)} <= 0) # applying the cut globally would lead the solver to x=0 as the optimal solution
-            @fact macroexpand(:(@usercut(cb, sum{x[i], i=1:length(weights)} <= 0, badkwarg=true))).head --> :error
+            @usercut(cb, sum(x) <= 0, localcut=true)
+            # @usercut(cb, sum(x) <= 0) # applying the cut globally would lead the solver to x=0 as the optimal solution
+            @fact macroexpand(:(@usercut(cb, sum(x) <= 0, badkwarg=true))).head --> :error
             entered[1] = true
         end
         entered[2] = true

--- a/test/hockschittkowski/hs110.jl
+++ b/test/hockschittkowski/hs110.jl
@@ -28,8 +28,8 @@ m = Model()
 @variable(m, -2.001 <= x[1:10] <= 9.999, start = 9)
 
 @NLobjective(m, Min,
-    sum{ log(x[j] - 2)^2 + log(10 - x[j])^2, j=1:10} -
-    prod{x[i],i=1:10} ^ 0.2
+    sum( log(x[j] - 2)^2 + log(10 - x[j])^2 for j=1:10) -
+    prod( x[i] for i=1:10) ^ 0.2
 )
 
 solve(m)

--- a/test/hockschittkowski/hs111.jl
+++ b/test/hockschittkowski/hs111.jl
@@ -30,7 +30,7 @@ m = Model()
 @variable(m, -100 <= x[1:10] <= 100, start = -2.3)
 
 @NLobjective(m, Min,
-    sum{exp(x[j]) * (c[j] + x[j] - log( sum{exp(x[k]), k=1:10} ) ), j=1:10})
+    sum(exp(x[j]) * (c[j] + x[j] - log( sum(exp(x[k]) for k=1:10) ) ) for j=1:10))
 
 @NLconstraint(m, exp(x[1]) + 2*exp(x[2]) + 2*exp(x[3]) +   exp(x[6]) + exp(x[10]) == 2)
 @NLconstraint(m, exp(x[4]) + 2*exp(x[5]) +   exp(x[6]) +   exp(x[7])              == 1)

--- a/test/hockschittkowski/hs112.jl
+++ b/test/hockschittkowski/hs112.jl
@@ -29,7 +29,7 @@ c = [-6.089, -17.164, -34.054, -5.914, -24.721, -14.986, -24.100, -10.708, -26.6
 m = Model()
 @variable(m, x[1:10] >= 1e-6, start = 0.1)
 
-@NLobjective(m, Min, sum{x[j]*(c[j] + log(x[j]/sum{x[k],k=1:10})), j=1:10})
+@NLobjective(m, Min, sum(x[j]*(c[j] + log(x[j]/sum(x[k] for k=1:10))) for j=1:10))
 
 @NLconstraint(m, x[1] + 2*x[2] + 2*x[3] + x[6] + x[10] == 2)
 @NLconstraint(m, x[4] + 2*x[5] + x[6] + x[7] == 1)

--- a/test/hockschittkowski/hs118.jl
+++ b/test/hockschittkowski/hs118.jl
@@ -43,12 +43,12 @@ end
 @variable(m, L[i] <= x[i=1:15] <= U[i])
 
 @NLobjective(m, Min,
-    sum{2.3     * x[3*k+1]   +
+    sum(2.3     * x[3*k+1]   +
         0.0001  * x[3*k+1]^2 +
         1.7     * x[3*k+2]   +
         0.0001  * x[3*k+2]^2 +
         2.2     * x[3*k+3] +
-        0.00015 * x[3*k+3]^2, k=0:4})
+        0.00015 * x[3*k+3]^2 for k=0:4))
 
 # setobjective(m, :Min,
 #   sum([(2.3     * x[3*k+1]   +

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -15,8 +15,8 @@ mysense = :Min
 JuMP.@variable(mymod, x >= 0)
 r = 3:5
 JuMP.@variable(mymod, y[i=r] <= i)
-JuMP.@constraint(mymod, x + sum{ j*y[j], j=r } <= 1)
-JuMP.@constraint(mymod, sum{ y[j], j=r ; j == 4} <= 1)
+JuMP.@constraint(mymod, x + sum( j*y[j] for j=r ) <= 1)
+JuMP.@constraint(mymod, sum( y[j] for j=r if j == 4) <= 1)
 JuMP.@constraint(mymod, -1 <= x + y[3] <= 1)
 JuMP.@objective(mymod, mysense, y[4])
 JuMP.@NLconstraint(mymod, y[3] == 1)

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -131,6 +131,15 @@ facts("[macros] sum(generator)") do
     @constraint(m, sum( C[i,j]*x[i,j] for i = 1:3, j = 1:i) == 0);
     @fact string(m.linconstr[end]) --> "x[1,1] + 4 x[2,1] + 5 x[2,2] + 7 x[3,1] + 8 x[3,2] + 9 x[3,3] $eq 0"
 
+    @constraint(m, sum( C[i,j]*x[i,j] for i = 1:3 for j = 1:i) == 0);
+    @fact string(m.linconstr[end]) --> "x[1,1] + 4 x[2,1] + 5 x[2,2] + 7 x[3,1] + 8 x[3,2] + 9 x[3,3] $eq 0"
+
+    @constraint(m, sum( C[i,j]*x[i,j] for i = 1:3 if true for j = 1:i) == 0);
+    @fact string(m.linconstr[end]) --> "x[1,1] + 4 x[2,1] + 5 x[2,2] + 7 x[3,1] + 8 x[3,2] + 9 x[3,3] $eq 0"
+
+    @constraint(m, sum( C[i,j]*x[i,j] for i = 1:3 if true for j = 1:i if true) == 0);
+    @fact string(m.linconstr[end]) --> "x[1,1] + 4 x[2,1] + 5 x[2,2] + 7 x[3,1] + 8 x[3,2] + 9 x[3,3] $eq 0"
+
     @constraint(m, sum( 0*x[i,1] for i=1:3) == 0)
     @fact string(m.linconstr[end]) --> "0 $eq 0"
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -76,7 +76,7 @@ facts("[model] Test printing a model") do
     @objective(modA, Max, ((x + y)/2.0 + 3.0)/3.0 + z + r[3])
     @constraintref constraints[1:3]
     constraints[1] = @constraint(modA, 2 <= x+y <= 4)
-    constraints[2] = @constraint(modA, sum{r[i],i=3:5} <= (2 - x)/2.0)
+    constraints[2] = @constraint(modA, sum(r[i] for i=3:5) <= (2 - x)/2.0)
     constraints[3] = @constraint(modA, 6y + y <= z + r[6]/1.9)
     #####################################################################
     # Test LP writer (given names)
@@ -347,7 +347,7 @@ context("With solver $(typeof(solver))") do
     @variable(modA, 0 <= r[i=3:6] <= i)
     @objective(modA, Max, ((x + y)/2.0 + 3.0)/3.0 + z + r[3])
     @constraint(modA, 2 <= x+y)
-    @constraint(modA, sum{r[i],i=3:5} <= (2 - x)/2.0)
+    @constraint(modA, sum(r[i] for i=3:5) <= (2 - x)/2.0)
     @constraint(modA, 7.0*y <= z + r[6]/1.9)
 
     @fact solve(modA)       --> :Optimal
@@ -376,7 +376,7 @@ context("With solver $(typeof(solver))") do
     @objective(modA, Min, -((x + y)/2.0 + 3.0)/3.0 - z - r[3])
     @constraintref cons[1:3]
     cons[1] = @constraint(modA, x+y >= 2)
-    cons[2] = @constraint(modA, sum{r[i],i=3:5} <= (2 - x)/2.0)
+    cons[2] = @constraint(modA, sum(r[i] for i=3:5) <= (2 - x)/2.0)
     cons[3] = @constraint(modA, 7.0*y <= z + r[6]/1.9)
 
     # Solution
@@ -418,7 +418,7 @@ context("With solver $(typeof(solver))") do
     @objective(modA, Max, ((x + y)/2.0 + 3.0)/3.0 + z + r[3])
     @constraintref cons[1:3]
     cons[1] = @constraint(modA, x+y >= 2)
-    cons[2] = @constraint(modA, sum{r[i],i=3:5} <= (2 - x)/2.0)
+    cons[2] = @constraint(modA, sum(r[i] for i=3:5) <= (2 - x)/2.0)
     cons[3] = @constraint(modA, 7.0*y <= z + r[6]/1.9)
 
     # Solution
@@ -743,8 +743,8 @@ context("With solver $(typeof(solver))") do
     a = [1,2,3]
     b = [5,4,7,2,1]
 
-    @constraint(modS, z == sum{a[i]*x[i], i=1:3})
-    @constraint(modS, w == sum{b[i]*y[i], i=1:5})
+    @constraint(modS, z == sum(a[i]*x[i] for i=1:3))
+    @constraint(modS, w == sum(b[i]*y[i] for i=1:5))
 
     @fact_throws constructSOS([x[1]+y[1]])
     @fact_throws constructSOS([1z])
@@ -787,10 +787,10 @@ facts("[model] Test vectorized model creation") do
     @variable(modS, x[1:10])
     @variable(modS, y[1:7])
     for i in 1:50
-        @constraint(modS, sum{A[i,j]*x[j], j=1:10} + sum{B[i,k]*y[k], k=1:7} <= 1)
+        @constraint(modS, sum(A[i,j]*x[j] for j=1:10) + sum(B[i,k]*y[k] for k=1:7) <= 1)
     end
     AA, BB = 4A'*A, 4B'*A
-    @objective(modS, Max, sum{AA[i,j]*x[i]*x[j], i=1:10,j=1:10} + sum{BB[i,j]*y[i]*y[j], i=1:7, j=1:7})
+    @objective(modS, Max, sum(AA[i,j]*x[i]*x[j] for i=1:10,j=1:10) + sum(BB[i,j]*y[i]*y[j] for i=1:7, j=1:7))
 
     @fact JuMP.prepConstrMatrix(modV) --> JuMP.prepConstrMatrix(modS)
     @fact JuMP.prepProblemBounds(modV) --> JuMP.prepProblemBounds(modS)
@@ -980,8 +980,8 @@ facts("[model] Nonliteral exponents in @constraint") do
     foo() = 2
     @constraint(m, x^(foo()) + x^(foo()-1) + x^(foo()-2) == 1)
     @constraint(m, (x-1)^(foo()) + (x-1)^2 + (x-1)^1 + (x-1)^0 == 1)
-    @constraint(m, sum{x, i in 1:3}^(foo()) == 1)
-    @constraint(m, sum{x, i in 1:3}^(foo()-1) == 1)
+    @constraint(m, sum(x for i in 1:3)^(foo()) == 1)
+    @constraint(m, sum(x for i in 1:3)^(foo()-1) == 1)
     @fact m.quadconstr[1].terms --> x^2 + x
     @fact m.quadconstr[2].terms --> x^2 + x^2 - x - x - x - x + x + 1
     @fact m.quadconstr[3].terms --> x^2 + x^2 + x^2 + x^2 + x^2 + x^2 + x^2 + x^2 + x^2 - 1
@@ -999,7 +999,7 @@ facts("[model] sets used as indexsets in JuMPArray") do
     end
     m = Model()
     @variable(m, x[set, set2], Bin)
-    @objective(m , Max, sum{sum{x[e,p], e in set}, p in set2})
+    @objective(m , Max, sum(sum(x[e,p] for e in set) for p in set2))
     solve(m)
     sol = getvalue(x)
     checked_objval = 0

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -86,8 +86,6 @@ context("With solver $(typeof(nlp_solver))") do
         [1.000000, 4.742999, 3.821150, 1.379408], 1e-3)
 end; end; end
 
-if VERSION >= v"0.5-dev+5475"
-eval("""
 facts("[nonlinear] Test HS071 solves correctly (generators)") do
     # hs071
     # Polynomial objective and constraints
@@ -109,9 +107,7 @@ facts("[nonlinear] Test HS071 solves correctly (generators)") do
     @fact status --> :Optimal
     @fact getvalue(x)[:] --> roughly(
         [1.000000, 4.742999, 3.821150, 1.379408], 1e-5)
-
-    @fact isexpr(macroexpand(:(@NLconstraint(m, sum(x[i]^2 for i=1:4) == 40))),:error) --> true
-end""");end
+end
 
 
 facts("[nonlinear] Test HS071 solves correctly, epigraph") do
@@ -569,15 +565,13 @@ context("With solver $(typeof(nlp_solver))") do
     @fact getvalue(x) --> roughly(ones(18),1e-4)
 end; end; end
 
-if VERSION >= v"0.5-dev+5475"
-eval("""
 facts("[nonlinear] Test Hessian chunking code (generators)") do
     m = Model()
     @variable(m, x[1:18] >= 1, start = 1.2)
     @NLobjective(m, Min, prod(x[i] for i=1:18))
     @fact solve(m) --> :Optimal
     @fact getvalue(x) --> roughly(ones(18),1e-4)
-end"""); end
+end
 
 #############################################################################
 # Test that output is produced in correct MPB form
@@ -594,11 +588,7 @@ function MathProgBase.loadproblem!(m::DummyNLPModel, numVar, numConstr, x_l, x_u
         @fact MathProgBase.isconstrlinear(d,1) --> true
         @fact MathProgBase.isconstrlinear(d,3) --> true
         @fact MathProgBase.constr_expr(d,1) --> :(2.0*x[1] + 1.0*x[2] <= 1.0)
-        if VERSION >= v"0.5.0-dev+3231"
-            @fact MathProgBase.constr_expr(d,2) --> :(2.0*x[1] + 1.0*x[2] <= -0.0)
-        else
-            @fact MathProgBase.constr_expr(d,2) --> :(2.0*x[1] + 1.0*x[2] <= 0.0)
-        end
+        @fact MathProgBase.constr_expr(d,2) --> :(2.0*x[1] + 1.0*x[2] <= -0.0)
         @fact MathProgBase.constr_expr(d,3) --> :(-5.0 <= 2.0*x[1] + 1.0*x[2] <= 5.0)
         if numConstr > 3
             @fact MathProgBase.constr_expr(d,4) --> :(2.0*x[1]*x[1] + 1.0*x[2] + -2.0 >= 0)

--- a/test/perf/macro.jl
+++ b/test/perf/macro.jl
@@ -10,14 +10,14 @@ function test_linear(N)
     for z in 1:10
         @constraint(m,
             9*y[1,1,1] - 5*y[N,N,N] -
-            2*sum{ z*x[j,i*N],                j=((z-1)*N+1):z*N, i=3:4} +
-              sum{ i*(9*x[i,j] + 3*x[j,i]),   i=N:2N,            j=N:2N} +
+            2*sum( z*x[j,i*N]              for j=((z-1)*N+1):z*N, i=3:4) +
+              sum( i*(9*x[i,j] + 3*x[j,i]) for i=N:2N,            j=N:2N) +
             x[1,1] + x[10N,5N] + x[2N,1] +
             1*y[1,1,N] + 2*y[1,N,1] + 3*y[N,1,1] +
             y[N,N,N] - 2*y[N,N,N] + 3*y[N,N,N]
              <=
-            sum{sum{sum{N*i*j*k*y[i,j,k] + x[i,j],k=1:N; i!=j && j!=k},j=1:N},i=1:N} +
-            sum{sum{x[i,j], j=1:5N; j % i == 3}, i=1:10N; i <= N*z}
+            sum(sum(sum(N*i*j*k*y[i,j,k] + x[i,j] for k=1:N if i!=j && j!=k) for j=1:N) for i=1:N) +
+            sum(sum(x[i,j] for j=1:5N if j % i == 3) for i=1:10N if i <= N*z)
             )
     end
 end
@@ -30,14 +30,14 @@ function test_quad(N)
     for z in 1:10
         @constraint(m,
             9*y[1,1,1] - 5*y[N,N,N] -
-            2*sum{ z*x[j,i*N],                j=((z-1)*N+1):z*N, i=3:4} +
-              sum{ i*(9*x[i,j] + 3*x[j,i]),   i=N:2N,            j=N:2N} +
+            2*sum( z*x[j,i*N]              for j=((z-1)*N+1):z*N, i=3:4) +
+              sum( i*(9*x[i,j] + 3*x[j,i]) for i=N:2N,            j=N:2N) +
             x[1,1] + x[10N,5N] * x[2N,1] +
             1*y[1,1,N] * 2*y[1,N,1] + 3*y[N,1,1] +
             y[N,N,N] - 2*y[N,N,N] * 3*y[N,N,N]
              <=
-            sum{sum{sum{N*i*j*k*y[i,j,k] * x[i,j],k=1:N; i!=j && j!=k},j=1:N},i=1:N} +
-            sum{sum{x[i,j], j=1:5N; j % i == 3}, i=1:10N; i <= N*z}
+            sum(sum(sum(N*i*j*k*y[i,j,k] * x[i,j] for k=1:N if i!=j && j!=k) for j=1:N) for i=1:N) +
+            sum(sum(x[i,j] for j=1:5N if j % i == 3) for i=1:10N if i <= N*z)
             )
     end
 end

--- a/test/perf/norms.jl
+++ b/test/perf/norms.jl
@@ -4,13 +4,13 @@ function norm_stress1(N)
     m = Model()
     @variable(m, x[1:N])
     for i in 1:N
-        @constraint(m, norm2{x[j],j=1:i} <= i)
+        @constraint(m, norm(x[j] for j=1:i) <= i)
     end
     for i in 1:N
-        @constraint(m, norm2{(i/j)*x[j],j=1:i} <= i)
+        @constraint(m, norm((i/j)*x[j] for j=1:i) <= i)
     end
     for i in 1:N
-        @constraint(m, norm2{(i/j)*x[j],j=1:i} + sum{x[j],j=1:N} <= i)
+        @constraint(m, norm((i/j)*x[j] for j=1:i) + sum(x[j] for j=1:N) <= i)
     end
 end
 

--- a/test/perf/speed.jl
+++ b/test/perf/speed.jl
@@ -64,7 +64,7 @@ function pMedian(numFacility::Int,numCustomer::Int,numLocation::Int,useMPS)
     @variable(m, 0 <= x[1:numLocation,1:numCustomer] <= 1)
 
     # Objective: min distance
-    @objective(m, Max, sum{abs(customerLocations[a]-i)*x[i,a], a = 1:numCustomer, i = 1:numLocation} )
+    @objective(m, Max, sum(abs(customerLocations[a]-i)*x[i,a] for a = 1:numCustomer, i = 1:numLocation) )
 
     # Constraints
     for a in 1:numCustomer
@@ -73,11 +73,11 @@ function pMedian(numFacility::Int,numCustomer::Int,numLocation::Int,useMPS)
             @constraint(m, x[i,a] - s[i] <= 0)
         end
         # Subject to one of x must be 1
-        @constraint(m, sum{x[i,a],i=1:numLocation} == 1 )
+        @constraint(m, sum(x[i,a] for i=1:numLocation) == 1 )
     end
 
     # Subject to must allocate all facilities
-    @constraint(m, sum{s[i],i=1:numLocation} == numFacility )
+    @constraint(m, sum(s[i] for i=1:numLocation) == numFacility )
     buildTime = toq()
 
     tic()

--- a/test/perf/speed2.jl
+++ b/test/perf/speed2.jl
@@ -25,7 +25,7 @@ function pMedian(numFacility::Int,numCustomer::Int,numLocation::Int)
     @variable(m, 0 <= x[1:numLocation,1:numCustomer] <= 1)
 
     # Objective: min distance
-    @objective(m, Max, sum{abs(customerLocations[a]-i)*x[i,a], a = 1:numCustomer, i = 1:numLocation} )
+    @objective(m, Max, sum(abs(customerLocations[a]-i)*x[i,a] for a = 1:numCustomer, i = 1:numLocation) )
 
     # Constraints
     for a in 1:numCustomer
@@ -34,11 +34,11 @@ function pMedian(numFacility::Int,numCustomer::Int,numLocation::Int)
             @constraint(m, x[i,a] - s[i] <= 0)
         end
         # Subject to one of x must be 1
-        @constraint(m, sum{x[i,a],i=1:numLocation} == 1 )
+        @constraint(m, sum(x[i,a] for i=1:numLocation) == 1 )
     end
 
     # Subject to must allocate all facilities
-    @constraint(m, sum{s[i],i=1:numLocation} == numFacility )
+    @constraint(m, sum(s[i] for i=1:numLocation) == numFacility )
     buildTime = toq()
 
     tic()
@@ -64,8 +64,8 @@ function cont5(n)
     @variable(mod,  0 <= y[0:m,0:n] <= 1)
     @variable(mod, -1 <= u[1:m] <= 1)
     @objective(mod, Min, 0.25*dx*( (y[m,0] - yt[1])^2 +
-       2*sum{ (y[m,j]-yt[j+1])^2, j=1:n1} + (y[m,n]-yt[n+1])^2) +
-       0.25*a*dt*(2*sum{u[i]^2,i=1:m1} + u[m]^2))
+       2*sum( (y[m,j]-yt[j+1])^2 for j=1:n1) + (y[m,n]-yt[n+1])^2) +
+       0.25*a*dt*(2*sum(u[i]^2 for i=1:m1) + u[m]^2))
 
     # PDE
     for i = 0:m1

--- a/test/perf/timetoprint.jl
+++ b/test/perf/timetoprint.jl
@@ -10,7 +10,7 @@ using JuMP
 m = Model()
 N = 100
 @variable(m, x[1:N])
-@constraint(m, sum{i*x[i],i=1:N} >= N)
+@constraint(m, sum(i*x[i] for i=1:N) >= N)
 @time JuMP.aff_str(JuMP.REPLMode, m.linconstr[end].terms)
 @time JuMP.model_str(JuMP.REPLMode, m)"""
 `)
@@ -24,7 +24,7 @@ using JuMP
 m = Model()
 N = 100
 @variable(m, x[1:N])
-@constraint(m, sum{i*x[i],i=1:N} >= N)
+@constraint(m, sum(i*x[i] for i=1:N) >= N)
 @time JuMP.model_str(JuMP.REPLMode, m)"""
 `)
 test2_time = toq()
@@ -37,7 +37,7 @@ using JuMP
 m = Model()
 N = 10000
 @variable(m, x[1:N])
-@constraint(m, sum{i*x[i],i=1:N} >= N)
+@constraint(m, sum(i*x[i] for i=1:N) >= N)
 @time sprint(print, m)"""
 `)
 test3_time = toq()
@@ -55,17 +55,17 @@ N = 10
 @variable(m, x4[[:a,:b,:c]])
 @variable(m, x5[[:a,:b,:c],[:d,"e",4]])
 @constraint(m,
-    sum{i*x1[i],i=1:N} +
-    sum{i*f*x2[i,f],i=1:N,f=1:N} + 
-    sum{i*f*x3[i,f],i=1:N,f=1:2:N} +
+    sum(i*x1[i] for i=1:N) +
+    sum(i*f*x2[i,f] for i=1:N,f=1:N) + 
+    sum(i*f*x3[i,f] for i=1:N,f=1:2:N) +
     sum(x4) >= N)
 @time sprint(print, m)"""
 `)
 test4_time = toq()
 
 println("Julia ", VERSION)
-println("Current branch: $(chomp(readall(`git rev-parse --abbrev-ref HEAD`)))")
-println("Current commit: $(chomp(readall(`git rev-parse HEAD`)))")
+println("Current branch: $(chomp(readstring(`git rev-parse --abbrev-ref HEAD`)))")
+println("Current commit: $(chomp(readstring(`git rev-parse HEAD`)))")
 @printf("Test 1: %7.2f s\n", test1_time)
 @printf("Test 2: %7.2f s\n", test2_time)
 @printf("Test 3: %7.2f s\n", test3_time)

--- a/test/perf/vector_speedtest.jl
+++ b/test/perf/vector_speedtest.jl
@@ -10,28 +10,28 @@ function test(n::Int)
     @variable(m,z[1:n])
 
     #initialize
-    @constraint(m,sum{c[i]*z[i],i=1:n}<=0)
+    @constraint(m,sum(c[i]*z[i] for i=1:n)<=0)
 
     #Vector
     tic()
-    @constraint(m,sum{c[i]*z[i],i=1:n}<=1)
-    println("Vector with sum{}: $(toq())")
+    @constraint(m,sum(c[i]*z[i] for i=1:n)<=1)
+    println("Vector with sum(): $(toq())")
     tic()
     @constraint(m,vecdot(c,z) <= 1)
     println("Vector with vecdot() : $(toq())")
 
     #2D Matrix
     tic()
-    @constraint(m,sum{a[i,j]*x[i,j],i=1:n,j=1:n}<=1)
-    println("2D Matrix with sum{}: $(toq())")
+    @constraint(m,sum(a[i,j]*x[i,j] for i=1:n,j=1:n)<=1)
+    println("2D Matrix with sum(): $(toq())")
     tic()
     @constraint(m,vecdot(a,x)<=1)
     println("2D Matrix with bigvecdot(): $(toq())")
 
     #3D Matrix
     tic()
-    @constraint(m,sum{b[i,j,k]*y[i,j,k],i=1:n,j=1:n,k=1:n}<=1)
-    println("3D Matrix with sum{}: $(toq())")
+    @constraint(m,sum(b[i,j,k]*y[i,j,k] for i=1:n,j=1:n,k=1:n)<=1)
+    println("3D Matrix with sum(): $(toq())")
     tic()
     @constraint(m,vecdot(b,y)<=1)
     println("3D Matrix with vecdot(): $(toq())")

--- a/test/qcqpmodel.jl
+++ b/test/qcqpmodel.jl
@@ -244,7 +244,7 @@ context("With solver $(typeof(solver))") do
     @objective(modN, Min, t)
     @constraint(modN, x + y >= 1)
     tmp = [x,y]
-    @constraint(modN, norm2{tmp[i], i=1:2} <= t)
+    @constraint(modN, norm(tmp[i] for i=1:2) <= t)
 
     @fact solve(modN) --> :Optimal
     @fact modN.objVal --> roughly(sqrt(1/2), 1e-6)
@@ -322,7 +322,7 @@ for solver in soc_solvers
 context("With solver $(typeof(solver))") do
     m = Model(solver=solver);
     @variable(m, x[1:3]);
-    @constraint(m, 2norm2{x[i]-1, i=1:3} <= 2)
+    @constraint(m, 2norm(x[i]-1 for i=1:3) <= 2)
     @objective(m, Max, x[1]+x[2])
 
     @fact solve(m) --> :Optimal

--- a/test/sdp.jl
+++ b/test/sdp.jl
@@ -482,13 +482,13 @@ context("With solver $(typeof(solver))") do
         @variable(m, t1 >= 0)
         @variable(m, L1[1:d])
         @constraint(m, L1 .== (μ-μhat))
-        @constraint(m, sum{L1[i]^2, i=1:d} <= t1^2)
+        @constraint(m, sum(L1[i]^2 for i=1:d) <= t1^2)
         @constraint(m, t1 <= Γ1(𝛿/2,N))
 
         @variable(m, t2 >= 0)
         @variable(m, L2[1:d,1:d])
         @constraint(m, L2 .== (Σ-Σhat))
-        @constraint(m, sum{L2[i,j]^2, i=1:d, j=1:d} <= t2^2)
+        @constraint(m, sum(L2[i,j]^2 for i=1:d, j=1:d) <= t2^2)
         @constraint(m, t2 <= Γ2(𝛿/2,N))
 
         A = [(1-ɛ)/ɛ (u-μ)';


### PR DESCRIPTION
This reimplements generator parsing to be entirely consistent with the usage in Julia. We can now parse
```jl
sum(x[i,j] for i in 1:N for j in 1:i)
```
and nested conditions like
```jl
sum(x[i,j] for i in 1:N if iseven(i) for j in 1:i if isodd(j))
```
Notably this breaks the behavior that I hacked together:
```jl
sum(x[i,j] for i in 1:N, j in 1:i)
```
which works currently in JuMP but doesn't work in plain Julia. I referenced this inconsistency in the [post](https://groups.google.com/d/msg/julia-opt/vUK1NHEHqfk/WD-6lSbMCAAJ) announcing the syntax change. I don't think we have a choice but to be consistent with Julia.

Another change is that I dumped ``norm2`` and friends for ``norm`` directly, e.g.,
```jl
norm(x[i] for i in 1:2) # 2-norm by default
norm((x[i] for i in 1:2), 1) # 1-norm with second argument
```
This is also consistent with Julia (https://github.com/JuliaOpt/JuMP.jl/issues/892) but the extra pair of parentheses needed is unfortunate. CC @IainNZ who's a user of non-L2-norms.

TODO:
- [x] Deprecation warnings for curly syntax
- [x] Figure out what to do about curlies with no index sets (``sum{x[i]; foo}``)
- [x] Update docs, examples, and tests