### PR TITLE
Fix #887

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -358,10 +358,10 @@ Base.diagm(x::Vector{Variable}) = diagm(convert(Vector{AffExpr}, x))
 function _multiply!{T<:JuMPTypes}(ret::Array{T}, lhs::Array, rhs::Array)
     m, n = size(lhs,1), size(lhs,2)
     r, s = size(rhs,1), size(rhs,2)
-    for i in 1:m, j in 1:s
+    for i ∈ 1:m, j ∈ 1:s
         q = ret[i,j]
         _sizehint_expr!(q, n)
-        for k in 1:n
+        for k ∈ 1:n
             tmp = convert(T, lhs[i,k]*rhs[k,j])
             append!(q, tmp)
         end
@@ -385,11 +385,11 @@ function _multiplyt!{T<:JuMPTypes}(ret::Array{T}, lhs::Array, rhs::Array)
 end
 
 function _multiply!{T<:Union{GenericAffExpr,GenericQuadExpr}}(ret::Array{T}, lhs::SparseMatrixCSC, rhs::Array)
-    nzv = lhs.nzval
-    rv  = lhs.rowval
-    for col in 1:lhs.n
-        for k in 1:size(ret, 2)
-            for j in lhs.colptr[col]:(lhs.colptr[col+1]-1)
+    nzv = nonzeros(lhs)
+    rv  = rowvals(lhs)
+    for col ∈ 1:lhs.n
+        for k ∈ 1:size(ret, 2)
+            for j ∈ lhs.colptr[col]:(lhs.colptr[col+1]-1)
                 append!(ret[rv[j], k], nzv[j] * rhs[col,k])
             end
         end
@@ -403,14 +403,14 @@ function _multiplyt!{T<:Union{GenericAffExpr,GenericQuadExpr}}(ret::Array{T}, lh
 end
 
 function _multiply!{T<:Union{GenericAffExpr,GenericQuadExpr}}(ret::Array{T}, lhs::Matrix, rhs::SparseMatrixCSC)
-    rowval = rhs.rowval
-    nzval  = rhs.nzval
+    rowval = rowvals(rhs)
+    nzval  = nonzeros(rhs)
     for multivec_row in 1:size(lhs,1)
-        for col in 1:rhs.n
+        for col ∈ 1:rhs.n
             idxset = rhs.colptr[col]:(rhs.colptr[col+1]-1)
             q = ret[multivec_row, col]
             _sizehint_expr!(q, length(idxset))
-            for k in idxset
+            for k ∈ idxset
                 append!(q, lhs[multivec_row, rowval[k]] * nzval[k])
             end
         end
@@ -420,8 +420,8 @@ end
 
 # this computes lhs.'*rhs and places it in ret
 function _multiplyt!{T<:Union{GenericAffExpr,GenericQuadExpr}}(ret::Array{T}, lhs::Matrix, rhs::SparseMatrixCSC)
-    rowval = rhs.rowval
-    nzval  = rhs.nzval
+    rowval = rowvals(rhs)
+    nzval  = nonzeros(rhs)
     for multivec_row ∈ 1:size(lhs,2) # transpose
         for col ∈ 1:rhs.n
             idxset = rhs.colptr[col]:(rhs.colptr[col+1]-1)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -451,11 +451,11 @@ import Base.Ac_mul_B
 # these methods are called when one does A.'*v or A'*v respectively 
 At_mul_B{T<:JuMPTypes}(A::Union{Matrix{T},SparseMatrixCSC{T}}, x::Union{Matrix, Vector, SparseMatrixCSC}) = _matmult(A, x)
 At_mul_B{T<:JuMPTypes,R<:JuMPTypes}(A::Union{Matrix{T},SparseMatrixCSC{T}}, x::Union{Matrix{R}, Vector{R}, SparseMatrixCSC{R}}) = _matmult(A, x)
-At_mul_B{T<:JuMPTypes}(A::Union{Matrix,SparseMatrixCSC}, x::Union{Matrix{T}, Vector{T}, SparseMatrixCSC{T}}) = _matmult(A, X)
+At_mul_B{T<:JuMPTypes}(A::Union{Matrix,SparseMatrixCSC}, x::Union{Matrix{T}, Vector{T}, SparseMatrixCSC{T}}) = _matmult(A, x)
 # these methods are the same as above since complex numbers are not implemented in JuMP
 Ac_mul_B{T<:JuMPTypes}(A::Union{Matrix{T},SparseMatrixCSC{T}}, x::Union{Matrix, Vector, SparseMatrixCSC}) = _matmult(A, x)
 Ac_mul_B{T<:JuMPTypes,R<:JuMPTypes}(A::Union{Matrix{T},SparseMatrixCSC{T}}, x::Union{Matrix{R}, Vector{R}, SparseMatrixCSC{R}}) = _matmult(A, x)
-Ac_mul_B{T<:JuMPTypes}(A::Union{Matrix,SparseMatrixCSC}, x::Union{Matrix{T}, Vector{T}, SparseMatrixCSC{T}}) = _matmult(A, X)
+Ac_mul_B{T<:JuMPTypes}(A::Union{Matrix,SparseMatrixCSC}, x::Union{Matrix{T}, Vector{T}, SparseMatrixCSC{T}}) = _matmult(A, x)
 
 function _matmul(A, x)
     m, n = size(A,1), size(A,2)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -399,7 +399,7 @@ end
 
 # this computes lhs.'*rhs and places it in ret
 function _multiplyt!{T<:Union{GenericAffExpr,GenericQuadExpr}}(ret::Array{T}, lhs::SparseMatrixCSC, rhs::Array)
-    _multiply!(ret, transpose(lhs), rhs) # for sparse matrices this should be cheap
+    _multiply!(ret, transpose(lhs), rhs) # TODO fully implement
 end
 
 function _multiply!{T<:Union{GenericAffExpr,GenericQuadExpr}}(ret::Array{T}, lhs::Matrix, rhs::SparseMatrixCSC)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -403,9 +403,9 @@ _multiply!{T<:JuMPTypes}(ret::AbstractArray{T}, lhs::SparseMatrixCSC, rhs::Spars
 
 _multiply!(ret, lhs, rhs) = A_mul_B!(ret, lhs, ret)
 
-(*){T<:JuMPTypes}(             A::Union{Matrix{T},SparseMatrixCSC{T}}, x::Union{Matrix,   Vector,   SparseMatrixCSC})    = _matmul(A, x)
-(*){T<:JuMPTypes,R<:JuMPTypes}(A::Union{Matrix{T},SparseMatrixCSC{T}}, x::Union{Matrix{R},Vector{R},SparseMatrixCSC{R}}) = _matmul(A, x)
-(*){T<:JuMPTypes}(             A::Union{Matrix,   SparseMatrixCSC},    x::Union{Matrix{T},Vector{T},SparseMatrixCSC{T}}) = _matmul(A, x)
+(*){T<:JuMPTypes}(             A::Union{Matrix{T},Vector{T},SparseMatrixCSC{T}}, x::Union{Matrix,   Vector,   SparseMatrixCSC})    = _matmul(A, x)
+(*){T<:JuMPTypes,R<:JuMPTypes}(A::Union{Matrix{T},Vector{T},SparseMatrixCSC{T}}, x::Union{Matrix{R},Vector{R},SparseMatrixCSC{R}}) = _matmul(A, x)
+(*){T<:JuMPTypes}(             A::Union{Matrix,   Vector,   SparseMatrixCSC},    x::Union{Matrix{T},Vector{T},SparseMatrixCSC{T}}) = _matmul(A, x)
 
 function _matmul(A, x)
     m, n = size(A,1), size(A,2)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -448,11 +448,11 @@ _multiply!(ret, lhs, rhs) = A_mul_B!(ret, lhs, ret)
 
 import Base.At_mul_B
 import Base.Ac_mul_B
-# confusingly, these methods are called when one does A'*v or A.'*v respectively
+# these methods are called when one does A.'*v or A'*v respectively
 At_mul_B{T<:JuMPTypes}(A::Union{Matrix{T},SparseMatrixCSC{T}}, x::Union{Matrix, Vector, SparseMatrixCSC}) = _matmult(A, x)
 At_mul_B{T<:JuMPTypes,R<:JuMPTypes}(A::Union{Matrix{T},SparseMatrixCSC{T}}, x::Union{Matrix{R}, Vector{R}, SparseMatrixCSC{R}}) = _matmult(A, x)
 At_mul_B{T<:JuMPTypes}(A::Union{Matrix,SparseMatrixCSC}, x::Union{Matrix{T}, Vector{T}, SparseMatrixCSC{T}}) = _matmult(A, X)
-# these methods are the same as a bove since complex numbers are not implemented in JuMP
+# these methods are the same as above since complex numbers are not implemented in JuMP
 Ac_mul_B{T<:JuMPTypes}(A::Union{Matrix{T},SparseMatrixCSC{T}}, x::Union{Matrix, Vector, SparseMatrixCSC}) = _matmult(A, x)
 Ac_mul_B{T<:JuMPTypes,R<:JuMPTypes}(A::Union{Matrix{T},SparseMatrixCSC{T}}, x::Union{Matrix{R}, Vector{R}, SparseMatrixCSC{R}}) = _matmult(A, x)
 Ac_mul_B{T<:JuMPTypes}(A::Union{Matrix,SparseMatrixCSC}, x::Union{Matrix{T}, Vector{T}, SparseMatrixCSC{T}}) = _matmult(A, X)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -369,7 +369,7 @@ function _multiply!{T<:JuMPTypes}(ret::Array{T}, lhs::Array, rhs::Array)
     ret
 end
 
-# this for transposed multiplication
+# this computes lhs.'*rhs and places it in ret
 function _multiplyt!{T<:JuMPTypes}(ret::Array{T}, lhs::Array, rhs::Array)
     m, n = size(lhs,2), size(lhs,1) # transpose
     r, s = size(rhs,1), size(rhs,2)
@@ -397,7 +397,7 @@ function _multiply!{T<:Union{GenericAffExpr,GenericQuadExpr}}(ret::Array{T}, lhs
     ret
 end
 
-# this for transposed multiplication
+# this computes lhs.'*rhs and places it in ret
 function _multiplyt!{T<:Union{GenericAffExpr,GenericQuadExpr}}(ret::Array{T}, lhs::SparseMatrixCSC, rhs::Array)
     _multiply!(ret, transpose(lhs), rhs) # for sparse matrices this should be cheap
 end
@@ -418,7 +418,7 @@ function _multiply!{T<:Union{GenericAffExpr,GenericQuadExpr}}(ret::Array{T}, lhs
     ret
 end
 
-# for transposed multiplication
+# this computes lhs.'*rhs and places it in ret
 function _multiplyt!{T<:Union{GenericAffExpr,GenericQuadExpr}}(ret::Array{T}, lhs::Matrix, rhs::SparseMatrixCSC)
     rowval = rhs.rowval
     nzval  = rhs.nzval

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -389,7 +389,7 @@ function _multiply!{T<:Union{GenericAffExpr,GenericQuadExpr}}(ret::Array{T}, lhs
     rv  = rowvals(lhs)
     for col ∈ 1:lhs.n
         for k ∈ 1:size(ret, 2)
-            for j ∈ lhs.colptr[col]:(lhs.colptr[col+1]-1)
+            for j ∈ nzrange(lhs, col)
                 append!(ret[rv[j], k], nzv[j] * rhs[col,k])
             end
         end
@@ -407,7 +407,7 @@ function _multiply!{T<:Union{GenericAffExpr,GenericQuadExpr}}(ret::Array{T}, lhs
     nzval  = nonzeros(rhs)
     for multivec_row in 1:size(lhs,1)
         for col ∈ 1:rhs.n
-            idxset = rhs.colptr[col]:(rhs.colptr[col+1]-1)
+            idxset = nzrange(rhs, col)
             q = ret[multivec_row, col]
             _sizehint_expr!(q, length(idxset))
             for k ∈ idxset
@@ -424,7 +424,7 @@ function _multiplyt!{T<:Union{GenericAffExpr,GenericQuadExpr}}(ret::Array{T}, lh
     nzval  = nonzeros(rhs)
     for multivec_row ∈ 1:size(lhs,2) # transpose
         for col ∈ 1:rhs.n
-            idxset = rhs.colptr[col]:(rhs.colptr[col+1]-1)
+            idxset = nzrange(rhs, col)
             q = ret[multivec_row, col]
             _sizehint_expr!(q, length(idxset))
             for k ∈ idxset

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -448,7 +448,7 @@ _multiply!(ret, lhs, rhs) = A_mul_B!(ret, lhs, ret)
 
 import Base.At_mul_B
 import Base.Ac_mul_B
-# these methods are called when one does A.'*v or A'*v respectively
+# these methods are called when one does A.'*v or A'*v respectively 
 At_mul_B{T<:JuMPTypes}(A::Union{Matrix{T},SparseMatrixCSC{T}}, x::Union{Matrix, Vector, SparseMatrixCSC}) = _matmult(A, x)
 At_mul_B{T<:JuMPTypes,R<:JuMPTypes}(A::Union{Matrix{T},SparseMatrixCSC{T}}, x::Union{Matrix{R}, Vector{R}, SparseMatrixCSC{R}}) = _matmult(A, x)
 At_mul_B{T<:JuMPTypes}(A::Union{Matrix,SparseMatrixCSC}, x::Union{Matrix{T}, Vector{T}, SparseMatrixCSC{T}}) = _matmult(A, X)

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -525,6 +525,10 @@ const sub2 = JuMP.repl[:sub2]
              1 2 1
              0 1 2]
         B = sparse(A)
+        X = spzeros(JuMP.Variable, 3, 3)
+        X[1, 1] = @variable(m, X11)
+        X[2, 3] = @variable(m, X23)
+        v = [4, 5, 6]
         @test vec_eq(A*x, [2x[1] +  x[2]
                             2x[2] + x[1] + x[3]
                             x[2] + 2x[3]])
@@ -586,6 +590,25 @@ const sub2 = JuMP.repl[:sub2]
                                          x[2] + 3x[3]])
 
         @test vec_eq(@JuMP.Expression(A*x/2), A*x/2)
+        @test vec_eq(X*v,  [4X11; 6X23; 0])
+        @test vec_eq(v'*X, [4X11  0     5X23])
+        @test vec_eq(X*A,  [2X11  X11  0
+                            0     X23  2X23
+                            0     0    0   ])
+        @test vec_eq(A*X,  [2X11  0    X23
+                            X11   0    2X23
+                            0     0    X23])
+        @test vec_eq(A*X', [2X11  0    0
+                            X11   X23  0
+                            0     2X23 0])
+        @test vec_eq(X'*A, [2X11  X11  0
+                            0     0    0
+                            X23   2X23 X23])
+        @test vec_eq(X*A, X*B)
+        @test vec_eq(A*X, B*X)
+        @test vec_eq(A*X', B*X')
+        # TODO this is known to fail currently
+        @test vec_eq(X'*A, X'*B)
     end
 
     @testset "Dot-ops" begin

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -634,7 +634,7 @@ const sub2 = JuMP.repl[:sub2]
         # @test_broken vec_eq(A*X, B*X)
         # @test_broken vec_eq(A*X', B*X')
         @test vec_eq(X'*A, X'*B)
-        # @test_broken(X'*X, X.'*X) # sparse quadratic known to be broken
+        # @test_broken(X'*X, X.'*X) # sparse quadratic known to be broken, see #912
     end
 
     @testset "Dot-ops" begin

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -601,14 +601,13 @@ const sub2 = JuMP.repl[:sub2]
         @test vec_eq(A*X', [2X11  0    0
                             X11   X23  0
                             0     2X23 0])
-        @test vec_eq(X'*A, [2X11  X11  0
-                            0     0    0
-                            X23   2X23 X23])
+        @test_broken vec_eq(X'*A, [2X11  X11  0
+                                   0     0    0
+                                   X23   2X23 X23])
         @test vec_eq(X*A, X*B)
-        @test vec_eq(A*X, B*X)
-        @test vec_eq(A*X', B*X')
-        # TODO this is known to fail currently
-        @test vec_eq(X'*A, X'*B)
+        @test_broken vec_eq(A*X, B*X)
+        @test_broken vec_eq(A*X', B*X')
+        @test_broken vec_eq(X'*A, X'*B)
     end
 
     @testset "Dot-ops" begin

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -525,9 +525,18 @@ const sub2 = JuMP.repl[:sub2]
              1 2 1
              0 1 2]
         B = sparse(A)
-        X = spzeros(JuMP.Variable, 3, 3)
-        X[1, 1] = @variable(m, X11)
-        X[2, 3] = @variable(m, X23)
+        @variable(m, X11)
+        @variable(m, X23)
+        X = sparse([1, 2], [1, 3], [X11, X23], 3, 3) # for testing Variable
+        @variable(m, Xd[1:3, 1:3])
+        Y = sparse([1, 2], [1, 3], [2X11, 4X23], 3, 3) # for testing GenericAffExpr
+        Yd = [2X11 0    0
+              0    0 4X23
+              0    0    0]        
+        Z = sparse([1, 2], [1, 3], [X11^2, 2X23^2], 3, 3) # for testing GenericQuadExpr
+        Zd = [X11^2 0      0
+              0     0 2X23^2
+              0     0      0]
         v = [4, 5, 6]
         @test vec_eq(A*x, [2x[1] +  x[2]
                             2x[2] + x[1] + x[3]
@@ -610,11 +619,22 @@ const sub2 = JuMP.repl[:sub2]
         @test vec_eq(X.'*A, [2X11 X11  0 
                              0    0    0
                              X23  2X23 X23])
+        @test vec_eq(A'*X, [2X11  0 X23
+                            X11   0 2X23
+                            0     0 X23])
         @test vec_eq(X.'*A, X'*A)
+        @test vec_eq(A.'*X, A'*X)
         @test vec_eq(X*A, X*B)
+        @test vec_eq(Y'*A, Y.'*A)
+        @test vec_eq(A*Y', A*Y.')
+        @test vec_eq(Z'*A, Z.'*A)
+        @test vec_eq(Xd'*Y, Xd.'*Y)
+        @test vec_eq(Y'*Xd, Y.'*Xd)
+        @test vec_eq(Xd'*Xd, Xd.'*Xd)
         # @test_broken vec_eq(A*X, B*X)
         # @test_broken vec_eq(A*X', B*X')
         @test vec_eq(X'*A, X'*B)
+        # @test_broken(X'*X, X.'*X) # sparse quadratic known to be broken
     end
 
     @testset "Dot-ops" begin

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -591,7 +591,10 @@ const sub2 = JuMP.repl[:sub2]
 
         @test vec_eq(@JuMP.Expression(A*x/2), A*x/2)
         @test vec_eq(X*v,  [4X11; 6X23; 0])
-        @test vec_eq(v'*X, [4X11  0     5X23])
+        @test vec_eq(v'*X,  [4X11  0   5X23])
+        @test vec_eq(v.'*X, [4X11  0   5X23])
+        @test vec_eq(X'*v,  [4X11;  0;  5X23])
+        @test vec_eq(X.'*v, [4X11; 0;  5X23])
         @test vec_eq(X*A,  [2X11  X11  0
                             0     X23  2X23
                             0     0    0   ])
@@ -601,13 +604,17 @@ const sub2 = JuMP.repl[:sub2]
         @test vec_eq(A*X', [2X11  0    0
                             X11   X23  0
                             0     2X23 0])
-        @test_broken vec_eq(X'*A, [2X11  X11  0
-                                   0     0    0
-                                   X23   2X23 X23])
+        @test vec_eq(X'*A, [2X11  X11  0
+                            0     0    0
+                            X23   2X23 X23])
+        @test vec_eq(X.'*A, [2X11 X11  0 
+                             0    0    0
+                             X23  2X23 X23])
+        @test vec_eq(X.'*A, X'*A)
         @test vec_eq(X*A, X*B)
         @test_broken vec_eq(A*X, B*X)
         @test_broken vec_eq(A*X', B*X')
-        @test_broken vec_eq(X'*A, X'*B)
+        @test vec_eq(X'*A, X'*B)
     end
 
     @testset "Dot-ops" begin

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -612,8 +612,8 @@ const sub2 = JuMP.repl[:sub2]
                              X23  2X23 X23])
         @test vec_eq(X.'*A, X'*A)
         @test vec_eq(X*A, X*B)
-        @test_broken vec_eq(A*X, B*X)
-        @test_broken vec_eq(A*X', B*X')
+        # @test_broken vec_eq(A*X, B*X)
+        # @test_broken vec_eq(A*X', B*X')
         @test vec_eq(X'*A, X'*B)
     end
 


### PR DESCRIPTION
It appears that the definitions for `*` in lines 406, 407 and 408 were missing the type `Vector` in the unions of their first arguments, even though it seems that the methods for this are fully implemented.

Edit: This is a very wrong statement.  See below.