### PR TITLE
preallocate reusable GradientConfig for AD of user-defined function

### DIFF
--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -1288,8 +1288,9 @@ function MathProgBase.eval_grad_f(d::UserFunctionEvaluator,grad,x)
     nothing
 end
 
-function UserAutoDiffEvaluator(dimension::Integer, f::Function)
-    ∇f = (out,y) -> ForwardDiff.gradient!(out, x -> f(x...), y)
+function UserAutoDiffEvaluator{T}(dimension::Integer, f::Function, ::Type{T} = Float64)
+    cfg = ForwardDiff.GradientConfig(zeros(T, dimension))
+    ∇f = (out, y) -> ForwardDiff.gradient!(out, x -> f(x...), y, cfg)
     return UserFunctionEvaluator(f, ∇f, dimension)
 end
 


### PR DESCRIPTION
Note that this will always use `Float64` for the element type unless you give it a different type - I added this capability to the function signature but haven't touched any callers. Let me know if I should run any perf test here.