### PR TITLE
Fix 907

### DIFF
--- a/src/parseExpr_staged.jl
+++ b/src/parseExpr_staged.jl
@@ -268,7 +268,11 @@ for T1 in (GenericAffExpr,GenericQuadExpr), T2 in (Number,Variable,GenericAffExp
     @eval addtoexpr(::$T1, ::_NLExpr, ::$T2) = _nlexprerr()
 end
 
-addtoexpr(ex, c, x) = ex + c*x
+addtoexpr{T<:GenericAffExpr}(ex::Array{T}, c::AbstractArray, x::AbstractArray) = append!.(ex, c*x)
+addtoexpr{T<:GenericAffExpr}(ex::Array{T}, c::AbstractArray, x::Number) = append!.(ex, c*x)
+addtoexpr{T<:GenericAffExpr}(ex::Array{T}, c::Number, x::AbstractArray) = append!.(ex, c*x)
+
+addtoexpr(ex, c, x) = ex + c*x  
 
 @generated addtoexpr_reorder(ex, arg) = :(addtoexpr(ex, 1.0, arg))
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -688,12 +688,12 @@ const sub2 = JuMP.repl[:sub2]
         u = [2, 3]
         v = [4, 5]
         expr_base = zero(JuMP.AffExpr)
-        @constraint(m, x*u .≤ x*v)
-        @test string(m.linconstr[1]) == "-2 x[1,1] - 2 x[1,2] ≤ 0"
-        @test string(m.linconstr[2]) == "-2 x[2,1] - 2 x[2,2] ≤ 0"
-        @constraint(m, x*u + y .≤ v)
-        @test string(m.linconstr[3]) == "2 x[1,1] + 3 x[1,2] + y[1] ≤ 4"
-        @test string(m.linconstr[4]) == "2 x[2,1] + 3 x[2,2] + y[2] ≤ 5"
+        @constraint(m, x*u .<= x*v) 
+        @test string(m.linconstr[1]) == "-2 x[1,1] - 2 x[1,2] $leq 0"
+        @test string(m.linconstr[2]) == "-2 x[2,1] - 2 x[2,2] $leq 0"
+        @constraint(m, x*u + y .<= v)
+        @test string(m.linconstr[3]) == "2 x[1,1] + 3 x[1,2] + y[1] $leq 4"
+        @test string(m.linconstr[4]) == "2 x[2,1] + 3 x[2,2] + y[2] $leq 5"
         expr = JuMP.addtoexpr(expr_base, x, u)
         expr2 = JuMP.addtoexpr(expr, y, 1.0)
         @test expr2 == [2.0x[1,1] + 3.0x[1,2] + y[1];

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -680,4 +680,23 @@ const sub2 = JuMP.repl[:sub2]
         @test_throws ErrorException @constraint m 2*x <= y <= 1
         @test_throws ErrorException @constraint m x+y <= x <= x*y
     end
+
+    @testset "Adding vector constraints" begin
+        m = Model()
+        @variable(m, x[1:2, 1:2])
+        @variable(m, y[1:2])
+        u = [2, 3]
+        v = [4, 5]
+        expr_base = zero(JuMP.AffExpr)
+        @constraint(m, x*u .≤ x*v)
+        @test string(m.linconstr[1]) == "-2 x[1,1] - 2 x[1,2] ≤ 0"
+        @test string(m.linconstr[2]) == "-2 x[2,1] - 2 x[2,2] ≤ 0"
+        @constraint(m, x*u + y .≤ v)
+        @test string(m.linconstr[3]) == "2 x[1,1] + 3 x[1,2] + y[1] ≤ 4"
+        @test string(m.linconstr[4]) == "2 x[2,1] + 3 x[2,2] + y[2] ≤ 5"
+        expr = JuMP.addtoexpr(expr_base, x, u)
+        expr2 = JuMP.addtoexpr(expr, y, 1.0)
+        @test expr2 == [2.0x[1,1] + 3.0x[1,2] + y[1];
+                        2.0x[2,1] + 3.0x[2,2] + y[2]]
+    end
 end


### PR DESCRIPTION
This fixes #907 in what I think is the least disruptive way possible.  This also fixes warnings arising from expressions like `X*u + y` that appear as arguments to constraint macros.  Unit tests have been added to cover the 3 new lines of code.

In my opinion we should also reconsider whether the warning
```
WARNING: The addition operator has been used on JuMP expressions a large number of times. This warning is safe to ignore but may indicate that model generation is slower than necessary. For performance reasons, you should not add expressions in a loop. Instead of x += y, use append!(x,y) to modify x in place. If y is a single variable, you may also use push!(x, coef, y) in place of x += coef*y.
```
should be removed altogether (since there isn't much of a performance detriment, since all users should use `+` 100% of the time and the only alternative `append!` is actually a slightly different use case).  However, it's hard to get the warning to appear outside of macros (for reasons I don't entirely understand) so with this fix it's unlikely to ever occur unless the user does something strange.  Alternatively, the default behavior of `+` can be changed. 