### PR TITLE
switch from throw(CallbackAbort()) to return CallbackAbort

### DIFF
--- a/doc/callbacks.rst
+++ b/doc/callbacks.rst
@@ -423,8 +423,8 @@ This code can also be found in ``/JuMP/examples/simplelazy2.jl``.
 Exiting a callback early
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you need to exit the optimization process earlier than a solver otherwise would, it is possible to throw a ``CallbackAbort`` exception in callback code::
+If you need to exit the optimization process earlier than a solver otherwise would, it is possible to return ``JuMP.StopTheSolver`` from the callback code::
 
-    throw(CallbackAbort())
+    return JuMP.StopTheSolver
 
 This will trigger the solver to exit immediately and return a ``:UserLimit`` status.


### PR DESCRIPTION
Pajarito will be using ``CallbackAbort()`` as part of the normal flow of the algorithm. ``CallbackAbort()`` has been segfaulting on OS X with Gurobi for a long time (https://github.com/JuliaOpt/Gurobi.jl/issues/47). Doesn't look like any fix for Julia is incoming, so the workaround is to just not throw exceptions in callbacks.

CC @chriscoey @JackDunnNZ 