### PR TITLE
model-level scope for user-defined functions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
 MathProgBase 0.5.1 0.6
-ReverseDiffSparse 0.6 0.7
+ReverseDiffSparse 0.7 0.8
 ForwardDiff 0.3 0.4
 Calculus

--- a/doc/nlp.rst
+++ b/doc/nlp.rst
@@ -146,22 +146,22 @@ JuMP uses `ForwardDiff.jl <https://github.com/JuliaDiff/ForwardDiff.jl>`_ to per
     mysquare(x) = x^2
     myf(x,y) = (x-1)^2+(y-2)^2
 
-    JuMP.register(:myf, 2, myf, autodiff=true)
-    JuMP.register(:mysquare, 1, mysquare, autodiff=true)
-
     m = Model()
+
+    JuMP.register(m, :myf, 2, myf, autodiff=true)
+    JuMP.register(m, :mysquare, 1, mysquare, autodiff=true)
 
     @variable(m, x[1:2] >= 0.5)
     @NLobjective(m, Min, myf(x[1],mysquare(x[2])))
 
-The above code creates a JuMP model with the objective function ``(x[1]-1)^2 + (x[2]^2-2)^2``. The first argument to ``JuMP.register`` is a Julia symbol object which registers the name of the user-defined function in JuMP expressions; the JuMP name need not be the same as the name of the corresponding Julia method. The second argument specifies how many arguments the function takes. The third argument is the name of the Julia method which computes the function, and ``autodiff=true`` instructs JuMP to compute exact gradients automatically.
+The above code creates a JuMP model with the objective function ``(x[1]-1)^2 + (x[2]^2-2)^2``. The first argument to ``JuMP.register`` the model for which the functions are registered. The second argument is a Julia symbol object which serves as the name of the user-defined function in JuMP expressions; the JuMP name need not be the same as the name of the corresponding Julia method. The third argument specifies how many arguments the function takes. The fourth argument is the name of the Julia method which computes the function, and ``autodiff=true`` instructs JuMP to compute exact gradients automatically.
 
 .. note::
     All arguments to user-defined functions are scalars, not vectors. To define a function which takes a large number of arguments, you may use the splatting syntax ``f(x...) = ...``.
 
 Forward-mode automatic differentiation as implemented by ForwardDiff.jl has a computational cost that scales linearly with the number of input dimensions. As such, it is not the most efficient way to compute gradients of user-defined functions if the number of input arguments is large. In this case, users may want to provide their own routines for evaluating gradients. The more general syntax for ``JuMP.register`` which accepts user-provided derivative evaluation routines is::
 
-    JuMP.register(s::Symbol, dimension::Integer, f::Function, ∇f::Function, ∇²f::Function)
+    JuMP.register(m::Model, s::Symbol, dimension::Integer, f::Function, ∇f::Function, ∇²f::Function)
 
 The input differs for functions which take a single input argument and functions which take more than one. For univariate functions, the derivative evaluation routines should return a number which represents the first and second-order derivatives respectively. For multivariate functions, the derivative evaluation routines will be passed a gradient vector which they must explicitly fill. Second-order derivatives of multivariate functions are not currently supported; this argument should be omitted. The following example sets up the same optimization problem as before, but now we explicitly provide evaluation routines for the user-defined functions::
 
@@ -175,15 +175,13 @@ The input differs for functions which take a single input argument and functions
         g[2] = 2*(y-2)
     end
 
-    JuMP.register(:myf, 2, myf, ∇f)
-    JuMP.register(:mysquare, 1, mysquare, mysquare_prime, mysquare_primeprime)
-
     m = Model()
+
+    JuMP.register(m, :myf, 2, myf, ∇f)
+    JuMP.register(m, :mysquare, 1, mysquare, mysquare_prime, mysquare_primeprime)
 
     @variable(m, x[1:2] >= 0.5)
     @NLobjective(m, Min, myf(x[1],mysquare(x[2])))
-
-Support for user-provided functions was recently introduced in JuMP 0.12 and is not mature. Please let us know if you find any important functionality missing.
 
 Factors affecting solution time
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
``JuMP.register`` now takes the model as the first parameter, and registrations apply only to a given model. This is a breaking change.
Closes #821

CC @tkelman 