### PR TITLE
enable printing for nonlinear expressions

### DIFF
--- a/test/print.jl
+++ b/test/print.jl
@@ -434,17 +434,26 @@ end
 
         mod_3 = Model()
 
-        @variable(mod_3, x[1:5])
-        @NLconstraint(mod_3, x[1]*x[2] == 1)
-        @NLconstraint(mod_3, x[3]*x[4] == 1)
-        @NLconstraint(mod_3, x[5]*x[1] == 1)
-        @NLobjective(mod_3, Min, x[1]*x[3])
+        @variable(mod_3, y[1:5])
+        @NLparameter(mod_3, p == 10)
+        @NLexpression(mod_3, ex, y[2])
+        @NLconstraint(mod_3, y[1]*y[2] == 1)
+        @NLconstraint(mod_3, y[3]*y[4] == 1)
+        @NLconstraint(mod_3, y[5]*y[1] - ex == 1)
+
+        @NLobjective(mod_3, Min, y[1]*y[3] - p)
+
+        io_test(REPLMode, p, "\"Reference to nonlinear parameter #1\"")
+        io_test(REPLMode, ex, "\"Reference to nonlinear expression #1\"")
 
         io_test(REPLMode, mod_3, """
-    Min (nonlinear expression)
+    Min y[1] * y[3] - parameter[1]
     Subject to
-     3 nonlinear constraints
-     x[i] free $fa i $inset {1,2,3,4,5}
+     y[1] * y[2] - 1.0 = 0
+     y[3] * y[4] - 1.0 = 0
+     (y[5] * y[1] - subexpression[1]) - 1.0 = 0
+     y[i] free $fa i $inset {1,2,3,4,5}
+    subexpression[1]: y[2]
     """, repl=:print)
         io_test(REPLMode, mod_3, """
     Minimization problem with:
@@ -453,9 +462,12 @@ end
      * 5 variables
     Solver is default solver""", repl=:show)
         io_test(IJuliaMode, mod_3, """
-    \\begin{alignat*}{1}\\min\\quad & (nonlinear expression)\\\\
-    \\text{Subject to} \\quad & 3 nonlinear constraints\\\\
-     & x_{i} free \\quad\\forall i \\in \\{1,2,3,4,5\\}\\\\
+    \\begin{alignat*}{1}\\min\\quad & y_{1} * y_{3} - parameter_{1}\\\\
+    \\text{Subject to} \\quad & y_{1} * y_{2} - 1.0 = 0\\\\
+     & y_{3} * y_{4} - 1.0 = 0\\\\
+     & (y_{5} * y_{1} - subexpression_{1}) - 1.0 = 0\\\\
+     & y_{i} free \\quad\\forall i \\in \\{1,2,3,4,5\\}\\\\
+    subexpression_{1} = \\quad &y_{2}\\\\
     \\end{alignat*}
     """, repl=:print)
     end


### PR DESCRIPTION
Mostly working, but IJulia output isn't right and needs more tests.
Slightly awkward since we don't have names for subexpressions or parameters, so they're printed as ``subexpression[i]`` or ``parameter[i]``.
Closes https://github.com/JuliaOpt/JuMP.jl/issues/201