### PR TITLE
Update operators.jl (_dot of vectors calls sum)

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -314,7 +314,10 @@ vecdot{T,S<:JuMPTypes,N}(lhs::Array{T,N},rhs::Array{S,N}) = _dot(lhs,rhs)
 
 function _dot{T,S}(lhs::Vector{T}, rhs::Vector{S})
     length(lhs) == length(rhs) || error("Incompatible dimensions")
-    sum(lhs[i] * rhs[i] for i = 1:length(lhs))
+    res = AffExpr()
+    for i = 1 : length(lhs)
+        append!(res, lhs[i] * rhs[i])
+    end
 end
     
 function _dot{T,S}(lhs::Array{T}, rhs::Array{S})

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -312,6 +312,11 @@ vecdot{T<:JuMPTypes,S,N}(lhs::Array{T,N},rhs::Array{S,N}) = _dot(lhs,rhs)
 vecdot{T<:JuMPTypes,S<:JuMPTypes,N}(lhs::Array{T,N},rhs::Array{S,N}) = _dot(lhs,rhs)
 vecdot{T,S<:JuMPTypes,N}(lhs::Array{T,N},rhs::Array{S,N}) = _dot(lhs,rhs)
 
+function _dot{T,S}(lhs::Vector{T}, rhs::Vector{S})
+    length(lhs) == length(rhs) || error("Incompatible dimensions")
+    sum(lhs[i] * rhs[i] for i = 1:length(lhs))
+end
+    
 function _dot{T,S}(lhs::Array{T}, rhs::Array{S})
     size(lhs) == size(rhs) || error("Incompatible dimensions")
     ret = zero(one(T)*one(S))


### PR DESCRIPTION
Trying to fix:

https://github.com/JuliaOpt/JuMP.jl/issues/940#issuecomment-274198879

Now `_dot(::Vector, ::Vector)` calls `sum`, which already as an efficient implementation.