### PR TITLE
deprecation fixes for julia 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ MathProgBase 0.6 0.7
 ReverseDiffSparse 0.7 0.8
 ForwardDiff 0.3 0.4
 Calculus
+Compat 0.18

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -8,9 +8,11 @@
 # See http://github.com/JuliaOpt/JuMP.jl
 #############################################################################
 
-isdefined(Base, :__precompile__) && __precompile__()
+__precompile__()
 
 module JuMP
+
+using Compat
 
 importall Base.Operators
 import Base.map
@@ -58,7 +60,7 @@ include("utils.jl")
 ###############################################################################
 # Model class
 # Keeps track of all model and column info
-abstract AbstractModel
+@compat abstract type AbstractModel end
 type Model <: AbstractModel
     obj#::QuadExpr
     objSense::Symbol
@@ -320,10 +322,10 @@ setprinthook(m::Model, f) = (m.printhook = f)
 #############################################################################
 # AbstractConstraint
 # Abstract base type for all constraint types
-abstract AbstractConstraint
+@compat abstract type AbstractConstraint end
 # Abstract base type for all scalar types
 # In JuMP, used only for Variable. Useful primarily for extensions
-abstract AbstractJuMPScalar
+@compat abstract type AbstractJuMPScalar end
 
 Base.start(::AbstractJuMPScalar) = false
 Base.next(x::AbstractJuMPScalar, state) = (x, true)
@@ -549,7 +551,7 @@ immutable ConstraintRef{M<:AbstractModel,T<:AbstractConstraint}
     idx::Int
 end
 
-typealias LinConstrRef ConstraintRef{Model,LinearConstraint}
+const LinConstrRef = ConstraintRef{Model,LinearConstraint}
 
 LinearConstraint(ref::LinConstrRef) = ref.m.linconstr[ref.idx]::LinearConstraint
 
@@ -870,13 +872,13 @@ end
 ##########################################################################
 # Behavior that's uniform across all JuMP "scalar" objects
 
-typealias JuMPTypes Union{AbstractJuMPScalar,
-                          NonlinearExpression,
-                          Norm,
-                          GenericAffExpr,
-                          QuadExpr,
-                          SOCExpr}
-typealias JuMPScalars Union{Number,JuMPTypes}
+const JuMPTypes = Union{AbstractJuMPScalar,
+                        NonlinearExpression,
+                        Norm,
+                        GenericAffExpr,
+                        QuadExpr,
+                        SOCExpr}
+const JuMPScalars = Union{Number,JuMPTypes}
 
 # would really want to do this on ::Type{T}, but doesn't work on v0.4
 Base.eltype{T<:JuMPTypes}(::T) = T

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -6,7 +6,7 @@
 using Base.Meta
 # multivarate "dictionary" used for collections of variables/constraints
 
-abstract JuMPContainer{T,N}
+@compat abstract type JuMPContainer{T,N} end
 
 include("JuMPArray.jl")
 
@@ -19,7 +19,7 @@ type JuMPDict{T,N} <: JuMPContainer{T,N}
     tupledict::Dict{NTuple{N,Any},T}
     meta::Dict{Symbol,Any}
 
-    JuMPDict() = new(Dict{NTuple{N,Any},T}(), Dict{Symbol,Any}())
+    (::Type{JuMPDict{T,N}}){T,N}() = new{T,N}(Dict{NTuple{N,Any},T}(), Dict{Symbol,Any}())
 end
 
 function JuMPDict{T,N}(d::Dict{NTuple{N,Any},T})
@@ -210,9 +210,9 @@ type KeyIterator{JA<:JuMPArray}
     x::JA
     dim::Int
     next_k_cache::Array{Any,1}
-    function KeyIterator(d)
+    function (::Type{KeyIterator{JA}}){JA}(d)
         n = ndims(d.innerArray)
-        new(d, n, Array{Any}(n+1))
+        new{JA}(d, n, Array{Any}(n+1))
     end
 end
 

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -77,7 +77,7 @@ end
 
 
 # Alias for (Float64, Variable), the specific GenericAffExpr used by JuMP
-typealias AffExpr GenericAffExpr{Float64,Variable}
+const AffExpr = GenericAffExpr{Float64,Variable}
 AffExpr() = zero(AffExpr)
 
 Base.isempty(a::AffExpr) = (length(a.vars) == 0 && a.constant == 0.)
@@ -161,7 +161,7 @@ function rhs(c::GenericRangeConstraint)
 end
 
 # Alias for AffExpr
-typealias LinearConstraint GenericRangeConstraint{AffExpr}
+const LinearConstraint = GenericRangeConstraint{AffExpr}
 
 function Base.copy(c::LinearConstraint, new_model::Model)
     return LinearConstraint(copy(c.terms, new_model), c.lb, c.ub)

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -5,7 +5,7 @@
 
 export addlazycallback, addcutcallback, addheuristiccallback, addinfocallback
 
-abstract JuMPCallback
+@compat abstract type JuMPCallback end
 type LazyCallback <: JuMPCallback
     f::Function
     fractional::Bool

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -11,7 +11,7 @@ end
 
 include("parsenlp.jl")
 
-typealias NonlinearConstraint GenericRangeConstraint{NonlinearExprData}
+const NonlinearConstraint = GenericRangeConstraint{NonlinearExprData}
 
 type NLPData
     nlobj

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -124,7 +124,9 @@ function (^)(lhs::Union{Variable,AffExpr}, rhs::Integer)
     end
 end
 (^)(lhs::Union{Variable,AffExpr}, rhs::Number) = error("Only exponents of 0, 1, or 2 are currently supported. Are you trying to build a nonlinear problem? Make sure you use @NLconstraint/@NLobjective.")
-(.^)(lhs::Union{Variable,AffExpr}, rhs::Number) = lhs^rhs
+if VERSION < v"0.6.0-"
+    @eval (.^)(lhs::Union{Variable,AffExpr}, rhs::Number) = lhs^rhs
+end
 # AffExpr--Variable
 (+){C,V<:JuMPTypes}(lhs::GenericAffExpr{C,V}, rhs::V) = (+)(rhs,lhs)
 (-){C,V<:JuMPTypes}(lhs::GenericAffExpr{C,V}, rhs::V) = GenericAffExpr{C,V}(vcat(lhs.vars,rhs),vcat(lhs.coeffs,-one(C)),lhs.constant)
@@ -570,31 +572,40 @@ end; end
 (/){T<:JuMPTypes}(lhs::SparseMatrixCSC{T}, rhs::Number) =
     SparseMatrixCSC(lhs.m, lhs.n, copy(lhs.colptr), copy(lhs.rowval), lhs.nzval ./ rhs)
 
-for (dotop,op) in [(:.+,:+), (:.-,:-), (:.*,:*), (:./,:/)]
-    @eval begin
-        $dotop(lhs::Number,rhs::JuMPTypes) = $op(lhs,rhs)
-        $dotop(lhs::JuMPTypes,rhs::Number) = $op(lhs,rhs)
-    end
-    for (T1,T2) in [(:JuMPTypes,:Number),(:JuMPTypes,:JuMPTypes),(:Number,:JuMPTypes)]
-        # Need these looks over S1,S2 for v0.3 because Union{Array,SparseMatrix}
-        # gives ambiguity warnings
-        for S1 in (:Array,:SparseMatrixCSC)
-            @eval $dotop{S<:$T1}(lhs::$S1{S},rhs::$T2) = $op(lhs,rhs)
+if VERSION >= v"0.6.0-"
+    for (op,opsymbol) in [(+,:+), (-,:-), (*,:*), (/,:/)]
+        @eval begin
+            Base.broadcast(::typeof($op),lhs::Number,rhs::JuMPTypes) = $opsymbol(lhs,rhs)
+            Base.broadcast(::typeof($op),lhs::JuMPTypes,rhs::Number) = $opsymbol(lhs,rhs)
         end
-        for (S1,S2) in [(:Array,:Array),(:Array,:SparseMatrixCSC),(:SparseMatrixCSC,:Array)]
-            @eval begin
-                function $dotop{S<:$T1,T<:$T2}(lhs::$S1{S},rhs::$S2{T})
-                    size(lhs) == size(rhs) || error("Incompatible dimensions")
-                    arr = Array{typeof($op(zero(S),zero(T)))}(size(rhs))
-                    @inbounds for i in eachindex(lhs)
-                        arr[i] = $op(lhs[i], rhs[i])
+    end
+else
+    for (dotop,op) in [(:.+,:+), (:.-,:-), (:.*,:*), (:./,:/)]
+        @eval begin
+            $dotop(lhs::Number,rhs::JuMPTypes) = $op(lhs,rhs)
+            $dotop(lhs::JuMPTypes,rhs::Number) = $op(lhs,rhs)
+        end
+        for (T1,T2) in [(:JuMPTypes,:Number),(:JuMPTypes,:JuMPTypes),(:Number,:JuMPTypes)]
+            # Need these looks over S1,S2 for v0.3 because Union{Array,SparseMatrix}
+            # gives ambiguity warnings
+            for S1 in (:Array,:SparseMatrixCSC)
+                @eval $dotop{S<:$T1}(lhs::$S1{S},rhs::$T2) = $op(lhs,rhs)
+            end
+            for (S1,S2) in [(:Array,:Array),(:Array,:SparseMatrixCSC),(:SparseMatrixCSC,:Array)]
+                @eval begin
+                    function $dotop{S<:$T1,T<:$T2}(lhs::$S1{S},rhs::$S2{T})
+                        size(lhs) == size(rhs) || error("Incompatible dimensions")
+                        arr = Array{typeof($op(zero(S),zero(T)))}(size(rhs))
+                        @inbounds for i in eachindex(lhs)
+                            arr[i] = $op(lhs[i], rhs[i])
+                        end
+                        arr
                     end
-                    arr
                 end
             end
-        end
-        for S2 in (:Array,:SparseMatrixCSC)
-            @eval $dotop{T<:$T2}(lhs::$T1,rhs::$S2{T}) = $op(lhs,rhs)
+            for S2 in (:Array,:SparseMatrixCSC)
+                @eval $dotop{T<:$T2}(lhs::$T1,rhs::$S2{T}) = $op(lhs,rhs)
+            end
         end
     end
 end

--- a/src/parseExpr_staged.jl
+++ b/src/parseExpr_staged.jl
@@ -256,7 +256,7 @@ end
 
 # Catch nonlinear expressions and parameters being used in addconstraint, etc.
 
-typealias _NLExpr Union{NonlinearExpression,NonlinearParameter}
+const _NLExpr = Union{NonlinearExpression,NonlinearParameter}
 _nlexprerr() = error("""Cannot use nonlinear expression or parameter in @constraint or @objective.
                         Use @NLconstraint or @NLobjective instead.""")
 # Following three definitions avoid ambiguity warnings

--- a/src/print.jl
+++ b/src/print.jl
@@ -23,9 +23,9 @@
 #############################################################################
 
 # Used for dispatching
-abstract PrintMode
-abstract REPLMode <: PrintMode
-abstract IJuliaMode <: PrintMode
+@compat abstract type PrintMode end
+@compat abstract type REPLMode <: PrintMode end
+@compat abstract type IJuliaMode <: PrintMode end
 
 # Whether something is zero or not for the purposes of printing it
 const PRINT_ZERO_TOL = 1e-10
@@ -95,7 +95,7 @@ const ijulia = Dict{Symbol,String}(
     :Vert       => "\\Vert",
     :sub2       => "_2")
 
-typealias PrintSymbols Dict{Symbol,String}
+const PrintSymbols = Dict{Symbol,String}
 
 # If not already mathmode, then wrap in MathJax start/close tags
 math(s,mathmode) = mathmode ? s : "\$\$ $s \$\$"

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -62,7 +62,7 @@ function Base.isequal{T,S}(q::GenericQuadExpr{T,S},other::GenericQuadExpr{T,S})
 end
 
 # Alias for (Float64, Variable)
-typealias QuadExpr GenericQuadExpr{Float64,Variable}
+const QuadExpr = GenericQuadExpr{Float64,Variable}
 Base.convert(::Type{QuadExpr}, v::Union{Real,Variable,AffExpr}) = QuadExpr(Variable[], Variable[], Float64[], AffExpr(v))
 QuadExpr() = zero(QuadExpr)
 
@@ -111,7 +111,7 @@ Base.copy{CON<:GenericQuadConstraint}(c::CON, new_model::Model) = CON(copy(c.ter
 
 
 # Alias for (Float64, Variable)
-typealias QuadConstraint GenericQuadConstraint{QuadExpr}
+const QuadConstraint = GenericQuadConstraint{QuadExpr}
 
 function Base.copy(c::QuadConstraint, new_model::Model)
     return QuadConstraint(copy(c.terms, new_model), c.sense)


### PR DESCRIPTION
``using JuMP`` no longer prints warnings when precompiling