### PR TITLE
Refactor conicdata

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -90,7 +90,7 @@ type Model <: AbstractModel
     redCosts::Vector{Float64}
     linconstrDuals::Vector{Float64}
     conicconstrDuals::Vector{Float64}
-    constrDualMap::Vector{Vector{Int}}
+    constr_to_row::Vector{Vector{Int}}
     # Vector of the same length as sdpconstr.
     # sdpconstrSym[c] is the list of pairs (i,j), i > j
     # such that a symmetry-enforcing constraint has been created
@@ -165,7 +165,7 @@ function Model(;solver=UnsetSolver(), simplify_nonlinear_expressions::Bool=false
           Float64[],                   # redCosts
           Float64[],                   # linconstrDuals
           Float64[],                   # conicconstrDuals
-          Vector{Int}[],               # constrDualMap
+          Vector{Int}[],               # constr_to_row
           Vector{Tuple{Int,Int}}[],    # sdpconstrSym
           nothing,                     # internalModel
           solver,                      # solver
@@ -627,7 +627,7 @@ function getconicdualaux(m::Model, idx::Int, issdp::Bool)
     numSymRows = getNumSymRows(m)
     numRows = numLinRows + numBndRows + numSOCRows + numSDPRows + numSymRows
     if length(m.conicconstrDuals) != numRows
-        # solve might not have been called so m.constrDualMap might be empty
+        # solve might not have been called so m.constr_to_row might be empty
         getdualwarn(idx)
         c = issdp ? m.sdpconstr[idx] : m.socconstr[idx]
         duals = fill(NaN, getNumRows(c))
@@ -641,10 +641,10 @@ function getconicdualaux(m::Model, idx::Int, issdp::Bool)
         if issdp
             offset += length(m.socconstr)
         end
-        dual = m.conicconstrDuals[m.constrDualMap[offset + idx]]
+        dual = m.conicconstrDuals[m.constr_to_row[offset + idx]]
         if issdp
             offset += length(m.sdpconstr)
-            symdual = m.conicconstrDuals[m.constrDualMap[offset + idx]]
+            symdual = m.conicconstrDuals[m.constr_to_row[offset + idx]]
             dual, symdual
         else
             dual

--- a/test/model.jl
+++ b/test/model.jl
@@ -13,6 +13,7 @@
 #############################################################################
 using JuMP
 using Base.Test
+using OffsetArrays
 
 # If solvers not loaded, load them (i.e running just these tests)
 !isdefined(:lp_solvers) && include("solvers.jl")
@@ -997,5 +998,13 @@ end
 
             @test_throws ErrorException @objective(m, Min, x) # vector objective
         end
+    end
+
+    @testset "Variable not owned by the model" begin
+        m = Model()
+        M = Model()
+        @variable(m, x)
+        @constraint(M, x == 1)
+        @test_throws ErrorException solve(M)
     end
 end


### PR DESCRIPTION
Related to #1009 
Refactor `conicdata` and add the `checkowned` option. Even if the `checkowned` option will always be `true` in JuMP, extensions such as StructJuMP may want to set it to `false` so that the constraint matrix only contains the columns of the variables of the model given as `m` but doesn't error if it sees variables from an other model.
Note that the code of [this file](https://github.com/StructJuMP/StructJuMP.jl/blob/616588ae3ce6b3f564fdb1ecfbff51bedae2cce4/src/BendersBridge.jl) and of [this file](https://github.com/blegat/StochasticDualDynamicProgramming.jl/blob/13befeb2840ce2619f19cb52068063b77c13b5e9/src/interface.jl) can now be greatly trimmed down thanks to this.