### PR TITLE
WIP: Add syntax for set inclusion constraints

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -384,7 +384,13 @@ macro constraint(args...)
     # Strategy: build up the code for non-macro addconstraint, and if needed
     # we will wrap in loops to assign to the ConstraintRefs
     refcall, idxvars, idxsets, idxpairs, condition = buildrefsets(c, variable)
-    # Build the constraint
+    # JuMP accepts constraint syntax of the form @constraint(m, foo in bar).
+    # This will be rewritten to a call to constructconstraint!(foo, bar). To
+    # extend JuMP to accept set-based constraints of this form, it is necessary
+    # to add the corresponding methods to constructconstraint!. Note that this
+    # will likely mean that bar will be some custom type, rather than e.g. a
+    # Symbol, since we will likely want to dispatch on the type of the set
+    # appearing in the constraint.
     if isexpr(x, :call)
         if x.args[1] == :in
             @assert length(x.args) == 3

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -389,7 +389,7 @@ macro constraint(args...)
         if x.args[1] == :in
             @assert length(x.args) == 3
             newaff, parsecode = parseExprToplevel(x.args[2], :q)
-            constraintcall = :(addconstraint($m, constructconstraint!($newaff,$(x.args[3]))))
+            constraintcall = :(addconstraint($m, constructconstraint!($newaff,$(esc(x.args[3])))))
         else
             # Simple comparison - move everything to the LHS
             @assert length(x.args) == 3

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -12,6 +12,8 @@ const  eq = JuMP.repl[:eq]
 const Vert = JuMP.repl[:Vert]
 const sub2 = JuMP.repl[:sub2]
 
+immutable __Cone__ end
+
 @testset "Macros" begin
 
 
@@ -733,10 +735,9 @@ const sub2 = JuMP.repl[:sub2]
         m = Model()
         @variable(m, x)
 
-        immutable Cone end
-        JuMP.constructconstraint!(aff, ::Cone) = (m.ext[:ConeTest] = 1; LinearConstraint(aff, 0, 0))
+        JuMP.constructconstraint!(aff, ::__Cone__) = (m.ext[:ConeTest] = 1; LinearConstraint(aff, 0, 0))
 
-        @constraint(m, 2x in Cone())
+        @test @constraint(m, 2x in __Cone__()) == LinearConstraint(2x, 0, 0)
         @test m.ext[:ConeTest] == 1
     end
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -728,4 +728,15 @@ const sub2 = JuMP.repl[:sub2]
        @test lc[2].lb == -Inf
        @test lc[2].ub == 2
     end
+
+    @testset "Set constraint syntax" begin
+        m = Model()
+        @variable(m, x)
+
+        immutable Cone end
+        JuMP.constructconstraint!(aff, ::Cone) = (m.ext[:ConeTest] = 1; LinearConstraint(aff, 0, 0))
+
+        @constraint(m, 2x in Cone())
+        @test m.ext[:ConeTest] == 1
+    end
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -737,7 +737,7 @@ immutable __Cone__ end
 
         JuMP.constructconstraint!(aff, ::__Cone__) = (m.ext[:ConeTest] = 1; LinearConstraint(aff, 0, 0))
 
-        @test @constraint(m, 2x in __Cone__()) == LinearConstraint(2x, 0, 0)
+        @constraint(m, 2x in __Cone__())
         @test m.ext[:ConeTest] == 1
     end
 end


### PR DESCRIPTION
e.g. ``@constraint(model, 2x in Cone)``. This dispatches to ``constructconstraint!(2x, Cone)``, so you need to add the corresponding methods to do the right things.

cc @chriscoey