### PR TITLE
WIP: Overload getindex to allow variables to be accessed with []

### DIFF
--- a/doc/refmodel.rst
+++ b/doc/refmodel.rst
@@ -57,7 +57,8 @@ Methods
 * ``solve(m::Model; suppress_warnings=false, relaxation=false)`` - solves the model using the selected solver (or a default for the problem class), and takes two optional arguments that are disabled by default. Setting ``suppress_warnings`` to ``true`` will suppress all JuMP-specific output (e.g. warnings about infeasibility and lack of dual information) but will not suppress solver output (which should be done by passing options to the solver). Setting ``relaxation=true`` solves the standard continuous relaxation for the model: that is, integrality is dropped, special ordered set constraints are not enforced, and semi-continuous and semi-integer variables with bounds ``[l,u]`` are replaced with bounds ``[min(l,0),max(u,0)]``.
 * ``JuMP.build(m::Model)`` - builds the model in memory at the MathProgBase level without optimizing.
 * ``setsolver(m::Model,s::AbstractMathProgSolver)`` - changes the solver which will be used for the next call to ``solve()``, discarding the current internal model if present.
-* ``getindex(m::Model,name::Symbol)`` - returns the variable, or group of variables, or constraint, or group of constraints, of the given name which were added to the model.
+* ``getindex(m::Model,name::Symbol)`` - returns the variable, or group of variables, or constraint, or group of constraints, of the given name which were added to the model. This errors if multiple variables or constraints share the same name.
+* ``setindex!(m::Model, value, name::Symbol)`` - stores the object ``value`` in the model ``m`` so that it can be accessed via ``getindex``.
 
 **Objective**
 

--- a/doc/refmodel.rst
+++ b/doc/refmodel.rst
@@ -57,8 +57,7 @@ Methods
 * ``solve(m::Model; suppress_warnings=false, relaxation=false)`` - solves the model using the selected solver (or a default for the problem class), and takes two optional arguments that are disabled by default. Setting ``suppress_warnings`` to ``true`` will suppress all JuMP-specific output (e.g. warnings about infeasibility and lack of dual information) but will not suppress solver output (which should be done by passing options to the solver). Setting ``relaxation=true`` solves the standard continuous relaxation for the model: that is, integrality is dropped, special ordered set constraints are not enforced, and semi-continuous and semi-integer variables with bounds ``[l,u]`` are replaced with bounds ``[min(l,0),max(u,0)]``.
 * ``JuMP.build(m::Model)`` - builds the model in memory at the MathProgBase level without optimizing.
 * ``setsolver(m::Model,s::AbstractMathProgSolver)`` - changes the solver which will be used for the next call to ``solve()``, discarding the current internal model if present.
-* ``getvariable(m::Model,name::Symbol)`` - returns the variable or group of variables of the given name which were added to the model with ``@variable``. Throws an error if multiple variables were created with the same name.
-* ``getconstraint(m::Model,name::Symbol)`` - returns the constraint or group of constraint of the given name which were added to the model with ``@constraint`` or ``@NLconstraint``. Throws an error if multiple constraints were created with the same name.
+* ``getindex(m::Model,name::Symbol)`` - returns the variable, or group of variables, or constraint, or group of constraints, of the given name which were added to the model.
 
 **Objective**
 

--- a/doc/refvariable.rst
+++ b/doc/refvariable.rst
@@ -122,7 +122,7 @@ The ``lowerbound`` and ``upperbound`` keywords must be used instead of compariso
 Besides these syntax restrictions in the ``@variable`` macro, the **only** differences between anonymous and named variables are:
 
     1. For the purposes of printing a model, JuMP will not have a name for anonymous variables and will instead use ``__anon__``. You may set the name of a variable for printing by using ``setname`` or the ``basename`` keyword argument described below.
-    2. Anonymous variables cannot be retrieved by using ``getvariable``.
+    2. Anonymous variables cannot be retrieved by using ``getindex`` or ``m[name]``.
 
 If you would like to change the name used when printing a variable or group of variables, you may use the ``basename`` keyword argument::
 
@@ -234,7 +234,7 @@ Two possible uses for fixed variables are:
 
 2. For solving a sequence of problems with varying parameters.
    One may call ``JuMP.fix(x, val)``
-   to change the value of a fixed variable or to fix a 
+   to change the value of a fixed variable or to fix a
    previously unfixed variable. For LPs
    in particular, most solvers are able to efficiently hot-start when
    solving the resulting modified problem.

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -835,6 +835,9 @@ function getvariable(m::Model, varname::Symbol)
     end
 end
 
+# allow easy accessing of JuMP Variables
+Base.getindex(m::JuMP.Model, varname::Symbol) = getvariable(m, varname)
+
 function getconstraint(m::Model, conname::Symbol)
     if !haskey(m.conDict, conname)
         error("No constraint with name $conname")

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -823,6 +823,12 @@ function Base.getindex(m::JuMP.Model, name::Symbol)
         return m.objDict[name]
     end
 end
+function Base.setindex!(m::JuMP.Model, value, name::Symbol)
+    if haskey(m.objDict, name)
+        error("There is already an object in the model with the name $name")
+    end
+    m.objDict[name] = value
+end
 
 # usage warnings
 function mapcontainer_warn(f, x::JuMPContainer, var_or_expr)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -808,7 +808,8 @@ registercon(m::Model, conname, value) = value # constraint name isn't a simple s
 
 function registerobject(m::Model, name::Symbol, value, warnstring::String)
     if haskey(m.objDict, name)
-        error(warnstring)
+        warn(warnstring)
+        m.objDict[name] = nothing
     else
         m.objDict[name] = value
     end
@@ -818,15 +819,17 @@ end
 # allow easy accessing of JuMP Variables and Constraints
 function Base.getindex(m::JuMP.Model, name::Symbol)
     if !haskey(m.objDict, name)
-        error("No object with name $name")
+        throw(KeyError("No object with name $name"))
+    elseif m.objDict[name] === nothing
+        error("There are multiple variables and/or constraints named $name that are already attached to this model. If creating variables programmatically, use the anonymous variable syntax x = @variable(m, [1:N], ...). If creating constraints programmatically, use the anonymous constraint syntax con = @constraint(m, ...).")
     else
         return m.objDict[name]
     end
 end
 function Base.setindex!(m::JuMP.Model, value, name::Symbol)
-    if haskey(m.objDict, name)
-        error("There is already an object in the model with the name $name")
-    end
+    # if haskey(m.objDict, name)
+    #     warn("Overwriting the object $name stored in the model. Consider using anonymous variables and constraints instead")
+    # end
     m.objDict[name] = value
 end
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -845,7 +845,7 @@ function getconstraint(m::Model, conname::Symbol)
     end
 end
 
-# allow easy accessing of JuMP Variables
+# allow easy accessing of JuMP Variables and Constraints
 function Base.getindex(m::JuMP.Model, name::Symbol)
     isvariable   = haskey(m.varDict, name)
     isconstraint = haskey(m.conDict, name)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -835,9 +835,6 @@ function getvariable(m::Model, varname::Symbol)
     end
 end
 
-# allow easy accessing of JuMP Variables
-Base.getindex(m::JuMP.Model, varname::Symbol) = getvariable(m, varname)
-
 function getconstraint(m::Model, conname::Symbol)
     if !haskey(m.conDict, conname)
         error("No constraint with name $conname")
@@ -845,6 +842,21 @@ function getconstraint(m::Model, conname::Symbol)
         error("Multiple constraints with name $conname")
     else
         return m.conDict[conname]
+    end
+end
+
+# allow easy accessing of JuMP Variables
+function Base.getindex(m::JuMP.Model, name::Symbol)
+    isvariable   = haskey(m.varDict, name)
+    isconstraint = haskey(m.conDict, name)
+    if isvariable && !isconstraint
+        return getvariable(m, name)
+    elseif !isvariable && isconstraint
+        return getconstraint(m, name)
+    elseif isvariable && isconstraint
+        error("$name is both a variable and a constraint. Use getconstraint(m, name) or getvariable(m, name) to specify.")
+    else
+        error("No variable or constraint with name $name")
     end
 end
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -79,6 +79,8 @@ end
 @deprecate setSolver setsolver
 @deprecate setUpper setupperbound
 @deprecate setValue setvalue
+@deprecate getvariable getindex
+@deprecate getconstraint getindex
 
 function registerNLFunction(args...;autodiff=false)
     Base.depwarn("registerNLFunction is deprecated, use JuMP.register instead.",:registerNLFunction)

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -649,17 +649,17 @@ immutable __Cone__ end
         @test_throws ErrorException @variable(m, x[S])
     end
 
-    @testset "getconstraint" begin
+    @testset "getindex constraint" begin
         m = Model()
         @variable(m, x)
         _c1 = @constraint(m, c1, x == 1)
         _c2 = @constraint(m, c2[i=1:3], x == i)
         _c3 = @NLconstraint(m, c3, x^3 == 1)
         _c4 = @NLconstraint(m, c4[i=1:3], x^i == 1)
-        @test _c1 == getconstraint(m, :c1)
-        @test _c2 == getconstraint(m, :c2)
-        @test _c3 == getconstraint(m, :c3)
-        @test _c4 == getconstraint(m, :c4)
+        @test _c1 == m[:c1]
+        @test _c2 == m[:c2]
+        @test _c3 == m[:c3]
+        @test _c4 == m[:c4]
     end
 
     @testset "Anonymous singleton variables" begin

--- a/test/model.jl
+++ b/test/model.jl
@@ -1043,4 +1043,15 @@ end
             @test getobjectivebound(m) == -5
         end
     end
+
+    @testset "getindex for variables and constraints" begin
+        m = Model()
+        @variable(m, x)
+        @test m[:x] == x
+        @test_throws Exception m[:y]
+        @constraint(m, c, x <= 1)
+        @test m[:c] == c
+        @variable(m, c)
+        @test_throws Exception m[:c]
+    end
 end

--- a/test/model.jl
+++ b/test/model.jl
@@ -1047,4 +1047,13 @@ end
         @test m[:c] == c
         @test_throws Exception @variable(m, c)
     end
+
+    @testset "setindex! for variables and constraints" begin
+        m = Model()
+        m[:x] = @variable(m)
+        @test isa(m[:x], Variable)
+        m[:c] = @constraint(m, m[:x] <= 1)
+        @test isa(m[:c], JuMP.ConstraintRef)
+        @test_throws Exception m[:c] = @variable(m)
+    end
 end

--- a/test/model.jl
+++ b/test/model.jl
@@ -453,12 +453,12 @@ end
 
         @test dest.solvehook(dest) == :Optimal
 
-        @test Set(collect(keys(dest.varDict))) == Set([:x,:y,:z,:w,:v])
-        @test isequal(dest.varDict[:x], Variable(dest, 1))
-        @test isequal(dest.varDict[:y], Variable(dest, 2))
-        @test all(t -> isequal(t[1], t[2]), zip(dest.varDict[:z], [Variable(dest, 3), Variable(dest, 4), Variable(dest, 5)]))
-        @test all(t -> isequal(t[1], t[2]), zip(dest.varDict[:w].innerArray, [Variable(dest, 6), Variable(dest, 7), Variable(dest, 8)]))
-        td = dest.varDict[:v].tupledict
+        @test Set(collect(keys(dest.objDict))) == Set([:x,:y,:z,:w,:v])
+        @test isequal(dest.objDict[:x], Variable(dest, 1))
+        @test isequal(dest.objDict[:y], Variable(dest, 2))
+        @test all(t -> isequal(t[1], t[2]), zip(dest.objDict[:z], [Variable(dest, 3), Variable(dest, 4), Variable(dest, 5)]))
+        @test all(t -> isequal(t[1], t[2]), zip(dest.objDict[:w].innerArray, [Variable(dest, 6), Variable(dest, 7), Variable(dest, 8)]))
+        td = dest.objDict[:v].tupledict
         @test length(td) == 2
         @test isequal(td[:red,1], Variable(dest, 9))
         @test isequal(td[:red,3], Variable(dest, 10))
@@ -470,12 +470,6 @@ end
         JuMP.setprinthook(source, m -> 2)
         dest2 = copy(source)
         @test dest2.printhook(dest2) == 2
-
-        # Test copying model with multiple variables of same name
-        @variable(source, x)
-        dest3 = copy(source)
-        @test_throws ErrorException getvariable(dest3, :x)
-        @test dest3.varDict[:x] == nothing
 
         addlazycallback(source, cb -> 3)
         @test_throws ErrorException copy(source)
@@ -1051,7 +1045,6 @@ end
         @test_throws Exception m[:y]
         @constraint(m, c, x <= 1)
         @test m[:c] == c
-        @variable(m, c)
-        @test_throws Exception m[:c]
+        @test_throws Exception @variable(m, c)
     end
 end

--- a/test/model.jl
+++ b/test/model.jl
@@ -1042,10 +1042,11 @@ end
         m = Model()
         @variable(m, x)
         @test m[:x] == x
-        @test_throws Exception m[:y]
+        @test_throws KeyError m[:y]
         @constraint(m, c, x <= 1)
         @test m[:c] == c
-        @test_throws Exception @variable(m, c)
+        @variable(m, c)
+        @test_throws Exception m[:c]
     end
 
     @testset "setindex! for variables and constraints" begin
@@ -1054,6 +1055,7 @@ end
         @test isa(m[:x], Variable)
         m[:c] = @constraint(m, m[:x] <= 1)
         @test isa(m[:c], JuMP.ConstraintRef)
-        @test_throws Exception m[:c] = @variable(m)
+        m[:c] = @variable(m) # user purposely changes object in m[:c]
+        @test isa(m[:c], JuMP.Variable)
     end
 end

--- a/test/print.jl
+++ b/test/print.jl
@@ -690,14 +690,14 @@ end
         m1 = Model()
         @variable(m1, x[1:2] >= 0)
         n1 = copy(m1)
-        io_test(REPLMode, m1.varDict[:x], "x[i] $ge 0 $for_all i $inset {1,2}")
-        io_test(REPLMode, n1.varDict[:x], "x[i] $ge 0 $for_all i $inset {1,2}")
+        io_test(REPLMode, m1.objDict[:x], "x[i] $ge 0 $for_all i $inset {1,2}")
+        io_test(REPLMode, n1.objDict[:x], "x[i] $ge 0 $for_all i $inset {1,2}")
 
         a = [:a; :b]
         m2 = Model()
         @variable(m2, x[a] >= 0)
         n2 = copy(m2)
-        io_test(REPLMode, m2.varDict[:x], "x[i] $ge 0 $for_all i $inset {a,b}")
-        io_test(REPLMode, n2.varDict[:x], "x[i] $ge 0 $for_all i $inset {a,b}")
+        io_test(REPLMode, m2.objDict[:x], "x[i] $ge 0 $for_all i $inset {a,b}")
+        io_test(REPLMode, n2.objDict[:x], "x[i] $ge 0 $for_all i $inset {a,b}")
     end
 end

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -239,5 +239,4 @@ end
         @test typeof(Y) == SparseMatrixCSC{Float64, Int}
         @test Y == sparse([1, 3], [2, 3], [1, 2])
     end
-
 end

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -239,4 +239,11 @@ end
         @test typeof(Y) == SparseMatrixCSC{Float64, Int}
         @test Y == sparse([1, 3], [2, 3], [1, 2])
     end
+
+    @testset "Get Index on variable" begin
+        m = Model()
+        @variable(m, x)
+        @test m[:x] == x
+        @test_throws Exception m[:y]
+    end
 end

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -33,8 +33,9 @@ using Base.Test
         @test isequal(mcon[:lbonly],lbonly)
         @test isequal(mcon[:ubonly],ubonly)
         @test isequal(mcon[:onerangeub][-7],onerangeub[-7])
-        @test_throws ErrorException @variable(mcon, lbonly)
-        @test_throws ErrorException mcon[:foo]
+        @variable(mcon, lbonly)
+        @test_throws ErrorException mcon[:lbonly]
+        @test_throws KeyError mcon[:foo]
         d = Dict()
         @variable(mcon, d["bar"][1:10] == 1)
         @test getvalue(d["bar"][1]) == 1

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -30,12 +30,11 @@ using Base.Test
         @variable(mcon, x[i=-10:10,s] <= 5.5, Int, start=i+1)
         @test getupperbound(x[-4,"Green"]) == 5.5
         @test getvalue(x[-3,"Blue"]) == -2
-        @test isequal(getvariable(mcon, :lbonly),lbonly)
-        @test isequal(getvariable(mcon, :ubonly),ubonly)
-        @test isequal(getvariable(mcon, :onerangeub)[-7],onerangeub[-7])
-        @variable(mcon, lbonly)
-        @test_throws ErrorException getvariable(mcon, :lbonly)
-        @test_throws ErrorException getvariable(mcon, :foo)
+        @test isequal(mcon[:lbonly],lbonly)
+        @test isequal(mcon[:ubonly],ubonly)
+        @test isequal(mcon[:onerangeub][-7],onerangeub[-7])
+        @test_throws ErrorException @variable(mcon, lbonly)
+        @test_throws ErrorException mcon[:foo]
         d = Dict()
         @variable(mcon, d["bar"][1:10] == 1)
         @test getvalue(d["bar"][1]) == 1

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -240,10 +240,4 @@ end
         @test Y == sparse([1, 3], [2, 3], [1, 2])
     end
 
-    @testset "Get Index on variable" begin
-        m = Model()
-        @variable(m, x)
-        @test m[:x] == x
-        @test_throws Exception m[:y]
-    end
 end


### PR DESCRIPTION
@reganbaucke proposed the following as a nicer way to associate variables with models.

It's particularly attractive if you are copying models around and losing track of which scope `x` is in.