### PR TITLE
Add the constructvariable!/variabletype functions

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -822,6 +822,7 @@ function constructvariable!(m::Model, _error::Function, lowerbound::Number, uppe
     Variable(m, lowerbound, upperbound, category == :Default ? :Cont : category, objective, inconstraints, coefficients, basename, start)
 end
 
+variabletype(m::Model, _error::Function, lowerbound::Number, upperbound::Number, category::Symbol, basename::AbstractString, start::Number) = Variable
 function constructvariable!(m::Model, _error::Function, lowerbound::Number, upperbound::Number, category::Symbol, basename::AbstractString, start::Number; extra_kwargs...)
     for (kwarg, _) in extra_kwargs
         _error("Unrecognized keyword argument $kwarg")

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -14,7 +14,7 @@ const sub2 = JuMP.repl[:sub2]
 
 immutable __Cone__ end
 
-type MyType
+type MyVariable
     lowerbound
     upperbound
     category
@@ -774,21 +774,21 @@ end
     end
 
     @testset "Extension of @variable with constructvariable! #1029" begin
-        JuMP.variabletype(m::Model, ::Type{MyType}) = MyType
-        function JuMP.constructvariable!(m::Model, ::Type{MyType}, _error::Function, lowerbound::Number, upperbound::Number, category::Symbol, basename::AbstractString, start::Number; test_kw::Int = 0)
-            MyType(lowerbound, upperbound, category, basename, start, test_kw)
+        JuMP.variabletype(m::Model, ::Type{MyVariable}) = MyVariable
+        function JuMP.constructvariable!(m::Model, ::Type{MyVariable}, _error::Function, lowerbound::Number, upperbound::Number, category::Symbol, basename::AbstractString, start::Number; test_kw::Int = 0)
+            MyVariable(lowerbound, upperbound, category, basename, start, test_kw)
         end
         m = Model()
-        @variable(m, 1 <= x <= 2, MyType, category = :Bin, test_kw = 1, start = 3)
-        @test isa(x, MyType)
+        @variable(m, 1 <= x <= 2, MyVariable, category = :Bin, test_kw = 1, start = 3)
+        @test isa(x, MyVariable)
         @test x.lowerbound == 1
         @test x.upperbound == 2
         @test x.category == :Bin
         @test x.basename == "x"
         @test x.start == 3
         @test x.test_kw == 1
-        @variable(m, y[1:3] >= 0, MyType, test_kw = 2)
-        @test isa(y, Vector{MyType})
+        @variable(m, y[1:3] >= 0, MyVariable, test_kw = 2)
+        @test isa(y, Vector{MyVariable})
         for i in 1:3
             @test y[i].lowerbound == 0
             @test y[i].upperbound == Inf


### PR DESCRIPTION
This allows extensions to use the @variable macro to create other types
of variables. For example, in PolyJuMP, we could add the syntax
```julia
@variable(m, p, Poly(X))
@variable(m, p >= 0, Poly(X))
# or
@variable(m, p, :Poly, monomials=X)
@variable(m, p >= 0, :Poly, monomials=X)
```
where X is the vector of monomials