### PR TITLE
Initial Migration to Docstrings

### DIFF
--- a/docs/src/refexpr.md
+++ b/docs/src/refexpr.md
@@ -27,28 +27,21 @@ Methods
 ```@docs
 addconstraint
 @constraint
+@constraints
 @expression
 @SDconstraint
 addSOS1
 addSOS2
 @LinearConstraint
+@LinearConstraints
 @QuadConstraint
+@QuadConstraints
 Base.push!{C,V}(aff::GenericAffExpr{C,V}, new_coeff::C, new_var::V)
 Base.append!{C,V}(aff::GenericAffExpr{C,V}, other::GenericAffExpr{C,V})
 linearterms
 getvalue(a::AffExpr)
 getvalue(a::QuadExpr)
 ```
-
--   `@constraints` - add groups of constraints at once, in the same fashion as @constraint. The model must be the first argument, and multiple constraints can be added on multiple lines wrapped in a `begin ... end` block. For example:
-
-        @constraints(m, begin
-          x >= 1
-          y - w <= 2
-          sum_to_one[i=1:3], z[i] + y == 1
-        end)
--   `@LinearConstraints(expr)` - Constructs a vector of `LinearConstraint` objects. Similar to `@LinearConstraint`, except it accepts multiple constraints as input as long as they are separated by newlines.
--   `@QuadConstraints(expr)` - Constructs a vector of `QuadConstraint` objects. Similar to `@QuadConstraint`, except it accepts multiple constraints as input as long as they are separated by newlines.
 
 
 Constraint References

--- a/docs/src/refexpr.md
+++ b/docs/src/refexpr.md
@@ -1,3 +1,7 @@
+```@meta
+CurrentModule = JuMP
+```
+
 Expressions and Constraints
 ===========================
 
@@ -20,9 +24,22 @@ The corresponding constraint is `QuadConstraint`, which is expected to be a conv
 Methods
 -------
 
--   `@constraint(m::Model, con)` - add linear or quadratic constraints.
--   `@constraint(m::Model, ref, con)` - add groups of linear or quadratic constraints. See Constraint Reference section for details.
--   `JuMP.addconstraint(m::Model, con)` - general way to add linear and quadratic constraints.
+```@docs
+addconstraint
+@constraint
+@expression
+@SDconstraint
+addSOS1
+addSOS2
+@LinearConstraint
+@QuadConstraint
+Base.push!{C,V}(aff::GenericAffExpr{C,V}, new_coeff::C, new_var::V)
+Base.append!{C,V}(aff::GenericAffExpr{C,V}, other::GenericAffExpr{C,V})
+linearterms
+getvalue(a::AffExpr)
+getvalue(a::QuadExpr)
+```
+
 -   `@constraints` - add groups of constraints at once, in the same fashion as @constraint. The model must be the first argument, and multiple constraints can be added on multiple lines wrapped in a `begin ... end` block. For example:
 
         @constraints(m, begin
@@ -30,33 +47,9 @@ Methods
           y - w <= 2
           sum_to_one[i=1:3], z[i] + y == 1
         end)
-
--   `@expression(m::Model, ref, expr)` - efficiently builds a linear, quadratic, or second-order cone expression but does not add to model immediately. Instead, returns the expression which can then be inserted in other constraints. For example:
-
-        @expression(m, shared, sum(i*x[i] for i=1:5))
-        @constraint(m, shared + y >= 5)
-        @constraint(m, shared + z <= 10)
-
-The `ref` accepts index sets in the same way as `@variable`, and those indices can be used in the construction of the expressions:
-
-    @expression(m, expr[i=1:3], i*sum(x[j] for j=1:3))
-
-Anonymous syntax is also supported:
-
-    expr = @expression(m, [i=1:3], i*sum(x[j] for j=1:3))
-
--   `@SDconstraint(m::Model, expr)` - adds a semidefinite constraint to the model `m`. The expression `expr` must be a square, two-dimensional array.
--   `addSOS1(m::Model, coll::Vector{AffExpr})` - adds special ordered set constraint of type 1 (SOS1). Specify the set as a vector of weighted variables, e.g. `coll = [3x, y, 2z]`. Note that solvers expect the weights to be unique. See [here](http://lpsolve.sourceforge.net/5.5/SOS.htm) for more details. If there is no inherent weighting in your model, an SOS constraint is probably unnecessary.
--   `addSOS2(m::Model, coll::Vector{AffExpr})` - adds special ordered set constraint of type 2 (SOS2). Specify the set as a vector of weighted variables, e.g. `coll = [3x, y, 2z]`. Note that solvers expect the weights to be unique. See [here](http://lpsolve.sourceforge.net/5.5/SOS.htm) for more details.
--   `@LinearConstraint(expr)` - Constructs a `LinearConstraint` instance efficiently by parsing the `expr`. The same as `@constraint`, except it does not attach the constraint to any model.
 -   `@LinearConstraints(expr)` - Constructs a vector of `LinearConstraint` objects. Similar to `@LinearConstraint`, except it accepts multiple constraints as input as long as they are separated by newlines.
--   `@QuadConstraint(expr)` - Constructs a `QuadConstraint` instance efficiently by parsing the `expr`. The same as `@constraint`, except it does not attach the constraint to any model.
 -   `@QuadConstraints(expr)` - Constructs a vector of `QuadConstraint` objects. Similar to `@QuadConstraint`, except it accepts multiple constraints as input as long as they are separated by newlines.
--   `push!(aff::AffExpr, new_coeff::Float64, new_var::Variable)` - efficient way to grow an affine expression by one term. For example, to add `5x` to an existing expression `aff`, use `push!(aff, 5.0, x)`. This is significantly more efficient than `aff += 5.0*x`.
--   `append!(aff::AffExpr, other::AffExpr)` - efficiently append the terms of an affine expression to an existing affine expression. For example, given `aff = 5.0*x` and `other = 7.0*y + 3.0*z`, we can grow `aff` using `append!(aff, other)` which results in `aff` equaling `5x + 7y + 3z`. This is significantly more efficient than using `aff += other`.
--   `sum(affs::Array{AffExpr})` - efficiently sum an array of affine expressions.
--   `getvalue(expr)` - evaluate an `AffExpr` or `QuadExpr`, given the current solution values.
--   `linearterms{C,V}(aff::GenericAffExpr{C,V})` - provides an iterator over the `(a_i::C,x_i::V)` terms in affine expression ``\sum_i a_i x_i + b``.
+
 
 Constraint References
 ---------------------

--- a/docs/src/refmodel.md
+++ b/docs/src/refmodel.md
@@ -32,14 +32,28 @@ Methods
 
 **General**
 
+```@docs
+MathProgBase.numvar
+MathProgBase.numlinconstr
+MathProgBase.numquadconstr
+numsocconstr
+numsosconstr
+numsdconstr
+numnlconstr
+MathProgBase.numconstr
+```
+
 -   `MathProgBase.numvar(m::Model)` - returns the number of variables associated with the `Model m`.
 -   `MathProgBase.numlinconstr(m::Model)` - returns the number of linear constraints associated with the `Model m`.
 -   `MathProgBase.numquadconstr(m::Model)` - returns the number of quadratic constraints associated with the `Model m`.
+
 -   `JuMP.numsocconstr(m::Model)` - returns the number of second order cone constraints associated with the `Model m`.
 -   `JuMP.numsosconstr(m::Model)` - returns the number of sos constraints associated with the `Model m`.
 -   `JuMP.numsdconstr(m::Model)` - returns the number of semi-definite constraints associated with the `Model m`.
 -   `JuMP.numnlconstr(m::Model)` - returns the number of nonlinear constraints associated with the `Model m`.
+
 -   `MathProgBase.numconstr(m::Model)` - returns the total number of constraints associated with the `Model m`.
+
 -   `getsolvetime(m::Model)` - returns the solve time reported by the solver if it is implemented.
 -   `getnodecount(m::Model)` - returns the number of explored branch-and-bound nodes, if it is implemented.
 -   `getobjbound(m::Model)` - returns the best known bound on the optimal objective value. This is used, for example, when a branch-and-bound method is stopped before finishing.
@@ -63,12 +77,6 @@ setobjectivesense
 getobjectivevalue
 getobjectivebound
 ```
-
--   `getobjective(m::Model)` - returns the objective function as a `QuadExpr`.
--   `getobjectivesense(m::Model)` - returns objective sense, either `:Min` or `:Max`.
--   `setobjectivesense(m::Model, newSense::Symbol)` - sets the objective sense (`newSense` is either `:Min` or `:Max`).
--   `getobjectivevalue(m::Model)` - returns objective value after a call to `solve`.
--   `getobjectivebound(m::Model)` - returns the best known bound on the optimal objective value after a call to `solve`.
 
 **Output**
 

--- a/docs/src/refmodel.md
+++ b/docs/src/refmodel.md
@@ -41,18 +41,13 @@ numsosconstr
 numsdconstr
 numnlconstr
 MathProgBase.numconstr
+internalmodel
+solve
+build
+setsolver
+Base.getindex(m::Model, name::Symbol)
+Base.setindex!(m::Model, value, name::Symbol)
 ```
-
--   `MathProgBase.numvar(m::Model)` - returns the number of variables associated with the `Model m`.
--   `MathProgBase.numlinconstr(m::Model)` - returns the number of linear constraints associated with the `Model m`.
--   `MathProgBase.numquadconstr(m::Model)` - returns the number of quadratic constraints associated with the `Model m`.
-
--   `JuMP.numsocconstr(m::Model)` - returns the number of second order cone constraints associated with the `Model m`.
--   `JuMP.numsosconstr(m::Model)` - returns the number of sos constraints associated with the `Model m`.
--   `JuMP.numsdconstr(m::Model)` - returns the number of semi-definite constraints associated with the `Model m`.
--   `JuMP.numnlconstr(m::Model)` - returns the number of nonlinear constraints associated with the `Model m`.
-
--   `MathProgBase.numconstr(m::Model)` - returns the total number of constraints associated with the `Model m`.
 
 -   `getsolvetime(m::Model)` - returns the solve time reported by the solver if it is implemented.
 -   `getnodecount(m::Model)` - returns the number of explored branch-and-bound nodes, if it is implemented.
@@ -61,12 +56,7 @@ MathProgBase.numconstr
 -   `getrawsolver(m::Model)` - returns an object that may be used to access a solver-specific API.
 -   `getsimplexiter(m::Model)` - returns the cumulative number of simplex iterations during the optimization process. In particular, for a MIP it returns the total simplex iterations for all nodes.
 -   `getbarrieriter(m::Model)` - returns the cumulative number of barrier iterations during the optimization process.
--   `internalmodel(m::Model)` - returns the internal low-level `AbstractMathProgModel` object which can be used to access any functionality that is not exposed by JuMP. See the MathProgBase [documentation](https://mathprogbasejl.readthedocs.org/en/latest/).
--   `solve(m::Model; suppress_warnings=false, relaxation=false)` - solves the model using the selected solver (or a default for the problem class), and takes two optional arguments that are disabled by default. Setting `suppress_warnings` to `true` will suppress all JuMP-specific output (e.g. warnings about infeasibility and lack of dual information) but will not suppress solver output (which should be done by passing options to the solver). Setting `relaxation=true` solves the standard continuous relaxation for the model: that is, integrality is dropped, special ordered set constraints are not enforced, and semi-continuous and semi-integer variables with bounds `[l,u]` are replaced with bounds `[min(l,0),max(u,0)]`.
--   `JuMP.build(m::Model)` - builds the model in memory at the MathProgBase level without optimizing.
--   `setsolver(m::Model,s::AbstractMathProgSolver)` - changes the solver which will be used for the next call to `solve()`, discarding the current internal model if present.
--   `getindex(m::Model,name::Symbol)` - returns the variable, or group of variables, or constraint, or group of constraints, of the given name which were added to the model. This errors if multiple variables or constraints share the same name.
--   `setindex!(m::Model, value, name::Symbol)` - stores the object `value` in the model `m` so that it can be accessed via `getindex`.
+
 
 **Objective**
 

--- a/docs/src/refmodel.md
+++ b/docs/src/refmodel.md
@@ -49,15 +49,6 @@ Base.getindex(m::Model, name::Symbol)
 Base.setindex!(m::Model, value, name::Symbol)
 ```
 
--   `getsolvetime(m::Model)` - returns the solve time reported by the solver if it is implemented.
--   `getnodecount(m::Model)` - returns the number of explored branch-and-bound nodes, if it is implemented.
--   `getobjbound(m::Model)` - returns the best known bound on the optimal objective value. This is used, for example, when a branch-and-bound method is stopped before finishing.
--   `getobjgap(m::Model)` - returns the final relative optimality gap as optimization terminated. That is, it returns ``\frac{|b-f|}{|f|}``, where *b* is the best bound and *f* is the best feasible objective value.
--   `getrawsolver(m::Model)` - returns an object that may be used to access a solver-specific API.
--   `getsimplexiter(m::Model)` - returns the cumulative number of simplex iterations during the optimization process. In particular, for a MIP it returns the total simplex iterations for all nodes.
--   `getbarrieriter(m::Model)` - returns the cumulative number of barrier iterations during the optimization process.
-
-
 **Objective**
 
 ```@docs
@@ -67,6 +58,21 @@ setobjectivesense
 getobjectivevalue
 getobjectivebound
 ```
+
+**Solver**
+
+These functions are JuMP versions of the similarly named functions in MathProgBase.
+
+```@docs
+getsolvetime
+getnodecount
+getobjbound
+getobjgap
+getrawsolver
+getsimplexiter
+getbarrieriter
+```
+
 
 **Output**
 

--- a/docs/src/refmodel.md
+++ b/docs/src/refmodel.md
@@ -56,6 +56,14 @@ Methods
 
 **Objective**
 
+```@docs
+getobjective
+getobjectivesense
+setobjectivesense
+getobjectivevalue
+getobjectivebound
+```
+
 -   `getobjective(m::Model)` - returns the objective function as a `QuadExpr`.
 -   `getobjectivesense(m::Model)` - returns objective sense, either `:Min` or `:Max`.
 -   `setobjectivesense(m::Model, newSense::Symbol)` - sets the objective sense (`newSense` is either `:Min` or `:Max`).

--- a/docs/src/refmodel.md
+++ b/docs/src/refmodel.md
@@ -1,3 +1,7 @@
+```@meta
+CurrentModule = JuMP
+```
+
 Models
 ======
 
@@ -60,8 +64,10 @@ Methods
 
 **Output**
 
--   `writeLP(m::Model, filename::AbstractString; genericnames=true)` - write the model to `filename` in the LP file format. Set `genericnames=false` for user-defined variable names.
--   `writeMPS(m::Model, filename::AbstractString)` - write the model to `filename` in the MPS file format.
+```@docs
+writeLP
+writeMPS
+```
 
 Solve Status
 ------------

--- a/docs/src/refvariable.md
+++ b/docs/src/refvariable.md
@@ -1,3 +1,7 @@
+```@meta
+CurrentModule = JuMP
+```
+
 Variables
 =========
 
@@ -144,13 +148,19 @@ Methods
 
 **Bounds**
 
--   `setlowerbound(x::Variable, lower)`, `getlowerbound(x::Variable)` - Set/get the lower bound of a variable.
--   `setupperbound(x::Variable, upper)`, `getupperbound(x::Variable)` - Set/get the upper bound of a variable.
+```@docs
+setlowerbound
+getlowerbound
+setupperbound
+getupperbound
+```
 
 **Variable Category**
 
--   `setcategory(x::Variable, v_type::Symbol)` - Set the variable category for `x` after construction. Possible categories are listed above.
--   `getcategory(x::Variable)` - Get the variable category for `x`.
+```@docs
+setcategory
+getcategory
+```
 
 **Helper functions**
 
@@ -159,9 +169,11 @@ Methods
 
 **Values**
 
--   `getvalue(x)` - Get the value of this variable in the solution. If `x` is a single variable, this will simply return a number. If `x` is indexable then it will return an indexable dictionary of values. When the model is unbounded, `getvalue` will instead return the corresponding components of an unbounded ray, if available from the solver.
--   `setvalue(x,v)` - Provide an initial value `v` for this variable that can be used by supporting MILP solvers. If `v` is `NaN`, the solver may attempt to fill in this value to construct a feasible solution. `setvalue` cannot be used with fixed variables; instead their value may be set with `JuMP.fix(x,v)`.
--   `getdual(x)` - Get the reduced cost of this variable in the solution. Similar behavior to `getvalue` for indexable variables.
+```@docs
+getvalue
+setvalue
+getdual
+```
 
 !!! note
     The `getvalue` function always returns a floating-point value, even when a variable is constrained to take integer values, as most solvers only guarantee integrality up to a particular numerical tolerance. The built-in `round` function should be used to obtain integer values, e.g., by calling `round(Integer, getvalue(x))`.
@@ -170,7 +182,11 @@ Methods
 
 Variables (in the sense of columns) can have internal names (different from the Julia variable name) that can be used for writing models to file. This feature is disabled for performance reasons, but will be added if there is demand or a special use case.
 
--   `setname(x::Variable, newName)`, `getname(x::Variable)` - Set/get the variable's internal name.
+```@docs
+setname
+getname
+```
+
 
 Fixed variables
 ---------------

--- a/docs/src/refvariable.md
+++ b/docs/src/refvariable.md
@@ -170,7 +170,8 @@ getcategory
 **Values**
 
 ```@docs
-getvalue
+getvalue(v::Variable)
+getvalue(arr::Array{Variable})
 setvalue
 getdual
 ```

--- a/docs/src/refvariable.md
+++ b/docs/src/refvariable.md
@@ -162,11 +162,6 @@ setcategory
 getcategory
 ```
 
-**Helper functions**
-
--   `sum(x)` - Operates on arrays of variables, efficiently produces an affine expression. Available in macros.
--   `dot(x, coeffs)` - Performs a generalized "dot product" for arrays of variables and coefficients up to three dimensions, or equivalently the sum of the elements of the Hadamard product. Available in macros, and also as `dot(coeffs, x)`.
-
 **Values**
 
 ```@docs
@@ -187,6 +182,15 @@ Variables (in the sense of columns) can have internal names (different from the 
 setname
 getname
 ```
+
+
+Helper functions
+----------------
+The following built-in functions are overloaded to provide easy construction of expressions from variables,
+
+-   `sum(x)` - Operates on arrays of variables, efficiently produces an affine expression. Available in macros.
+-   `dot(x, coeffs)` - Performs a generalized "dot product" for arrays of variables and coefficients up to three dimensions, or equivalently the sum of the elements of the Hadamard product. Available in macros, and also as `dot(coeffs, x)`.
+
 
 
 Fixed variables

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -187,14 +187,61 @@ function Model(;solver=UnsetSolver(), simplify_nonlinear_expressions::Bool=false
 end
 
 # Getters/setters
+
+"""
+    MathProgBase.numvar(m::Model)
+
+returns the number of variables associated with the `Model m`.
+"""
 MathProgBase.numvar(m::Model) = m.numCols
+
+"""
+    MathProgBase.numlinconstr(m::Model)
+
+returns the number of linear constraints associated with the `Model m`
+"""
 MathProgBase.numlinconstr(m::Model) = length(m.linconstr)
+
+"""
+    MathProgBase.numquadconstr(m::Model)
+
+returns the number of quadratic constraints associated with the `Model m`
+"""
 MathProgBase.numquadconstr(m::Model) = length(m.quadconstr)
+
+"""
+    numsocconstr(m::Model)
+
+returns the number of second order cone constraints associated with the `Model m`
+"""
 numsocconstr(m::Model) = length(m.socconstr)
+
+"""
+    numsosconstr(m::Model)
+
+returns the number of sos constraints associated with the `Model m`
+"""
 numsosconstr(m::Model) = length(m.sosconstr)
+
+"""
+    numsdconstr(m::Model)
+
+returns the number of semi-definite constraints associated with the `Model m`
+"""
 numsdconstr(m::Model) = length(m.sdpconstr)
+
+"""
+    numnlconstr(m::Model)
+
+returns the number of nonlinear constraints associated with the `Model m`
+"""
 numnlconstr(m::Model) = m.nlpdata !== nothing ? length(m.nlpdata.nlconstr) : 0
 
+"""
+    MathProgBase.numconstr(m::Model)
+
+returns the total number of constraints associated with the `Model m`
+"""
 function MathProgBase.numconstr(m::Model)
     c = length(m.linconstr) + length(m.quadconstr) + length(m.socconstr) + length(m.sosconstr) + length(m.sdpconstr)
     if m.nlpdata !== nothing

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -288,7 +288,7 @@ returns the best known bound on the optimal objective value. This is used, for e
 @doc """
     getobjgap(m::Model)
 
-returns the final relative optimality gap as optimization terminated. That is, it returns ``\frac{|b-f|}{|f|}``, where *b* is the best bound and *f* is the best feasible objective value.
+returns the final relative optimality gap as optimization terminated. That is, it returns ``\\frac{|b-f|}{|f|}``, where *b* is the best bound and *f* is the best feasible objective value.
 """ getobjgap(m::Model)
 
 @doc """

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -707,6 +707,11 @@ function SDConstraint(lhs::AbstractMatrix, rhs::Number)
     SDConstraint(lhs)
 end
 
+"""
+    addconstraint(m::Model, c::SDConstraint)
+
+Add a SD constraint to `Model m`.
+"""
 function addconstraint(m::Model, c::SDConstraint)
     push!(m.sdpconstr,c)
     m.internalModelLoaded = false

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -263,6 +263,53 @@ for f in MathProgBase.SolverInterface.methods_by_tag[:rewrap]
     eval(Expr(:export,f))
 end
 
+
+# Doc strings for the auto-wrapped MPB functions above
+# it would be preferable to problematically use the docstrings from MPB functions instead
+
+@doc """
+    getsolvetime(m::Model)
+
+returns the solve time reported by the solver if it is implemented.
+""" getsolvetime(m::Model)
+
+@doc """
+    getnodecount(m::Model)
+
+returns the number of explored branch-and-bound nodes, if it is implemented.
+""" getnodecount(m::Model)
+
+@doc """
+    getobjbound(m::Model)
+
+returns the best known bound on the optimal objective value. This is used, for example, when a branch-and-bound method is stopped before finishing.
+""" getobjbound(m::Model)
+
+@doc """
+    getobjgap(m::Model)
+
+returns the final relative optimality gap as optimization terminated. That is, it returns ``\frac{|b-f|}{|f|}``, where *b* is the best bound and *f* is the best feasible objective value.
+""" getobjgap(m::Model)
+
+@doc """
+    getrawsolver(m::Model)
+
+returns an object that may be used to access a solver-specific API.
+""" getrawsolver(m::Model)
+
+@doc """
+    getsimplexiter(m::Model)
+
+returns the cumulative number of simplex iterations during the optimization process. In particular, for a MIP it returns the total simplex iterations for all nodes.
+""" getsimplexiter(m::Model)
+
+@doc """
+    getbarrieriter(m::Model)
+
+returns the cumulative number of barrier iterations during the optimization process.
+""" getbarrieriter(m::Model)
+
+
 """
     getobjective(m::Model)
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -216,6 +216,11 @@ for f in MathProgBase.SolverInterface.methods_by_tag[:rewrap]
     eval(Expr(:export,f))
 end
 
+"""
+    getobjective(m::Model)
+
+returns the objective function as a `QuadExpr`
+"""
 function getobjective(m::Model)
     traits = ProblemTraits(m)
     if traits.nlp
@@ -224,9 +229,32 @@ function getobjective(m::Model)
     return m.obj
 end
 
+"""
+    getobjectivebound(m::Model)
+
+returns the best known bound on the optimal objective value after a call to `solve`
+"""
 getobjectivebound(m::Model) = m.objBound
+
+"""
+    getobjectivevalue(m::Model)
+
+returns objective value after a call to `solve`
+"""
 getobjectivevalue(m::Model) = m.objVal
+
+"""
+    getobjectivesense(m::Model)
+
+returns objective sense, either `:Min` or `:Max`
+"""
 getobjectivesense(m::Model) = m.objSense
+
+"""
+    setobjectivesense(m::Model, newSense::Symbol)
+
+sets the objective sense (`newSense` is either `:Min` or `:Max`)
+"""
 function setobjectivesense(m::Model, newSense::Symbol)
     if (newSense != :Max && newSense != :Min)
         error("Model sense must be :Max or :Min")

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -40,7 +40,7 @@ end
 """
     linearterms(aff::GenericAffExpr)
 
-Provides an iterator over the `(a_i::C,x_i::V)` terms in affine expression ``\sum_i a_i x_i + b``.
+Provides an iterator over the `(a_i::C,x_i::V)` terms in affine expression ``\\sum_i a_i x_i + b``.
 """
 linearterms(aff::GenericAffExpr) = LinearTermIterator(aff)
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -348,6 +348,16 @@ constructconstraint!(x::AbstractMatrix, ::PSDCone) = SDConstraint(x)
 
 constraint_error(args, str) = error("In @constraint($(join(args,","))): ", str)
 
+"""
+    @constraint(m::Model, con)
+
+add linear or quadratic constraints.
+
+    @constraint(m::Model, ref, con)
+
+add groups of linear or quadratic constraints.
+
+"""
 macro constraint(args...)
     # Pick out keyword arguments
     if isexpr(args[1],:parameters) # these come if using a semicolon
@@ -493,6 +503,12 @@ macro constraint(args...)
     end)
 end
 
+
+"""
+    @SDconstraint(m, x)
+
+Adds a semidefinite constraint to the `Model m`. The expression `x` must be a square, two-dimensional array.
+"""
 macro SDconstraint(m, x)
     m = esc(m)
 
@@ -529,6 +545,12 @@ macro SDconstraint(m, x)
     end)
 end
 
+
+"""
+    @LinearConstraint(x)
+
+Constructs a `LinearConstraint` instance efficiently by parsing the `x`. The same as `@constraint`, except it does not attach the constraint to any model.
+"""
 macro LinearConstraint(x)
     (x.head == :block) &&
         error("Code block passed as constraint. Perhaps you meant to use @LinearConstraints instead?")
@@ -577,6 +599,11 @@ macro LinearConstraint(x)
     end
 end
 
+"""
+    @QuadConstraint(x)
+
+Constructs a `QuadConstraint` instance efficiently by parsing the `x`. The same as `@constraint`, except it does not attach the constraint to any model.
+"""
 macro QuadConstraint(x)
     (x.head == :block) &&
         error("Code block passed as constraint. Perhaps you meant to use @QuadConstraints instead?")
@@ -735,6 +762,24 @@ macro Expression(x)
 end
 
 
+"""
+    @expression(args...)
+
+efficiently builds a linear, quadratic, or second-order cone expression but does not add to model immediately. Instead, returns the expression which can then be inserted in other constraints. For example:
+
+    @expression(m, shared, sum(i*x[i] for i=1:5))
+    @constraint(m, shared + y >= 5)
+    @constraint(m, shared + z <= 10)
+
+The `ref` accepts index sets in the same way as `@variable`, and those indices can be used in the construction of the expressions:
+
+    @expression(m, expr[i=1:3], i*sum(x[j] for j=1:3))
+
+Anonymous syntax is also supported:
+
+    expr = @expression(m, [i=1:3], i*sum(x[j] for j=1:3))
+
+"""
 macro expression(args...)
     if length(args) == 3
         m = esc(args[1])

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -730,6 +730,37 @@ for (mac,sym) in [(:constraints,  Symbol("@constraint")),
     end
 end
 
+
+# Doc strings for the auto-generated macro pluralizations
+@doc """
+    @constraints(m, args...)
+
+adds groups of constraints at once, in the same fashion as @constraint. The model must be the first argument, and multiple constraints can be added on multiple lines wrapped in a `begin ... end` block. For example:
+
+    @constraints(m, begin
+      x >= 1
+      y - w <= 2
+      sum_to_one[i=1:3], z[i] + y == 1
+    end)
+""" :(@constraints)
+
+@doc """
+    @LinearConstraints(m, args...)
+
+Constructs a vector of `LinearConstraint` objects. Similar to `@LinearConstraint`, except it accepts multiple constraints as input as long as they are separated by newlines.
+""" :(@LinearConstraints)
+
+@doc """
+    @QuadConstraints(m, args...)
+
+Constructs a vector of `QuadConstraint` objects. Similar to `@QuadConstraint`, except it accepts multiple constraints as input as long as they are separated by newlines.
+""" :(@QuadConstraints)
+
+
+
+
+
+
 macro objective(m, args...)
     m = esc(m)
     if length(args) != 2

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -798,18 +798,23 @@ end
 
 efficiently builds a linear, quadratic, or second-order cone expression but does not add to model immediately. Instead, returns the expression which can then be inserted in other constraints. For example:
 
-    @expression(m, shared, sum(i*x[i] for i=1:5))
-    @constraint(m, shared + y >= 5)
-    @constraint(m, shared + z <= 10)
+```julia
+@expression(m, shared, sum(i*x[i] for i=1:5))
+@constraint(m, shared + y >= 5)
+@constraint(m, shared + z <= 10)
+```
 
 The `ref` accepts index sets in the same way as `@variable`, and those indices can be used in the construction of the expressions:
 
-    @expression(m, expr[i=1:3], i*sum(x[j] for j=1:3))
+```julia
+@expression(m, expr[i=1:3], i*sum(x[j] for j=1:3))
+```
 
 Anonymous syntax is also supported:
 
-    expr = @expression(m, [i=1:3], i*sum(x[j] for j=1:3))
-
+```julia
+expr = @expression(m, [i=1:3], i*sum(x[j] for j=1:3))
+```
 """
 macro expression(args...)
     if length(args) == 3

--- a/src/norms.jl
+++ b/src/norms.jl
@@ -121,6 +121,11 @@ end
 # Alias for the AffExpr case
 const SOCConstraint = GenericSOCConstraint{SOCExpr}
 
+"""
+    addconstraint(m::Model, c::SOCConstraint)
+
+Add a SOC constraint to `Model m`.
+"""
 function addconstraint(m::Model, c::SOCConstraint)
     push!(m.socconstr,c)
     m.internalModelLoaded = false

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -88,6 +88,11 @@ function Base.copy(q::QuadExpr, new_model::Model)
                 copy(q.qcoeffs), copy(q.aff, new_model))
 end
 
+"""
+    getvalue(a::QuadExpr)
+
+Evaluate a `QuadExpr` given the current solution values.
+"""
 function getvalue(a::QuadExpr)
     ret = getvalue(a.aff)
     for it in 1:length(a.qvars1)
@@ -117,6 +122,11 @@ function Base.copy(c::QuadConstraint, new_model::Model)
     return QuadConstraint(copy(c.terms, new_model), c.sense)
 end
 
+"""
+    addconstraint(m::Model, c::QuadConstraint)
+
+Add a quadratic constraint to `Model m`.
+"""
 function addconstraint(m::Model, c::QuadConstraint)
     push!(m.quadconstr,c)
     if m.internalModelLoaded

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -141,6 +141,14 @@ function fillConicDuals(m::Model)
 
 end
 
+"""
+    solve(m::Model; suppress_warnings=false,
+                ignore_solve_hook=(m.solvehook===nothing),
+                relaxation=false,
+                kwargs...)
+
+solves the model using the selected solver (or a default for the problem class), and takes two optional arguments that are disabled by default. Setting `suppress_warnings` to `true` will suppress all JuMP-specific output (e.g. warnings about infeasibility and lack of dual information) but will not suppress solver output (which should be done by passing options to the solver). Setting `relaxation=true` solves the standard continuous relaxation for the model: that is, integrality is dropped, special ordered set constraints are not enforced, and semi-continuous and semi-integer variables with bounds `[l,u]` are replaced with bounds `[min(l,0),max(u,0)]`
+"""
 function solve(m::Model; suppress_warnings=false,
                 ignore_solve_hook=(m.solvehook===nothing),
                 relaxation=false,
@@ -291,8 +299,14 @@ function solve(m::Model; suppress_warnings=false,
     stat
 end
 
-# Converts the JuMP Model into a MathProgBase model based on the
-# traits of the model
+
+"""
+    build(m::Model; suppress_warnings=false, 
+        relaxation=false, 
+        traits=ProblemTraits(m,relaxation=relaxation))
+
+builds the model in memory at the MathProgBase level without optimizing.
+"""
 function build(m::Model; suppress_warnings=false, relaxation=false, traits=ProblemTraits(m,relaxation=relaxation))
     if isa(m.solver, UnsetSolver)
         no_solver_error(traits)

--- a/src/sos.jl
+++ b/src/sos.jl
@@ -43,6 +43,11 @@ end
 
 addSOS1(m::Model, coll) = addSOS1(m, convert(Vector{AffExpr}, coll))
 
+"""
+    addSOS1(m::Model, coll::Vector{AffExpr})
+
+Adds special ordered set constraint of type 1 (SOS1). Specify the set as a vector of weighted variables, e.g. `coll = [3x, y, 2z]`. Note that solvers expect the weights to be unique. See [here](http://lpsolve.sourceforge.net/5.5/SOS.htm) for more details. If there is no inherent weighting in your model, an SOS constraint is probably unnecessary.
+"""
 function addSOS1(m::Model, coll::Vector{AffExpr})
     vars, weight = constructSOS(m,coll)
     push!(m.sosconstr, SOSConstraint(vars, weight, :SOS1))
@@ -59,6 +64,11 @@ end
 
 addSOS2(m::Model, coll) = addSOS2(m, convert(Vector{AffExpr}, coll))
 
+"""
+    addSOS2(m::Model, coll::Vector{AffExpr})
+
+Adds special ordered set constraint of type 2 (SOS2). Specify the set as a vector of weighted variables, e.g. `coll = [3x, y, 2z]`. Note that solvers expect the weights to be unique. See [here](http://lpsolve.sourceforge.net/5.5/SOS.htm) for more details.
+"""
 function addSOS2(m::Model, coll::Vector{AffExpr})
     vars, weight = constructSOS(m,coll)
     push!(m.sosconstr, SOSConstraint(vars, weight, :SOS2))

--- a/src/writers.jl
+++ b/src/writers.jl
@@ -3,6 +3,11 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""
+    writeMPS(m::Model, fname::AbstractString)
+
+write the model to `fname` in the MPS file format.
+"""
 function writeMPS(m::Model, fname::AbstractString)
     f = open(fname, "w")
 
@@ -188,6 +193,11 @@ function varname_given(m::Model, col::Integer)
     name
 end
 
+"""
+    writeLP(m::Model, fname::AbstractString; genericnames=true)
+
+write the model to `fname` in the LP file format. Set `genericnames=false` for user-defined variable names.
+"""
 function writeLP(m::Model, fname::AbstractString; genericnames=true)
     varname = genericnames ? varname_generic : varname_given
 


### PR DESCRIPTION
My best effort to migrate the documentation to use Docstrings.  I focused on just moving the existing text around, and did not consider any organization or polishing yet.  

Things I could use help with,
- finding the remaining functions mentioned in refmodel.md, refvariable.md
- it is not clear how to best document the macro pluralization feature in refexpr.md 
- If macros don't have types, does a type signature in their documentation make sense?
- it looks like latex is not rendering inside doc strings (e.g.  refexpr.md, `linearterms(aff::GenericAffExpr)`) may need to apply the recommended fix

Some improvements to consider during this sprint,
- Incorporating doc strings highlights the mix of manual and library docs, I am in favor of breaking these into two sections at the top level
- Is there a resonable way to incorporate the epic nodes in JuMP's code (For example, "Let S₊ be the cone of symmetric semidefinite matrices in" note in JuMP.jl) into docstrings that get into the developer docs?
