### PR TITLE
fix showerror for VariableNotOwnedError

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -693,7 +693,7 @@ type VariableNotOwnedError <: Exception
     context::String
 end
 function Base.showerror(io::IO, ex::VariableNotOwnedError)
-    print(io, "VariableNotOwnedError: Variable not owned by model present in $context")
+    print(io, "VariableNotOwnedError: Variable not owned by model present in $(ex.context)")
 end
 
 function verify_ownership(m::Model, vec::Vector{Variable})


### PR DESCRIPTION
Before:

```julia
julia> using JuMP, Gurobi

julia> m1 = Model(); @variable m1 x;

julia> m2 = Model(solver=GurobiSolver()); @objective m2 Min x + 1; solve(m2)
ERROR:
Stacktrace:
 [1] prepAffObjective(::JuMP.Model) at /Users/rdeits/.julia/v0.6/JuMP/src/solvers.jl:516
 [2] #build#119(::Bool, ::Bool, ::JuMP.ProblemTraits, ::Function, ::JuMP.Model) at /Users/rdeits/.julia/v0.6/JuMP/src/solvers.jl:341
 [3] (::JuMP.#kw##build)(::Array{Any,1}, ::JuMP.#build, ::JuMP.Model) at ./<missing>:0
 [4] #solve#116(::Bool, ::Bool, ::Bool, ::Array{Any,1}, ::Function, ::JuMP.Model) at /Users/rdeits/.julia/v0.6/JuMP/src/solvers.jl:176
 [5] solve(::JuMP.Model) at /Users/rdeits/.julia/v0.6/JuMP/src/solvers.jl:158SYSTEM: show(lasterr) caused an error
UndefVarError(:context)

Stacktrace:
 [1] prepAffObjective(::JuMP.Model) at /Users/rdeits/.julia/v0.6/JuMP/src/solvers.jl:516
 [2] #build#119(::Bool, ::Bool, ::JuMP.ProblemTraits, ::Function, ::JuMP.Model) at /Users/rdeits/.julia/v0.6/JuMP/src/solvers.jl:341
 [3] (::JuMP.#kw##build)(::Array{Any,1}, ::JuMP.#build, ::JuMP.Model) at ./<missing>:0
 [4] #solve#116(::Bool, ::Bool, ::Bool, ::Array{Any,1}, ::Function, ::JuMP.Model) at /Users/rdeits/.julia/v0.6/JuMP/src/solvers.jl:176
 [5] solve(::JuMP.Model) at /Users/rdeits/.julia/v0.6/JuMP/src/solvers.jl:158
 [6] eval(::Module, ::Any) at ./boot.jl:235
 [7] eval_user_input(::Any, ::Base.REPL.REPLBackend) at ./REPL.jl:66
 [8] macro expansion at ./REPL.jl:97 [inlined]
 [9] (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:73
```

after:

```julia
julia> using JuMP, Gurobi
INFO: Recompiling stale cache file /Users/rdeits/.julia/lib/v0.6/JuMP.ji for module JuMP.
^[[A
julia> m1 = Model(); @variable m1 x;

julia> m2 = Model(solver=GurobiSolver()); @objective m2 Min x + 1; solve(m2)
ERROR: VariableNotOwnedError: Variable not owned by model present in objective
Stacktrace:
 [1] prepAffObjective(::JuMP.Model) at /Users/rdeits/.julia/v0.6/JuMP/src/solvers.jl:516
 [2] #build#119(::Bool, ::Bool, ::JuMP.ProblemTraits, ::Function, ::JuMP.Model) at /Users/rdeits/.julia/v0.6/JuMP/src/solvers.jl:341
 [3] (::JuMP.#kw##build)(::Array{Any,1}, ::JuMP.#build, ::JuMP.Model) at ./<missing>:0
 [4] #solve#116(::Bool, ::Bool, ::Bool, ::Array{Any,1}, ::Function, ::JuMP.Model) at /Users/rdeits/.julia/v0.6/JuMP/src/solvers.jl:176
 [5] solve(::JuMP.Model) at /Users/rdeits/.julia/v0.6/JuMP/src/solvers.jl:158
```