### PR TITLE
JuMP/MOI: Basic support for quadratic expressions and constraints

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -74,7 +74,7 @@ const FIXREF = MOICON{MOI.SingleVariable,MOI.EqualTo{Float64}}
 const INTREF = MOICON{MOI.SingleVariable,MOI.Integer}
 const BINREF = MOICON{MOI.SingleVariable,MOI.ZeroOne}
 
-@MOIU.instance JuMPInstance (ZeroOne, Integer) (EqualTo, GreaterThan, LessThan, Interval) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone, RotatedSecondOrderCone, PositiveSemidefiniteConeTriangle) () (SingleVariable,) (ScalarAffineFunction,) (VectorOfVariables,) (VectorAffineFunction,)
+@MOIU.instance JuMPInstance (ZeroOne, Integer) (EqualTo, GreaterThan, LessThan, Interval) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone, RotatedSecondOrderCone, PositiveSemidefiniteConeTriangle) () (SingleVariable,) (ScalarAffineFunction,ScalarQuadraticFunction) (VectorOfVariables,) (VectorAffineFunction,)
 
 # dummy solver
 type UnsetSolver <: MathOptInterface.AbstractSolver
@@ -545,37 +545,10 @@ end
 # linearindex(x::ConstraintRef) = x.idx
 
 ###############################################################################
-# GenericAffineExpression, AffExpr
-# GenericRangeConstraint, LinearConstraint
+# GenericAffineExpression, AffExpr, AffExprConstraint
 include("affexpr.jl")
 
-struct VectorAffineConstraint{S <: MOI.AbstractVectorSet} <: AbstractConstraint
-    func::Vector{AffExpr}
-    set::S
-end
 
-"""
-    addconstraint(m::Model, c::VectorAffineConstraint)
-
-Add the vector constraint `c` to `Model m`.
-"""
-function addconstraint(m::Model, c::VectorAffineConstraint)
-    @assert !m.solverinstanceattached # TODO
-    cref = MOI.addconstraint!(m.instance, MOI.VectorAffineFunction(c.func), c.set)
-    return ConstraintRef(m, cref)
-end
-
-# const LinConstrRef = ConstraintRef{Model,LinearConstraint}
-
-# LinearConstraint(ref::LinConstrRef) = ref.m.linconstr[ref.idx]::LinearConstraint
-
-
-function constraintobject(cref::ConstraintRef{Model}, ::Type{AffExpr})
-    m = cref.m
-    f = MOI.get(m.instance, MOI.ConstraintFunction(), cref.instanceref)
-    s = MOI.get(m.instance, MOI.ConstraintSet(), cref.instanceref)
-    return LinearConstraint(AffExpr(m, f), s)
-end
 
 ###############################################################################
 # GenericQuadExpr, QuadExpr

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -11,8 +11,7 @@
 # Defines all types relating to expressions with a quadratic and affine part
 # - GenericQuadExpr             ∑qᵢⱼ xᵢⱼ  +  ∑ aᵢ xᵢ  +  c
 #   - QuadExpr                  Alias for (Float64, Variable)
-# - GenericQuadConstraint       ∑qᵢⱼ xᵢⱼ  +  ∑ aᵢ xᵢ  +  c  [≤,≥]  0
-#   - QuadConstraint            Alias for (Float64, Variable)
+# - QuadExprConstraint       ∑qᵢⱼ xᵢⱼ  +  ∑ aᵢ xᵢ  +  c  in set
 # Operator overloads in src/operators.jl
 #############################################################################
 
@@ -61,25 +60,59 @@ function Base.isequal{T,S}(q::GenericQuadExpr{T,S},other::GenericQuadExpr{T,S})
     return true
 end
 
+# Check if two QuadExprs are equal regardless of the order, and after merging duplicates
+# Mostly useful for testing.
+function isequal_canonical(quad::GenericQuadExpr{CoefType,VarType}, other::GenericQuadExpr{CoefType,VarType}) where {CoefType,VarType}
+    function canonicalize(q)
+        d = Dict{Set{VarType},CoefType}()
+        @assert length(q.qvars1) == length(q.qvars2) == length(q.qcoeffs)
+        for (v1,v2,c) in zip(q.qvars1, q.qvars2, q.qcoeffs)
+            vset = Set((v1,v2))
+            d[vset] = c + get(d, vset, zero(CoefType))
+        end
+        return d
+    end
+    d1 = canonicalize(quad)
+    d2 = canonicalize(other)
+    return isequal(d1,d1) && isequal_canonical(quad.aff, other.aff)
+end
+
 # Alias for (Float64, Variable)
 const QuadExpr = GenericQuadExpr{Float64,Variable}
 Base.convert(::Type{QuadExpr}, v::Union{Real,Variable,AffExpr}) = QuadExpr(Variable[], Variable[], Float64[], AffExpr(v))
 QuadExpr() = zero(QuadExpr)
 
-# function setobjective(m::Model, sense::Symbol, q::QuadExpr)
-#     m.obj = q
-#     if m.internalModelLoaded
-#         if method_exists(MathProgBase.setquadobjterms!, (typeof(m.internalModel), Vector{Cint}, Vector{Cint}, Vector{Float64}))
-#             verify_ownership(m, m.obj.qvars1)
-#             verify_ownership(m, m.obj.qvars2)
-#             MathProgBase.setquadobjterms!(m.internalModel, Cint[v.col for v in m.obj.qvars1], Cint[v.col for v in m.obj.qvars2], m.obj.qcoeffs)
-#         else
-#             isa(m.internalModel, MathProgBase.AbstractLinearQuadraticModel) && Base.warn_once("Solver does not support adding a quadratic objective to an existing model. JuMP's internal model will be discarded.")
-#             m.internalModelLoaded = false
-#         end
-#     end
-#     setobjectivesense(m, sense)
-# end
+function MOI.ScalarQuadraticFunction(q::QuadExpr)
+    return MOI.ScalarQuadraticFunction(instancereference.(q.aff.vars), q.aff.coeffs, instancereference.(q.qvars1), instancereference.(q.qvars2), q.qcoeffs, q.aff.constant)
+end
+
+function QuadExpr(m::Model, f::MOI.ScalarQuadraticFunction)
+    return QuadExpr(Variable.(m,f.quadratic_rowvariables), Variable.(m, f.quadratic_colvariables), f.quadratic_coefficients, AffExpr(Variable.(m,f.affine_variables), f.affine_coefficients, f.constant))
+end
+
+function setobjective(m::Model, sense::Symbol, a::QuadExpr)
+    @assert !m.solverinstanceattached # TODO
+    if sense == :Min
+        moisense = MOI.MinSense
+    else
+        @assert sense == :Max
+        moisense = MOI.MaxSense
+    end
+    MOI.set!(m.instance, MOI.ObjectiveSense(), moisense)
+    MOI.set!(m.instance, MOI.ObjectiveFunction(), MOI.ScalarQuadraticFunction(a))
+    nothing
+end
+
+"""
+    objectivefunction(m::Model, ::Type{QuadExpr})
+
+Return a `QuadExpr` object representing the objective function.
+Error if the objective is not quadratic.
+"""
+function objectivefunction(m::Model, ::Type{QuadExpr})
+    f = MOI.get(m.instance, MOI.ObjectiveFunction())::MOI.ScalarQuadraticFunction
+    return QuadExpr(m, f)
+end
 
 # Copy a quadratic expression to a new model by converting all the
 # variables to the new model's variables
@@ -105,67 +138,27 @@ end
 
 
 ##########################################################################
-# GenericQuadConstraint
-# ∑qᵢⱼ xᵢⱼ  +  ∑ aᵢ xᵢ  +  c  [≤,≥]  0
-# As RHS is implicitly taken to be zero, we store only LHS and sense
-type GenericQuadConstraint{QuadType} <: AbstractConstraint
-    terms::QuadType
-    sense::Symbol
-end
-Base.copy{CON<:GenericQuadConstraint}(c::CON, new_model::Model) = CON(copy(c.terms, new_model), c.sense)
+# TODO: GenericQuadExprConstraint
 
-
-# Alias for (Float64, Variable)
-const QuadConstraint = GenericQuadConstraint{QuadExpr}
-
-function Base.copy(c::QuadConstraint, new_model::Model)
-    return QuadConstraint(copy(c.terms, new_model), c.sense)
+struct QuadExprConstraint{S <: MOI.AbstractScalarSet} <: AbstractConstraint
+    func::QuadExpr
+    set::S
 end
 
-# """
-#     addconstraint(m::Model, c::QuadConstraint)
-#
-# Add a quadratic constraint to `Model m`.
-# """
-# function addconstraint(m::Model, c::QuadConstraint)
-#     push!(m.quadconstr,c)
-#     if m.internalModelLoaded
-#         if method_exists(MathProgBase.addquadconstr!, (typeof(m.internalModel),
-#                                                        Vector{Cint},
-#                                                        Vector{Float64},
-#                                                        Vector{Cint},
-#                                                        Vector{Cint},
-#                                                        Vector{Float64},
-#                                                        Char,
-#                                                        Float64))
-#             if !((s = string(c.sense)[1]) in ['<', '>', '='])
-#                 error("Invalid sense for quadratic constraint")
-#             end
-#             terms = c.terms
-#             verify_ownership(m, terms.qvars1)
-#             verify_ownership(m, terms.qvars2)
-#             MathProgBase.addquadconstr!(m.internalModel,
-#                                         Cint[v.col for v in c.terms.aff.vars],
-#                                         c.terms.aff.coeffs,
-#                                         Cint[v.col for v in c.terms.qvars1],
-#                                         Cint[v.col for v in c.terms.qvars2],
-#                                         c.terms.qcoeffs,
-#                                         s,
-#                                         -c.terms.aff.constant)
-#         else
-#             Base.warn_once("Solver does not appear to support adding quadratic constraints to an existing model. JuMP's internal model will be discarded.")
-#             m.internalModelLoaded = false
-#         end
-#     end
-#     return ConstraintRef{Model,QuadConstraint}(m,length(m.quadconstr))
-# end
-# addconstraint(m::Model, c::Array{QuadConstraint}) =
-#     error("Vectorized constraint added without elementwise comparisons. Try using one of (.<=,.>=,.==).")
-#
-# function addVectorizedConstraint(m::Model, v::Array{QuadConstraint})
-#     ret = Array{ConstraintRef{Model,QuadConstraint}}(size(v))
-#     for I in eachindex(v)
-#         ret[I] = addconstraint(m, v[I])
-#     end
-#     ret
-# end
+"""
+    addconstraint(m::Model, c::QuadExprConstraint)
+
+Add a `QuadExpr` constraint to `Model m`.
+"""
+function addconstraint(m::Model, c::QuadExprConstraint)
+    @assert !m.solverinstanceattached # TODO
+    cref = MOI.addconstraint!(m.instance, MOI.ScalarQuadraticFunction(c.func), c.set)
+    return ConstraintRef(m, cref)
+end
+
+function constraintobject(cref::ConstraintRef{Model}, ::Type{QuadExpr}, ::Type{SetType}) where {SetType <: MOI.AbstractScalarSet}
+    m = cref.m
+    f = MOI.get(m.instance, MOI.ConstraintFunction(), cref.instanceref)::MOI.ScalarQuadraticFunction
+    s = MOI.get(m.instance, MOI.ConstraintSet(), cref.instanceref)::SetType
+    return QuadExprConstraint(QuadExpr(m, f), s)
+end

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -1,24 +1,49 @@
 
 
 @testset "Constraints" begin
-    @testset "Linear constraints" begin
+    @testset "AffExpr constraints" begin
         m = Model()
         @variable(m, x)
 
         cref = @constraint(m, 2x <= 10)
-        c = JuMP.constraintobject(cref, AffExpr)
+        c = JuMP.constraintobject(cref, AffExpr, MOI.LessThan)
         @test JuMP.isequal_canonical(c.func, 2x)
         @test c.set == MOI.LessThan(10.0)
+        @test_throws TypeError JuMP.constraintobject(cref, QuadExpr, MOI.LessThan)
+        @test_throws TypeError JuMP.constraintobject(cref, AffExpr, MOI.EqualTo)
 
         cref = @constraint(m, 3x + 1 ≥ 10)
-        c = JuMP.constraintobject(cref, AffExpr)
+        c = JuMP.constraintobject(cref, AffExpr, MOI.GreaterThan)
         @test JuMP.isequal_canonical(c.func, 3x)
         @test c.set == MOI.GreaterThan(9.0)
 
         cref = @constraint(m, 1 == -x)
-        c = JuMP.constraintobject(cref, AffExpr)
+        c = JuMP.constraintobject(cref, AffExpr, MOI.EqualTo)
         @test JuMP.isequal_canonical(c.func, 1.0x)
         @test c.set == MOI.EqualTo(-1.0)
 
+    end
+
+    @testset "QuadExpr constraints" begin
+        m = Model()
+        @variable(m, x)
+        @variable(m, y)
+
+        cref = @constraint(m, x^2 + x <= 1)
+        c = JuMP.constraintobject(cref, QuadExpr, MOI.LessThan)
+        @test JuMP.isequal_canonical(c.func, x^2 + x)
+        @test c.set == MOI.LessThan(1.0)
+
+        cref = @constraint(m, y*x - 1.0 == 0.0)
+        c = JuMP.constraintobject(cref, QuadExpr, MOI.EqualTo)
+        @test JuMP.isequal_canonical(c.func, x*y)
+        @test c.set == MOI.EqualTo(1.0)
+        @test_throws TypeError JuMP.constraintobject(cref, QuadExpr, MOI.LessThan)
+        @test_throws TypeError JuMP.constraintobject(cref, AffExpr, MOI.EqualTo)
+
+        # cref = @constraint(m, [x^2 - 1] in MOI.SecondOrderCone(1))
+        # c = JuMP.constraintobject(cref, QuadExpr, MOI.SecondOrderCone)
+        # @test JuMP.isequal_canonical(c.func, -1 + x^2)
+        # @test c.set == MOI.SecondOrderCone(1)
     end
 end

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -13,4 +13,14 @@
         @test JuMP.objectivesense(m) == :Max
         @test JuMP.isequal_canonical(JuMP.objectivefunction(m, AffExpr), 4x + 1)
     end
+
+    @testset "Quadratic objectives" begin
+        m = Model()
+        @variable(m, x)
+
+        @objective(m, Min, x^2 + 2x)
+        @test JuMP.objectivesense(m) == :Min
+        @test JuMP.isequal_canonical(JuMP.objectivefunction(m, QuadExpr), x^2 + 2x)
+        @test_throws TypeError JuMP.objectivefunction(m, AffExpr)
+    end
 end

--- a/test/print.jl
+++ b/test/print.jl
@@ -47,14 +47,21 @@ end
         io_test(REPLMode, ex, "2 x[1] + 2 y[2,3]")
         io_test(IJuliaMode, ex, "2 x_{1} + 2 y_{2,3}")
 
-        # TODO: Quadratic expressions
-        # ex = @expression(mod, (x[1]+x[2])*(y[2,2]+3.0))
-        # io_test(REPLMode, ex, "x[1]*y[2,2] + x[2]*y[2,2] + 3 x[1] + 3 x[2] - 1")
-        # io_test(IJuliaMode, ex, "x_{1}\\times y_{2,2} + x_{2}\\times y_{2,2} + 3 x_{1} + 3 x_{2} - 1")
-        #
-        # ex = @expression(mod, (y[2,2]+3.0)*(x[1]+x[2]))
-        # io_test(REPLMode, ex, "x[1]*y[2,2] + x[2]*y[2,2] + 3 x[1] + 3 x[2] - 1")
-        # io_test(IJuliaMode, ex, "x_{1}\\times y_{2,2} + x_{2}\\times y_{2,2} + 3 x_{1} + 3 x_{2} - 1")
+        ex = @expression(mod, (x[1]+x[2])*(y[2,2]+3.0))
+        io_test(REPLMode, ex, "x[1]*y[2,2] + x[2]*y[2,2] + 3 x[1] + 3 x[2]")
+        io_test(IJuliaMode, ex, "x_{1}\\times y_{2,2} + x_{2}\\times y_{2,2} + 3 x_{1} + 3 x_{2}")
+
+        ex = @expression(mod, (y[2,2]+3.0)*(x[1]+x[2]))
+        io_test(REPLMode, ex, "y[2,2]*x[1] + y[2,2]*x[2] + 3 x[1] + 3 x[2]")
+        io_test(IJuliaMode, ex, "y_{2,2}\\times x_{1} + y_{2,2}\\times x_{2} + 3 x_{1} + 3 x_{2}")
+
+        ex = @expression(mod, (x[1]+x[2])*(y[2,2]+3.0) + z^2 - 1)
+        io_test(REPLMode, ex, "x[1]*y[2,2] + x[2]*y[2,2] + z$(repl[:sq]) + 3 x[1] + 3 x[2] - 1")
+        io_test(IJuliaMode, ex, "x_{1}\\times y_{2,2} + x_{2}\\times y_{2,2} + z$(ijulia[:sq]) + 3 x_{1} + 3 x_{2} - 1")
+
+        ex = @expression(mod, -z*x[1] - x[1]*z + x[1]*x[2] + 0*z^2)
+        io_test(REPLMode, ex, "-2 z*x[1] + x[1]*x[2]")
+        io_test(IJuliaMode, ex, "-2 z\\times x_{1} + x_{1}\\times x_{2}")
     end
 
     @testset "Variable" begin


### PR DESCRIPTION
~Quadratic objectives don't yet work because of https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl/issues/12~

- Renamed `LinearConstraint` to `AffExprConstraint`
- Similarly, `QuadExprConstraint`