### PR TITLE
SDP constraint

### DIFF
--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -257,3 +257,10 @@ function constraintobject(cref::ConstraintRef{Model}, ::Type{AffExpr}, ::Type{Se
     s = MOI.get(m.instance, MOI.ConstraintSet(), cref.instanceref)::SetType
     return AffExprConstraint(AffExpr(m, f), s)
 end
+
+function constraintobject(cref::ConstraintRef{Model}, ::Type{Vector{AffExpr}}, ::Type{SetType}) where {SetType <: MOI.AbstractVectorSet}
+    m = cref.m
+    f = MOI.get(m.instance, MOI.ConstraintFunction(), cref.instanceref)::MOI.VectorAffineFunction
+    s = MOI.get(m.instance, MOI.ConstraintSet(), cref.instanceref)::SetType
+    return VectorAffExprConstraint(map(f -> AffExpr(m, f), f), s)
+end

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -262,5 +262,5 @@ function constraintobject(cref::ConstraintRef{Model}, ::Type{Vector{AffExpr}}, :
     m = cref.m
     f = MOI.get(m.instance, MOI.ConstraintFunction(), cref.instanceref)::MOI.VectorAffineFunction
     s = MOI.get(m.instance, MOI.ConstraintSet(), cref.instanceref)::SetType
-    return VectorAffExprConstraint(map(f -> AffExpr(m, f), f), s)
+    return VectorAffExprConstraint(map(f -> AffExpr(m, f), MOIU.eachscalar(f)), s)
 end

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -31,26 +31,6 @@ Base.zero(a::GenericAffExpr) = zero(typeof(a))
 Base.one( a::GenericAffExpr) =  one(typeof(a))
 Base.copy(a::GenericAffExpr) = GenericAffExpr(copy(a.vars),copy(a.coeffs),copy(a.constant))
 
-"""
-    fill_expr!(m::Model, expr::Dict{Variable, T}, terms::GenericAffExpr{T, Variable}, coeff=one(T))
-
-Fills the dictionary `expr` with the terms of `terms` multipled by `coeff`. If `v` is a `Variable`, `expr[v]` will the sum of the terms in `terms` with variable `v` summed with the value `expr[v]` has when at the start of the function or `zero(T)` if `v` is not a key of `expr`.
-"""
-function fill_expr!(m::Model, expr::Dict{Variable, T}, terms::GenericAffExpr{T, Variable}, coeff=one(T)) where T
-    assert_isfinite(terms)
-    coeffs = terms.coeffs
-    vars = terms.vars
-    # collect duplicates
-    for ind in eachindex(coeffs)
-        if vars[ind].m === m
-            var = vars[ind]
-            expr[var] = get(expr, var, zero(T)) + coeff * coeffs[ind]
-        else
-            throw(VariableNotOwnedError("constraints"))
-        end
-    end
-end
-
 # Old iterator protocol - iterates over tuples (aᵢ,xᵢ)
 struct LinearTermIterator{GAE<:GenericAffExpr}
     aff::GAE

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -31,6 +31,26 @@ Base.zero(a::GenericAffExpr) = zero(typeof(a))
 Base.one( a::GenericAffExpr) =  one(typeof(a))
 Base.copy(a::GenericAffExpr) = GenericAffExpr(copy(a.vars),copy(a.coeffs),copy(a.constant))
 
+"""
+    fill_expr!(m::Model, expr::Dict{Variable, T}, terms::GenericAffExpr{T, Variable}, coeff=one(T))
+
+Fills the dictionary `expr` with the terms of `terms` multipled by `coeff`. If `v` is a `Variable`, `expr[v]` will the sum of the terms in `terms` with variable `v` summed with the value `expr[v]` has when at the start of the function or `zero(T)` if `v` is not a key of `expr`.
+"""
+function fill_expr!(m::Model, expr::Dict{Variable, T}, terms::GenericAffExpr{T, Variable}, coeff=one(T)) where T
+    assert_isfinite(terms)
+    coeffs = terms.coeffs
+    vars = terms.vars
+    # collect duplicates
+    for ind in eachindex(coeffs)
+        if vars[ind].m === m
+            var = vars[ind]
+            expr[var] = get(expr, var, zero(T)) + coeff * coeffs[ind]
+        else
+            throw(VariableNotOwnedError("constraints"))
+        end
+    end
+end
+
 # Old iterator protocol - iterates over tuples (aᵢ,xᵢ)
 struct LinearTermIterator{GAE<:GenericAffExpr}
     aff::GAE

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -63,7 +63,7 @@ end
 struct SDSymInstanceRef{T}
     sd::MOICON{MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle}
     # symmetry enforcing constraints, it is null if the matrix is symmetric
-    symref::Nullable{MOICON{MOI.VectorAffineFunction{T}, MOI.Zeros}}
+    symref::Union{MOICON{MOI.VectorAffineFunction{T}, MOI.Zeros}, Void}
     # if k in symidx then invtrimap(k) has a symmetry enforcing constraint in symref
     symidx::IntSet
 end
@@ -99,10 +99,10 @@ function _constrain_symmetry(m::Model, c::SDConstraint{T}, sdref) where T
         push!(symaff, aff)
     end
     if isempty(symaff)
-        symref = Nullable{MOICON{MOI.VectorAffineFunction{Float64}, MOI.Zeros}}()
+        symref = nothing
     else
         symcon = VectorAffExprConstraint(symaff, MOI.Zeros(length(symaff)))
-        symref = Nullable{MOICON{MOI.VectorAffineFunction{Float64}, MOI.Zeros}}(addconstraint(m, symcon).instanceref)
+        symref = addconstraint(m, symcon).instanceref
     end
     SDSymInstanceRef(sdref, symref, symidx)
 end

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -71,20 +71,7 @@ end
 constructconstraint!(x::AbstractMatrix, ::PSDCone) = SDConstraint(x)
 
 _constrain_symmetry(m::Model, c::SDConstraint{T, MT}, sdref) where {T, MT<:Symmetric} = sdref
-function fill_expr!(m::Model, expr::Dict{Variable, T}, terms, coeff=one(T)) where T
-    assert_isfinite(terms)
-    coeffs = terms.coeffs
-    vars = terms.vars
-    # collect duplicates
-    for ind in eachindex(coeffs)
-        if vars[ind].m === m
-            var = vars[ind]
-            expr[var] = get(expr, var, zero(T)) + coeff * coeffs[ind]
-        else
-            throw(VariableNotOwnedError("constraints"))
-        end
-    end
-end
+
 function _constrain_symmetry(m::Model, c::SDConstraint{T}, sdref) where T
     expr = Dict{Variable, Float64}()
     symaff = AffExpr[]

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -25,3 +25,113 @@ function addconstraint(m::Model, c::SDVariableConstraint)
     cref = MOI.addconstraint!(m.instance, MOI.VectorOfVariables([instancereference(c.Q[i, j]) for j in 1:n for i in 1:j]), MOI.PositiveSemidefiniteConeTriangle(n))
     return ConstraintRef(m, cref)
 end
+
+##########################################################################
+# SDConstraint is a (dual) semidefinite constraint of the form
+# ∑ cᵢ Xᵢ ⪰ D, where D is a n×n data matrix, cᵢ are scalars,
+# and Xᵢ are n×n symmetric variable matrices. The inequality
+# is taken w.r.t. the psd partial order.
+struct SDConstraint{T<:AbstractJuMPScalar, MT<:AbstractMatrix{T}} <: AbstractConstraint
+    terms::MT
+end
+SDConstraint(terms::MT) where {T<:AbstractJuMPScalar, MT<:AbstractMatrix{T}} = SDConstraint{T, MT}(terms)
+
+"""
+    trimap(i, j)
+
+Returns the vectorized index `k` corresponding to the matrix indices `(i, j)`.
+"""
+function trimap(i::Integer, j::Integer)
+    if i < j
+        trimap(j, i)
+    else
+        div((i-1)*i, 2) + j
+    end
+end
+
+"""
+    invtrimap(i, j)
+
+Returns the matrix indices `(i, j)` (`i <= j`) corresponding to the vectorized index `k`.
+"""
+function invtrimap(k::Integer)
+    i = isqrt(2k)
+    j = k - div((i-1)*i, 2)
+    i, j
+end
+
+struct SDSymInstanceRef{T}
+    sd::MOICON{MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle}
+    # symmetry enforcing constraints, it is null if the matrix is symmetric
+    symref::Nullable{MOICON{MOI.VectorAffineFunction{T}, MOI.Zeros}}
+    # if k in symidx then invtrimap(k) has a symmetry enforcing constraint in symref
+    symidx::IntSet
+end
+
+constructconstraint!(x::AbstractMatrix, ::PSDCone) = SDConstraint(x)
+
+_constrain_symmetry(m::Model, c::SDConstraint{T, MT}, sdref) where {T, MT<:Symmetric} = sdref
+function fill_expr!(m::Model, expr::Dict{Variable, T}, terms, coeff=1) where T
+    assert_isfinite(terms)
+    coeffs = terms.coeffs
+    vars = terms.vars
+    # collect duplicates
+    for ind in eachindex(coeffs)
+        if vars[ind].m === m
+            var = vars[ind]
+            expr[var] = get(expr, var, zero(T)) + coeff * coeffs[ind]
+        else
+            throw(VariableNotOwnedError("constraints"))
+        end
+    end
+end
+function _constrain_symmetry(m::Model, c::SDConstraint{T}, sdref) where T
+    expr = Dict{Variable, Float64}()
+    symaff = AffExpr[]
+    symidx = IntSet()
+    n = Base.LinAlg.checksquare(c.terms)
+    for i in 1:n, j in 1:i
+        empty!(expr)
+        fill_expr!(m, expr, c.terms[i, j])
+        fill_expr!(m, expr, c.terms[j, i], -1)
+        constant = c.terms[i, j].constant - c.terms[j, i].constant
+        # if the symmetry-enforcing row is empty or has only tiny coefficients due to unintended numerical asymmetry, drop it
+        largestabs = abs(constant)
+        for (var, coeff) in expr
+            if iszero(coeff)
+                delete!(expr, var)
+            else
+                largestabs = max(largestabs, abs(coeff))
+            end
+        end
+        if largestabs < 1e-10
+            continue
+        end
+        push!(symidx, trimap(i, j))
+        aff = AffExpr(collect(keys(expr)), collect(values(expr)), constant)
+        push!(symaff, aff)
+    end
+    if isempty(symaff)
+        symref = Nullable{MOICON{MOI.VectorAffineFunction{Float64}, MOI.Zeros}}()
+    else
+        symcon = VectorAffExprConstraint(symaff, MOI.Zeros(length(symaff)))
+        symref = Nullable{MOICON{MOI.VectorAffineFunction{Float64}, MOI.Zeros}}(addconstraint(m, symcon).instanceref)
+    end
+    SDSymInstanceRef(sdref, symref, symidx)
+end
+
+"""
+    addconstraint(m::Model, c::SDConstraint)
+
+Adds the semidefinite constraint `c` and returns a reference `cref` to the constraint.
+If `c.terms` is a matrix of type `Symmetric`, then `cref.instanceref` will be an instance constraint reference
+to the positive semidefiniteness of the matrix.
+Otherwise, `cref.instanceref` is a `SDSymInstanceRef` containing the PSD constraint and the symmetry constraints.
+"""
+function addconstraint(m::Model, c::SDConstraint)
+    @assert !m.solverinstanceattached # TODO
+    n = Base.LinAlg.checksquare(c.terms)
+    sdref = MOI.addconstraint!(m.instance, MOI.VectorAffineFunction([c.terms[i, j] for j in 1:n for i in 1:j]), MOI.PositiveSemidefiniteConeTriangle(n))
+    cref = _constrain_symmetry(m, c, sdref)
+    return ConstraintRef(m, cref)
+end

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -28,6 +28,10 @@ end
 
 function constructconstraint!(x::AbstractMatrix, ::PSDCone)
     n = Base.LinAlg.checksquare(x)
+    # Support for non-symmetric matrices as done prior to JuMP v0.19
+    # will be added once the appropriate cone has been added in MathOptInterface
+    # as discussed in the following PR:
+    # https://github.com/JuliaOpt/JuMP.jl/pull/1122#issuecomment-344980944
     @assert issymmetric(x)
     aff = [x[i, j] for j in 1:n for i in 1:j]
     s = MOI.PositiveSemidefiniteConeTriangle(n)

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -71,7 +71,7 @@ end
 constructconstraint!(x::AbstractMatrix, ::PSDCone) = SDConstraint(x)
 
 _constrain_symmetry(m::Model, c::SDConstraint{T, MT}, sdref) where {T, MT<:Symmetric} = sdref
-function fill_expr!(m::Model, expr::Dict{Variable, T}, terms, coeff=1) where T
+function fill_expr!(m::Model, expr::Dict{Variable, T}, terms, coeff=one(T)) where T
     assert_isfinite(terms)
     coeffs = terms.coeffs
     vars = terms.vars

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -26,99 +26,10 @@ function addconstraint(m::Model, c::SDVariableConstraint)
     return ConstraintRef(m, cref)
 end
 
-##########################################################################
-# SDConstraint is a (dual) semidefinite constraint of the form
-# ∑ cᵢ Xᵢ ⪰ D, where D is a n×n data matrix, cᵢ are scalars,
-# and Xᵢ are n×n symmetric variable matrices. The inequality
-# is taken w.r.t. the psd partial order.
-struct SDConstraint{T<:AbstractJuMPScalar, MT<:AbstractMatrix{T}} <: AbstractConstraint
-    terms::MT
-end
-SDConstraint(terms::MT) where {T<:AbstractJuMPScalar, MT<:AbstractMatrix{T}} = SDConstraint{T, MT}(terms)
-
-"""
-    trimap(i, j)
-
-Returns the vectorized index `k` corresponding to the matrix indices `(i, j)`.
-"""
-function trimap(i::Integer, j::Integer)
-    if i < j
-        trimap(j, i)
-    else
-        div((i-1)*i, 2) + j
-    end
-end
-
-"""
-    invtrimap(i, j)
-
-Returns the matrix indices `(i, j)` (`i <= j`) corresponding to the vectorized index `k`.
-"""
-function invtrimap(k::Integer)
-    i = isqrt(2k)
-    j = k - div((i-1)*i, 2)
-    i, j
-end
-
-struct SDSymInstanceRef{T}
-    sd::MOICON{MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle}
-    # symmetry enforcing constraints, it is null if the matrix is symmetric
-    symref::Union{MOICON{MOI.VectorAffineFunction{T}, MOI.Zeros}, Void}
-    # if k in symidx then invtrimap(k) has a symmetry enforcing constraint in symref
-    symidx::IntSet
-end
-
-constructconstraint!(x::AbstractMatrix, ::PSDCone) = SDConstraint(x)
-
-_constrain_symmetry(m::Model, c::SDConstraint{T, MT}, sdref) where {T, MT<:Symmetric} = sdref
-
-function _constrain_symmetry(m::Model, c::SDConstraint{T}, sdref) where T
-    expr = Dict{Variable, Float64}()
-    symaff = AffExpr[]
-    symidx = IntSet()
-    n = Base.LinAlg.checksquare(c.terms)
-    for i in 1:n, j in 1:i
-        empty!(expr)
-        fill_expr!(m, expr, c.terms[i, j])
-        fill_expr!(m, expr, c.terms[j, i], -1)
-        constant = c.terms[i, j].constant - c.terms[j, i].constant
-        # if the symmetry-enforcing row is empty or has only tiny coefficients due to unintended numerical asymmetry, drop it
-        largestabs = abs(constant)
-        for (var, coeff) in expr
-            if iszero(coeff)
-                delete!(expr, var)
-            else
-                largestabs = max(largestabs, abs(coeff))
-            end
-        end
-        if largestabs < 1e-10
-            continue
-        end
-        push!(symidx, trimap(i, j))
-        aff = AffExpr(collect(keys(expr)), collect(values(expr)), constant)
-        push!(symaff, aff)
-    end
-    if isempty(symaff)
-        symref = nothing
-    else
-        symcon = VectorAffExprConstraint(symaff, MOI.Zeros(length(symaff)))
-        symref = addconstraint(m, symcon).instanceref
-    end
-    SDSymInstanceRef(sdref, symref, symidx)
-end
-
-"""
-    addconstraint(m::Model, c::SDConstraint)
-
-Adds the semidefinite constraint `c` and returns a reference `cref` to the constraint.
-If `c.terms` is a matrix of type `Symmetric`, then `cref.instanceref` will be an instance constraint reference
-to the positive semidefiniteness of the matrix.
-Otherwise, `cref.instanceref` is a `SDSymInstanceRef` containing the PSD constraint and the symmetry constraints.
-"""
-function addconstraint(m::Model, c::SDConstraint)
-    @assert !m.solverinstanceattached # TODO
-    n = Base.LinAlg.checksquare(c.terms)
-    sdref = MOI.addconstraint!(m.instance, MOI.VectorAffineFunction([c.terms[i, j] for j in 1:n for i in 1:j]), MOI.PositiveSemidefiniteConeTriangle(n))
-    cref = _constrain_symmetry(m, c, sdref)
-    return ConstraintRef(m, cref)
+function constructconstraint!(x::AbstractMatrix, ::PSDCone)
+    n = Base.LinAlg.checksquare(x)
+    @assert issymmetric(x)
+    aff = [x[i, j] for j in 1:n for i in 1:j]
+    s = MOI.PositiveSemidefiniteConeTriangle(n)
+    return VectorAffExprConstraint(aff, s)
 end

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -47,6 +47,19 @@
         # @test c.set == MOI.SecondOrderCone(1)
     end
 
+    @testset "SDP constraint" begin
+        m = Model()
+        @variable(m, x)
+        @variable(m, y)
+
+        cref = @SDconstraint(m, [x 1; 1 -y] ⪰ [1 x; x -2])
+        c = JuMP.constraintobject(cref, Vector{AffExpr}, MOI.PositiveSemidefiniteConeTriangle)
+        @test JuMP.isequal_canonical(c.func[1], x-1)
+        @test JuMP.isequal_canonical(c.func[2], 1-x)
+        @test JuMP.isequal_canonical(c.func[3], 2-y)
+        @test c.set == MOI.PositiveSemidefiniteConeTriangle(2)
+    end
+
     @testset "Nonsensical SDPs" begin
         m = Model()
         @test_throws ErrorException @variable(m, unequal[1:5,1:6], PSD)

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -46,4 +46,42 @@
         # @test JuMP.isequal_canonical(c.func, -1 + x^2)
         # @test c.set == MOI.SecondOrderCone(1)
     end
+
+    @testset "Nonsensical SDPs" begin
+        m = Model()
+        @test_throws ErrorException @variable(m, unequal[1:5,1:6], PSD)
+        # Some of these errors happen at compile time, so we can't use @test_throws
+        @test macroexpand(:(@variable(m, notone[1:5,2:6], PSD))).head == :error
+        @test macroexpand(:(@variable(m, oneD[1:5], PSD))).head == :error
+        @test macroexpand(:(@variable(m, threeD[1:5,1:5,1:5], PSD))).head == :error
+        @test macroexpand(:(@variable(m, psd[2] <= rand(2,2), PSD))).head == :error
+        @test macroexpand(:(@variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), PSD))).head == :error
+        @test macroexpand(:(@variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), Symmetric))).head == :error
+        @test macroexpand(:(@variable(m, -ones(4,4) <= foo[1:4,1:4] <= ones(4,5), Symmetric))).head == :error
+        @test macroexpand(:(@variable(m, -rand(5,5) <= nonsymmetric[1:5,1:5] <= rand(5,5), Symmetric))).head == :error
+    end
+
+    @testset "Trivial symmetry constraints are removed (#766, #972)" begin
+        q = 2
+        m = 3
+        angles1 = linspace(3*pi/4, pi, m)
+        angles2 = linspace(0, -pi/2, m)
+        V = [3.*cos.(angles1)' 1.5.*cos.(angles2)';
+             3.*sin.(angles1)' 1.5.*sin.(angles2)']
+        V[abs.(V) .< 1e-10] = 0.0
+        p = 2*m
+        n = 100
+
+        mod = Model()
+        @variable(mod, x[j=1:p] >= 1, Int)
+        @variable(mod, u[i=1:q] >= 1)
+        @objective(mod, Min, sum(u))
+        @constraint(mod, sum(x) <= n)
+        for i=1:q
+            cref = @SDconstraint(mod, [V*diagm(x./n)*V' eye(q)[:,i] ; eye(q)[i:i,:] u[i]] >= 0)
+            @test cref.instanceref.symref === nothing
+            @test isempty(cref.instanceref.symidx)
+        end
+    end
+
 end

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -61,27 +61,4 @@
         @test macroexpand(:(@variable(m, -rand(5,5) <= nonsymmetric[1:5,1:5] <= rand(5,5), Symmetric))).head == :error
     end
 
-    @testset "Trivial symmetry constraints are removed (#766, #972)" begin
-        q = 2
-        m = 3
-        angles1 = linspace(3*pi/4, pi, m)
-        angles2 = linspace(0, -pi/2, m)
-        V = [3.*cos.(angles1)' 1.5.*cos.(angles2)';
-             3.*sin.(angles1)' 1.5.*sin.(angles2)']
-        V[abs.(V) .< 1e-10] = 0.0
-        p = 2*m
-        n = 100
-
-        mod = Model()
-        @variable(mod, x[j=1:p] >= 1, Int)
-        @variable(mod, u[i=1:q] >= 1)
-        @objective(mod, Min, sum(u))
-        @constraint(mod, sum(x) <= n)
-        for i=1:q
-            cref = @SDconstraint(mod, [V*diagm(x./n)*V' eye(q)[:,i] ; eye(q)[i:i,:] u[i]] >= 0)
-            @test cref.instanceref.symref === nothing
-            @test isempty(cref.instanceref.symidx)
-        end
-    end
-
 end

--- a/test/sdp.jl
+++ b/test/sdp.jl
@@ -304,28 +304,28 @@ ispsd(x::Matrix) = minimum(eigvals(x)) ≥ -1e-3
         #@test isapprox(getdual(c2), 0, atol=1e-4)
     end
 
-    function nuclear_norm(model, A)
-        m, n = size(A,1), size(A,2)
-        @variable(model, U[1:m,1:m])
-        @variable(model, V[1:n,1:n])
-        @SDconstraint(model, 0 ⪯ [U A; A' V])
-        return 0.5(trace(U) + trace(V'))
-    end
-
-    @testset "Test problem #5" begin
-        m = Model(solver=CSDPSolver(printlevel=0))
-        @variable(m, Y[1:3,1:3], PSD)
-        @constraint(m, Y[2,1] <= 4)
-        @constraint(m, Y[2,2] >= 3)
-        @constraint(m, Y[3,3] <= 2)
-        @objective(m, Min, nuclear_norm(m, Y))
-
-        JuMP.solve(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
-
-        @test isapprox(JuMP.objectivevalue(m), 3, atol=1e-5)
-    end
+#    function nuclear_norm(model, A)
+#        m, n = size(A,1), size(A,2)
+#        @variable(model, U[1:m,1:m])
+#        @variable(model, V[1:n,1:n])
+#        @SDconstraint(model, 0 ⪯ [U A; A' V])
+#        return 0.5(trace(U) + trace(V'))
+#    end
+#
+#    @testset "Test problem #5" begin
+#        m = Model(solver=CSDPSolver(printlevel=0))
+#        @variable(m, Y[1:3,1:3], PSD)
+#        @constraint(m, Y[2,1] <= 4)
+#        @constraint(m, Y[2,2] >= 3)
+#        @constraint(m, Y[3,3] <= 2)
+#        @objective(m, Min, nuclear_norm(m, Y))
+#
+#        JuMP.solve(m)
+#        @test JuMP.terminationstatus(m) == MOI.Success
+#        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+#
+#        @test isapprox(JuMP.objectivevalue(m), 3, atol=1e-5)
+#    end
 
     function operator_norm(model, A)
         m, n = size(A,1), size(A,2)
@@ -349,26 +349,26 @@ ispsd(x::Matrix) = minimum(eigvals(x)) ≥ -1e-3
         @test isapprox(JuMP.objectivevalue(m), 4, atol=1e-5)
     end
 
-    function lambda_max(model, A)
-        m, n = size(A,1), size(A,2)
-        @variable(model, t)
-        @SDconstraint(model, speye(n)*t - A ⪰ 0)
-        @SDconstraint(model, A >= 0)
-        return t
-    end
-
-    @testset "Test problem #7" begin
-        m = Model(solver=CSDPSolver(printlevel=0))
-        @variable(m, Y[1:3,1:3])
-        @constraint(m, Y[1,1] >= 4)
-        @objective(m, Min, lambda_max(m, Y))
-
-        JuMP.solve(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
-
-        @test isapprox(JuMP.objectivevalue(m), 4, atol=1e-5)
-    end
+#    function lambda_max(model, A)
+#        m, n = size(A,1), size(A,2)
+#        @variable(model, t)
+#        @SDconstraint(model, speye(n)*t - A ⪰ 0)
+#        @SDconstraint(model, A >= 0)
+#        return t
+#    end
+#
+#    @testset "Test problem #7" begin
+#        m = Model(solver=CSDPSolver(printlevel=0))
+#        @variable(m, Y[1:3,1:3])
+#        @constraint(m, Y[1,1] >= 4)
+#        @objective(m, Min, lambda_max(m, Y))
+#
+#        JuMP.solve(m)
+#        @test JuMP.terminationstatus(m) == MOI.Success
+#        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+#
+#        @test isapprox(JuMP.objectivevalue(m), 4, atol=1e-5)
+#    end
 
     function lambda_min(model, A)
         m, n = size(A,1), size(A,2)
@@ -573,60 +573,60 @@ ispsd(x::Matrix) = minimum(eigvals(x)) ≥ -1e-3
 #       @test isapprox(getdual(c), 0, atol=1e-5)
     end
 
-    # min X[1,1]     max y/2+z/2
-    # X[1,2] = 1/2   [0 y     [1 0
-    # X[2,1] = 1/2    z 0] ⪯   0 0]
-    # X+Xᵀ ⪰ 0
-    @testset "SDP with dual solution not attained without symmetric A_i" begin
-        #solver = fixscs(solver, 10000000)
-        m = Model(solver=CSDPSolver(printlevel=0))
-        @variable(m, y)
-        @variable(m, z)
-        c = @SDconstraint(m, [0 y; z 0] <= [1 0; 0 0])
-        @objective(m, Max, y/2+z/2)
-        JuMP.solve(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+#    # min X[1,1]     max y/2+z/2
+#    # X[1,2] = 1/2   [0 y     [1 0
+#    # X[2,1] = 1/2    z 0] ⪯   0 0]
+#    # X+Xᵀ ⪰ 0
+#    @testset "SDP with dual solution not attained without symmetric A_i" begin
+#        #solver = fixscs(solver, 10000000)
+#        m = Model(solver=CSDPSolver(printlevel=0))
+#        @variable(m, y)
+#        @variable(m, z)
+#        c = @SDconstraint(m, [0 y; z 0] <= [1 0; 0 0])
+#        @objective(m, Max, y/2+z/2)
+#        JuMP.solve(m)
+#        @test JuMP.terminationstatus(m) == MOI.Success
+#        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+#
+#        @test isapprox(JuMP.objectivevalue(m), 0, atol=1e-5)
+#        @test isapprox(JuMP.resultvalue(y), 0, atol=1e-5)
+#        @test isapprox(JuMP.resultvalue(z), 0, atol=1e-5)
+#
+#        #X = getdual(c)
+#        #@test isapprox(X[1,1], 0, atol=1e-5)
+#        #@test isapprox(X[1,2], 1/2, atol=1e-5)
+#        #@test isapprox(X[2,1], 1/2, atol=1e-5)
+#        #@test isapprox(getdual(y), 0, atol=1e-5)
+#        #@test isapprox(getdual(z), 0, atol=1e-5)
+#    end
 
-        @test isapprox(JuMP.objectivevalue(m), 0, atol=1e-5)
-        @test isapprox(JuMP.resultvalue(y), 0, atol=1e-5)
-        @test isapprox(JuMP.resultvalue(z), 0, atol=1e-5)
-
-        #X = getdual(c)
-        #@test isapprox(X[1,1], 0, atol=1e-5)
-        #@test isapprox(X[1,2], 1/2, atol=1e-5)
-        #@test isapprox(X[2,1], 1/2, atol=1e-5)
-        #@test isapprox(getdual(y), 0, atol=1e-5)
-        #@test isapprox(getdual(z), 0, atol=1e-5)
-    end
-
-    # min X[1,1]     max y
-    # X[1,2] = 1     [0 y     [1 0
-    # X[2,1] = 0      z 0] ⪯   0 0]
-    # X+Xᵀ ⪰ 0
-    @testset "SDP with dual solution not attained without symmetry" begin
-        #solver = fixscs(solver, 10000000)
-        m = Model(solver=CSDPSolver(printlevel=0))
-        @variable(m, y)
-        @variable(m, z)
-        c = @SDconstraint(m, [0 y; z 0] <= [1 0; 0 0])
-        @objective(m, Max, y)
-
-        JuMP.solve(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
-
-        @test isapprox(JuMP.objectivevalue(m), 0, atol=1e-5)
-        @test isapprox(JuMP.resultvalue(y), 0, atol=1e-5)
-        @test isapprox(JuMP.resultvalue(z), 0, atol=1e-5)
-
-        #X = getdual(c)
-        #@test isapprox(X[1,1], 0, atol=1e-5)
-        #@test isapprox(X[1,2], 1, atol=1e-5) # X is not symmetric !
-        #@test isapprox(X[2,1], 0, atol=1e-5)
-        #@test isapprox(getdual(y), 0, atol=1e-5)
-        #@test isapprox(getdual(z), 0, atol=1e-5)
-    end
+#    # min X[1,1]     max y
+#    # X[1,2] = 1     [0 y     [1 0
+#    # X[2,1] = 0      z 0] ⪯   0 0]
+#    # X+Xᵀ ⪰ 0
+#    @testset "SDP with dual solution not attained without symmetry" begin
+#        #solver = fixscs(solver, 10000000)
+#        m = Model(solver=CSDPSolver(printlevel=0))
+#        @variable(m, y)
+#        @variable(m, z)
+#        c = @SDconstraint(m, [0 y; z 0] <= [1 0; 0 0])
+#        @objective(m, Max, y)
+#
+#        JuMP.solve(m)
+#        @test JuMP.terminationstatus(m) == MOI.Success
+#        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+#
+#        @test isapprox(JuMP.objectivevalue(m), 0, atol=1e-5)
+#        @test isapprox(JuMP.resultvalue(y), 0, atol=1e-5)
+#        @test isapprox(JuMP.resultvalue(z), 0, atol=1e-5)
+#
+#        #X = getdual(c)
+#        #@test isapprox(X[1,1], 0, atol=1e-5)
+#        #@test isapprox(X[1,2], 1, atol=1e-5) # X is not symmetric !
+#        #@test isapprox(X[2,1], 0, atol=1e-5)
+#        #@test isapprox(getdual(y), 0, atol=1e-5)
+#        #@test isapprox(getdual(z), 0, atol=1e-5)
+#    end
 
     @testset "Nonzero dual for a scalar variable with sdp solver" begin
         m = Model(solver=CSDPSolver(printlevel=0))

--- a/test/sdp.jl
+++ b/test/sdp.jl
@@ -1,4 +1,7 @@
 @testset "Semidefinite Programming" begin
+
+ispsd(x::Matrix) = minimum(eigvals(x)) ≥ -1e-3
+
     @testset "SDP1" begin
         # Problem SDP1 - sdo1 from MOSEK docs
         # From Mosek.jl/test/mathprogtestextra.jl, under license:
@@ -64,6 +67,141 @@
         @test eigmin(Xv) > -1e-6
     end
 
+#    @testset "Simple SDP" begin
+#        #contains(string(typeof(solver)),"SCSSolver") && continue
+#        solver = CSDPSolver(printlevel=0)
+#        m = Model(solver=solver)
+#        @variable(m, X[1:3,1:3], PSD)
+#        @SDconstraint(m, X <= 1/2*eye(3,3))
+#        @variable(m, Y[1:5,1:5], Symmetric)
+#        @SDconstraint(m, -ones(5,5) <= Y)
+#        @SDconstraint(m, Y <= 2*ones(5,5))
+#        @variable(m, Z[1:4,1:4], Symmetric)
+#        @SDconstraint(m, ones(4,4) >= Z)
+#
+#        @constraint(m, trace(X) == 1)
+#        @constraint(m, trace(Y) == 3)
+#        @constraint(m, trace(Z) == -1)
+#
+#        #@test JuMP.numsdconstr(m) == 4
+#
+#        @objective(m, Max, X[1,2] + Y[1,2] + Z[1,2])
+#        JuMP.solve(m)
+#        @test JuMP.terminationstatus(m) == MOI.Success
+#        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+#
+#        XX, YY, ZZ, = JuMP.resultvalue.(X), JuMP.resultvalue.(Y), JuMP.resultvalue.(Z)
+#        Xtrue = [0.25 0.25 0
+#                 0.25 0.25 0
+#                 0    0    0.5]
+#        Ytrue = fill(0.6, 5, 5)
+#        Ztrue = [-1.5  3.5 1 1
+#                  3.5 -1.5 1 1
+#                  1    1   1 1
+#                  1    1   1 1]
+#
+#        @test XX ≈ Xtrue atol=1e-2
+#        @test YY ≈ Ytrue atol=1e-2
+#        @test ZZ ≈ Ztrue atol=1e-2
+#        @test ispsd(XX)
+#        @test ispsd(1/2*eye(3,3)-XX)
+#        @test ispsd(YY+ones(5,5))
+#        @test ispsd(2*ones(5,5)-YY)
+#        @test ispsd(ones(4,4)-ZZ)
+#        @test trace(XX) ≈ 1 atol=1e-4
+#        @test trace(YY) ≈ 3 atol=1e-4
+#        @test trace(ZZ) ≈ -1 atol=1e-4
+#        @test JuMP.objectivevalue(m) ≈ 4.35 atol=1e-2
+#
+#        @objective(m, Min, X[1,2] + Y[1,2] + Z[1,2])
+#        JuMP.solve(m)
+#        @test JuMP.terminationstatus(m) == MOI.Success
+#        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+#
+#        XX, YY, ZZ, = JuMP.resultvalue.(X), JuMP.resultvalue.(Y), JuMP.resultvalue.(Z)
+#        Xtrue = [ 0.25 -0.25 0
+#                 -0.25  0.25 0
+#                  0     0    0.5]
+#        Ytrue = fill(0.6, 5, 5)
+#        Ztrue = [-1.5 -1.5 1 1
+#                 -1.5 -1.5 1 1
+#                  1    1   1 1
+#                  1    1   1 1]
+#
+#        @test isapprox(XX, Xtrue, atol=1e-2)
+#        @test isapprox(YY, Ytrue, atol=1e-2)
+#        @test isapprox(ZZ, Ztrue, atol=1e-2)
+#        @test ispsd(XX)
+#        @test ispsd(1/2*eye(3,3)-XX)
+#        @test ispsd(YY+ones(5,5))
+#        @test ispsd(2*ones(5,5)-YY)
+#        @test ispsd(ones(4,4)-ZZ)
+#        @test isapprox(trace(XX), 1, atol=1e-4)
+#        @test isapprox(trace(YY), 3, atol=1e-4)
+#        @test isapprox(trace(ZZ), -1, atol=1e-4)
+#
+#        # Test SDP constraints
+#        m = Model(solver=solver)
+#        @variable(m, X[1:3,1:3], PSD)
+#        @SDconstraint(m, ones(3,3) <= X)
+#
+#        @objective(m, Min, trace(ones(3,3)*X))
+#        JuMP.solve(m)
+#        @test JuMP.terminationstatus(m) == MOI.Success
+#        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+#
+#        XX = JuMP.resultvalue.(X)
+#        @test ispsd(XX)
+#        @test ispsd(XX - ones(3,3))
+#        @test isapprox(JuMP.objectivevalue(m), 9, atol=1e-4)
+#
+#        # Another test SDP
+#        m = Model(solver=solver)
+#        @variable(m, X[1:3,1:3], PSD)
+#        @variable(m, Y[1:2,1:2], PSD)
+#
+#        C = eye(3,3)
+#        A1 = zeros(3,3)
+#        A1[1,1] = 1.0
+#        A2 = zeros(3,3)
+#        A2[2,2] = 1.0
+#        A3 = zeros(3,3)
+#        A3[3,3] = 1.0
+#        D = eye(2,2)
+#        B1 = ones(2,2)
+#        B2 = zeros(2,2)
+#        B2[1,1] = 1
+#        B3 = zeros(2,2)
+#        B3[1,2] = B3[2,1] = 2
+#
+#        @objective(m, Min, trace(C*X)+1+trace(D*Y))
+#        @constraint(m, trace(A1*X-eye(3,3)/3) == 0)
+#        @constraint(m, 2*trace(A2*X) == 1)
+#        @constraint(m, trace(A3*X) >= 2)
+#        @constraint(m, trace(B1*Y) == 1)
+#        @constraint(m, trace(B2*Y) == 0)
+#        @constraint(m, trace(B3*Y) <= 0)
+#        @constraint(m, trace(A1*X)+trace(B1*Y) >= 1)
+#        @constraint(m, Y[2,2] == 1)
+#
+#        JuMP.solve(m)
+#        @test JuMP.terminationstatus(m) == MOI.Success
+#        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+#
+#        XX, YY = JuMP.resultvalue.(X), JuMP.resultvalue.(Y)
+#        @test isapprox(trace(A1*XX-eye(3,3)/3), 0, atol=1e-5)
+#        @test isapprox(2*trace(A2*XX), 1, atol=1e-5)
+#        @test trace(A3*XX) >= 2 - 1e-5
+#        @test isapprox(trace(B1*YY), 1, atol=1e-5)
+#        @test isapprox(trace(B2*YY), 0, atol=1e-5)
+#        @test trace(B3*YY) <= 1e-3
+#        @test trace(A1*XX)+trace(B1*YY) >= 1
+#        @test isapprox(YY[2,2], 1, atol=1e-5)
+#        @test isapprox(XX, diagm([1,.5,2]), atol=1e-3)
+#        @test isapprox(YY, [0 0;0 1], atol=1e-3)
+#    end
+
+
     @testset "Nonsensical SDPs" begin
         m = Model()
         @test_throws ErrorException @variable(m, unequal[1:5,1:6], PSD)
@@ -78,6 +216,276 @@
         @test macroexpand(:(@variable(m, -rand(5,5) <= nonsymmetric[1:5,1:5] <= rand(5,5), Symmetric))).head == :error
     end
 
+#    @testset "SDP with SOC" begin
+#        m = Model(solver=CSDPSolver(printlevel=0))
+#        @variable(m, X[1:2,1:2], PSD)
+#        @variable(m, y[0:2])
+#        @constraint(m, norm([y[1],y[2]]) <= y[0])
+#        @SDconstraint(m, X <= eye(2))
+#        @constraint(m, X[1,1] + X[1,2] == y[1] + y[2])
+#        @objective(m, Max, trace(X) - y[0])
+#
+#        JuMP.solve(m)
+#        @test JuMP.terminationstatus(m) == MOI.Success
+#        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+#
+#        XX, yy = JuMP.resultvalue.(X), JuMP.resultvalue.(y)
+#        @test ispsd(XX)
+#        @test (yy[0] >= 0)
+#        @test (yy[1]^2 + yy[2]^2 <= yy[0]^2 + 1e-4)
+#        @test ispsd(eye(2)-XX)
+#        @test isapprox(XX[1,1] + XX[1,2], yy[1] + yy[2], atol=1e-4)
+#        @test isapprox(XX, eye(2), atol=1e-4)
+#        @test isapprox(yy[:], [1/sqrt(2), 0.5, 0.5], atol=1e-4)
+#        @test isapprox(JuMP.objectivevalue(m), 1.293, atol=1e-2)
+#    end
+
+    @testset "Trivial symmetry constraints are removed (#766, #972)" begin
+        q = 2
+        m = 3
+        angles1 = linspace(3*pi/4, pi, m)
+        angles2 = linspace(0, -pi/2, m)
+        V = [3.*cos.(angles1)' 1.5.*cos.(angles2)';
+             3.*sin.(angles1)' 1.5.*sin.(angles2)']
+        V[abs.(V) .< 1e-10] = 0.0
+        p = 2*m
+        n = 100
+
+        mod = Model()
+        @variable(mod, x[j=1:p] >= 1, Int)
+        @variable(mod, u[i=1:q] >= 1)
+        @objective(mod, Min, sum(u))
+        @constraint(mod, sum(x) <= n)
+        for i=1:q
+            cref = @SDconstraint(mod, [V*diagm(x./n)*V' eye(q)[:,i] ; eye(q)[i:i,:] u[i]] >= 0)
+            @test isnull(cref.instanceref.symref)
+            @test isempty(cref.instanceref.symidx)
+        end
+    end
+
+    # min tr(Y)          max 4x_1 +3x2
+    #     Y[2,1] <= 4        [ 0 y1 0    [1 0 0
+    #     Y[2,2] >= 3         y1 y2 0  <= 0 1 0
+    #     Y >= 0               0  0 0]    0 0 1]
+    #                         y1 <= 0 y2 >= 0
+    @testset "Test problem #2" begin
+        m = Model(solver=CSDPSolver(printlevel=0))
+        @variable(m, Y[1:3,1:3], PSD)
+        c1 = @constraint(m, Y[2,1] <= 4)
+        c2 = @constraint(m, Y[2,2] >= 3)
+        @objective(m, Min, trace(Y))
+
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+
+        @test isapprox(JuMP.objectivevalue(m), 3, atol=1e-5)
+        #@test isapprox(getdual(c1), 0, atol=1e-5)
+        #@test isapprox(getdual(c2), 1, atol=1e-5)
+        #@test isapprox(getdual(Y), [1 0 0; 0 0 0; 0 0 1], atol=1e-5)
+    end
+
+    # min Y[1,2]          max y
+    #     Y[2,1] = 1         [0   y/2 0     [ 0 .5 0
+    #                         y/2 0   0  <=  .5  0 0
+    #     Y >= 0              0   0   0]      0  0 0]
+    #                         y free
+    @testset "Test problem #3" begin
+        m = Model(solver=CSDPSolver(printlevel=0))
+        @variable(m, x >= 0)
+        @variable(m, Y[1:3,1:3], PSD)
+        c = @constraint(m, Y[2,1] == 1)
+        @objective(m, Min, Y[1,2])
+
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+
+        @test isapprox(JuMP.objectivevalue(m), 1, atol=1e-4)
+        Yval = JuMP.resultvalue.(Y)
+        @test isapprox(Yval[1,2], 1, atol=1e-4)
+        @test isapprox(Yval[2,1], 1, atol=1e-4)
+        #@test isapprox(getdual(c), 1, atol=1e-5)
+        #@test isapprox(getdual(Y), zeros(3,3), atol=1e-4)
+    end
+
+    # min x + Y[1,1]          max y + z
+    #     Y[2,1] = 1         [0   y/2 0     [1 0 0
+    #     x >= 1              y/2 0   0  <=  0 0 0
+    #                         0   0   0]     0 0 0]
+    #                         z <= 1
+    #     Y >= 0              y free
+    #     x >= 0              z <= 0
+    @testset "Test problem #4" begin
+        #solver = fixscs(solver, 2000000)
+        m = Model(solver=CSDPSolver(printlevel=0))
+        @variable(m, x >= 0)
+        @variable(m, Y[1:3,1:3], PSD)
+        c1 = @constraint(m, x >= 1)
+        c2 = @constraint(m, Y[2,1] == 1)
+        @objective(m, Min, x + Y[1,1])
+
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+
+        @test isapprox(JuMP.objectivevalue(m), 1, atol=1e-3)
+        @test isapprox(JuMP.resultvalue(x), 1, atol=1e-5)
+        @test isapprox(JuMP.resultvalue.(Y)[1,1], 0, atol=1e-4)
+        #@test isapprox(getdual(x), 0, atol=1e-5)
+        #@test isapprox(getdual(Y), [1 0 0; 0 0 0; 0 0 0], atol=1e-4)
+        #@test isapprox(getdual(c1), 1, atol=1e-5)
+        #@test isapprox(getdual(c2), 0, atol=1e-4)
+    end
+
+    function nuclear_norm(model, A)
+        m, n = size(A,1), size(A,2)
+        @variable(model, U[1:m,1:m])
+        @variable(model, V[1:n,1:n])
+        @SDconstraint(model, 0 ⪯ [U A; A' V])
+        return 0.5(trace(U) + trace(V'))
+    end
+
+    @testset "Test problem #5" begin
+        m = Model(solver=CSDPSolver(printlevel=0))
+        @variable(m, Y[1:3,1:3], PSD)
+        @constraint(m, Y[2,1] <= 4)
+        @constraint(m, Y[2,2] >= 3)
+        @constraint(m, Y[3,3] <= 2)
+        @objective(m, Min, nuclear_norm(m, Y))
+
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+
+        @test isapprox(JuMP.objectivevalue(m), 3, atol=1e-5)
+    end
+
+    function operator_norm(model, A)
+        m, n = size(A,1), size(A,2)
+        @variable(model, t >= 0)
+        @SDconstraint(model, [t*eye(n) A; A' eye(n)*t] >= 0)
+        return t
+    end
+
+    @testset "Test problem #6" begin
+        m = Model(solver=CSDPSolver(printlevel=0))
+        @variable(m, Y[1:3,1:3])
+        @constraint(m, Y[2,1] <= 4)
+        @constraint(m, Y[2,2] >= 3)
+        @constraint(m, sum(Y) >= 12)
+        @objective(m, Min, operator_norm(m, Y))
+
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+
+        @test isapprox(JuMP.objectivevalue(m), 4, atol=1e-5)
+    end
+
+    function lambda_max(model, A)
+        m, n = size(A,1), size(A,2)
+        @variable(model, t)
+        @SDconstraint(model, speye(n)*t - A ⪰ 0)
+        @SDconstraint(model, A >= 0)
+        return t
+    end
+
+    @testset "Test problem #7" begin
+        m = Model(solver=CSDPSolver(printlevel=0))
+        @variable(m, Y[1:3,1:3])
+        @constraint(m, Y[1,1] >= 4)
+        @objective(m, Min, lambda_max(m, Y))
+
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+
+        @test isapprox(JuMP.objectivevalue(m), 4, atol=1e-5)
+    end
+
+    function lambda_min(model, A)
+        m, n = size(A,1), size(A,2)
+        @variable(model, t)
+        @SDconstraint(model, A - eye(n)*t >= 0)
+        @SDconstraint(model, A >= 0)
+        return t
+    end
+
+    @testset "Test problem #8" begin
+        m = Model(solver=CSDPSolver(printlevel=0))
+        @variable(m, Y[1:3,1:3], PSD)
+        @constraint(m, trace(Y) <= 6)
+        @objective(m, Max, lambda_min(m, Y))
+
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+
+        @test isapprox(JuMP.objectivevalue(m), 2, atol=1e-5)
+    end
+
+    function matrix_frac(model, x, P)
+        n = size(P,1)
+        @variable(model, t)
+        @variable(model, M[1:(n+1),1:(n+1)], PSD)
+        @constraint(model, M[1:n,1:n] .== P)
+        @constraint(model, M[1:n,n+1] .== x)
+        @constraint(model, M[n+1,n+1] == t)
+        return t
+    end
+
+#    @testset "Test problem #9" begin
+#        m = Model(solver=CSDPSolver(printlevel=0))
+#        n = 3
+#        x = [1,2,3]
+#        lb = 0.5eye(n)
+#        ub = 2eye(n)
+#        @variable(m, lb[i,j] <= P[i=1:n,j=1:n] <= ub[i,j])
+#        @objective(m, Min, matrix_frac(m, x, P))
+#
+#        JuMP.solve(m)
+#        @test JuMP.terminationstatus(m) == MOI.Success
+#        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+#
+#        @test isapprox(JuMP.objectivevalue(m), 7, atol=1e-5)
+#    end
+
+    @testset "Correlation example" begin
+        m = Model(solver=CSDPSolver(printlevel=0))
+
+        @variable(m, X[1:3,1:3], PSD)
+
+        # Diagonal is 1s
+        @constraint(m, X[1,1] == 1)
+        @constraint(m, X[2,2] == 1)
+        @constraint(m, X[3,3] == 1)
+
+        # Bounds on the known correlations
+        @constraint(m, X[1,2] >= -0.2)
+        @constraint(m, X[1,2] <= -0.1)
+        @constraint(m, X[2,3] >=  0.4)
+        @constraint(m, X[2,3] <=  0.5)
+
+        # Find upper bound
+        @objective(m, Max, X[1,3])
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        @test (+0.8719 <= JuMP.resultvalue.(X)[1,3] <= +0.8720)
+
+#        # Find lower bound
+#        @objective(m, Min, X[1,3])
+#        JuMP.solve(m)
+#        @test JuMP.terminationstatus(m) == MOI.Success
+#        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+#        @test (-0.9779 >= JuMP.resultvalue.(X)[1,3] >= -0.9799)
+    end
+
     # min o                    max y + X11
     # Q11 - 1   = Q22        [y-X12-X21  0     [0 0
     #                             0     -y] <=  0 0]
@@ -85,29 +493,26 @@
     #  Q11 o  ] >= 0          -X[2,2] = 1
     # Q >= 0                        y free
     # o free                        X <= 0
-#   @testset "Just another SDP" begin
-#       model = Model(solver=CSDPSolver(printlevel=0))
-#       @variable(model, Q[1:2, 1:2], PSD)
-#       c1 = @constraint(model, Q[1,1] - 1 == Q[2,2])
-#       @variable(model, objective)
-#       T = [1 Q[1,1]; Q[1,1] objective]
-#       @test_throws ErrorException SDConstraint(T, 1)
-#       c2 = JuMP.addconstraint(model, SDConstraint(T, 0))
-#       @objective(model, Min, objective)
-#
-#       JuMP.solve(m)
-#
-#       @test JuMP.terminationstatus(m) == MOI.Success
-#       @test JuMP.primalstatus(m) == MOI.FeasiblePoint
-#
-#       @test JuMP.resultvalue(Q) ≈ [1 0; 0 0] atol=1e-3
-#       @test JuMP.objectivevalue(model) ≈ 1 atol=1e-4
-#       @test JuMP.resultvalue(objective) ≈ 1 atol=1e-4
-#       @test getdual(objective) ≈, 0, atol=1e-5
-#       @test getdual(Q) ≈ [0 0; 0 2] atol=1e-3
-#       @test getdual(c1) ≈ 2, atol=1e-4 # y
-#       @test getdual(c2) ≈ [-1 1; 1 -1] atol=1e-3 # X
-#   end
+    @testset "Just another SDP" begin
+        m = Model(solver=CSDPSolver(printlevel=0))
+        @variable(m, Q[1:2, 1:2], PSD)
+        c1 = @constraint(m, Q[1,1] - 1 == Q[2,2])
+        @variable(m, objective)
+        @SDconstraint(m, [1 Q[1,1]; Q[1,1] objective] ⪰ 0)
+        @objective(m, Min, objective)
+
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+
+        @test JuMP.resultvalue.(Q) ≈ [1 0; 0 0] atol=1e-3
+        @test JuMP.objectivevalue(m) ≈ 1 atol=1e-4
+        @test JuMP.resultvalue(objective) ≈ 1 atol=1e-4
+        #@test getdual(objective) ≈ 0 atol=1e-5
+        #@test getdual(Q) ≈ [0 0; 0 2] atol=1e-3
+        #@test getdual(c1) ≈ 2 atol=1e-4 # y
+        #@test getdual(c2) ≈ [-1 1; 1 -1] atol=1e-3 # X
+    end
 
     # The four following tests are from Example 2.11, Example 2.13 and Example 2.27 of:
     # Blekherman, G., Parrilo, P. A., & Thomas, R. R. (Eds.).
@@ -133,58 +538,54 @@
 #       @test getdual(c) ≈ 1-sqrt(2) atol=1e-5
     end
 
-#   # Example 2.13
-#   @testset "SDP constraint and optimal objective not rational with $solver" for solver in sdp_solvers
-#       solver = fixscs(solver, 7000000)
-#       m = Model(solver=solver)
-#       @variable(m, y)
-#       c = @SDconstraint(m, [2-y 1; 1 -y] >= 0)
-#       @objective(m, Max, y)
-#       @test all(isnan, getdual(c))
-#       status = solve(m)
-#
-#       @test status == :Optimal
-#       @test isapprox(getobjectivevalue(m), 1-sqrt(2), atol=1e-5)
-#       @test isapprox(getvalue(y), 1-sqrt(2), atol=1e-5)
-#
-#       X = getdual(c)
-#       @test isapprox(getdual(c), [(2-sqrt(2))/4 -1/(2*sqrt(2)); -1/(2*sqrt(2)) (2+sqrt(2))/4], atol=1e-4)
-#       @test isapprox(getdual(y), 0, atol=1e-5)
-#   end
-#
-#   # Example 2.27
-#   # min X[1,1]   max y
-#   # 2X[1,2] = 1  [0 y     [1 0
-#   # X ⪰ 0         y 0] ⪯   0 0]
-#   # The dual optimal solution is y=0 and there is a primal solution
-#   # [ eps  1/2
-#   #   1/2  1/eps]
-#   # for any eps > 0 however there is no primal solution with objective value 0.
-#   @testset "SDP with dual solution not attained with $solver" for solver in sdp_solvers
-#       solver = fixscs(solver, 7000000)
-#       m = Model(solver=solver)
-#       @variable(m, y)
-#       c = @SDconstraint(m, [0 y; y 0] <= [1 0; 0 0])
-#       @objective(m, Max, y)
-#       @test all(isnan, getdual(c))
-#       status = solve(m)
-#
-#       if contains(string(typeof(solver)),"MosekSolver")
-#           # Mosek returns Stall on this instance
-#           # Hack until we fix statuses in MPB
-#           JuMP.fillConicDuals(m)
-#       else
-#           @test status == :Optimal
-#       end
-#       @test isapprox(getobjectivevalue(m), 0, atol=1e-5)
-#       @test isapprox(getvalue(y), 0, atol=1e-5)
-#
-#       X = getdual(c)
-#       @test isapprox(X[1,1], 0, atol=1e-5)
-#       @test isapprox(X[1,2], 1/2, atol=1e-5)
-#       @test isapprox(X[2,1], 1/2, atol=1e-5)
-#       @test isapprox(getdual(y), 0, atol=1e-5)
-#   end
+    # Example 2.13
+    @testset "SDP constraint and optimal objective not rational" begin
+        #solver = fixscs(solver, 7000000)
+        m = Model(solver=CSDPSolver(printlevel=0))
+        @variable(m, y)
+        c = @SDconstraint(m, [2-y 1; 1 -y] >= 0)
+        @objective(m, Max, y)
+        #@test all(isnan, getdual(c))
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+
+        @test isapprox(JuMP.objectivevalue(m), 1-sqrt(2), atol=1e-5)
+        @test isapprox(JuMP.resultvalue(y), 1-sqrt(2), atol=1e-5)
+
+        #X = getdual(c)
+        #@test isapprox(getdual(c), [(2-sqrt(2))/4 -1/(2*sqrt(2)); -1/(2*sqrt(2)) (2+sqrt(2))/4], atol=1e-4)
+        #@test isapprox(getdual(y), 0, atol=1e-5)
+    end
+
+    # Example 2.27
+    # min X[1,1]   max y
+    # 2X[1,2] = 1  [0 y     [1 0
+    # X ⪰ 0         y 0] ⪯   0 0]
+    # The dual optimal solution is y=0 and there is a primal solution
+    # [ eps  1/2
+    #   1/2  1/eps]
+    # for any eps > 0 however there is no primal solution with objective value 0.
+    @testset "SDP with dual solution not attained" begin
+        #solver = fixscs(solver, 7000000)
+        m = Model(solver=CSDPSolver(printlevel=0))
+        @variable(m, y)
+        c = @SDconstraint(m, [0 y; y 0] <= [1 0; 0 0])
+        @objective(m, Max, y)
+        #@test all(isnan, getdual(c))
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+
+        @test isapprox(JuMP.objectivevalue(m), 0, atol=1e-5)
+        @test isapprox(JuMP.resultvalue(y), 0, atol=1e-5)
+
+        #X = getdual(c)
+        #@test isapprox(X[1,1], 0, atol=1e-5)
+        #@test isapprox(X[1,2], 1/2, atol=1e-5)
+        #@test isapprox(X[2,1], 1/2, atol=1e-5)
+        #@test isapprox(getdual(y), 0, atol=1e-5)
+    end
 
     @testset "SDP with primal solution not attained" begin
 #       solver = fixscs(solver, 7000000)
@@ -193,7 +594,9 @@
         c = @constraint(m, 2*X[1,2] == 1)
         @objective(m, Min, X[1,1])
 #       @test all(isnan, getdual(X))
-        status = solve(m)
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
 
         @test JuMP.terminationstatus(m) == MOI.Success
         @test JuMP.primalstatus(m) == MOI.FeasiblePoint
@@ -208,15 +611,93 @@
 #       @test isapprox(getdual(c), 0, atol=1e-5)
     end
 
+    # min X[1,1]     max y/2+z/2
+    # X[1,2] = 1/2   [0 y     [1 0
+    # X[2,1] = 1/2    z 0] ⪯   0 0]
+    # X+Xᵀ ⪰ 0
+    @testset "SDP with dual solution not attained without symmetric A_i" begin
+        #solver = fixscs(solver, 10000000)
+        m = Model(solver=CSDPSolver(printlevel=0))
+        @variable(m, y)
+        @variable(m, z)
+        c = @SDconstraint(m, [0 y; z 0] <= [1 0; 0 0])
+        @objective(m, Max, y/2+z/2)
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+
+        @test isapprox(JuMP.objectivevalue(m), 0, atol=1e-5)
+        @test isapprox(JuMP.resultvalue(y), 0, atol=1e-5)
+        @test isapprox(JuMP.resultvalue(z), 0, atol=1e-5)
+
+        #X = getdual(c)
+        #@test isapprox(X[1,1], 0, atol=1e-5)
+        #@test isapprox(X[1,2], 1/2, atol=1e-5)
+        #@test isapprox(X[2,1], 1/2, atol=1e-5)
+        #@test isapprox(getdual(y), 0, atol=1e-5)
+        #@test isapprox(getdual(z), 0, atol=1e-5)
+    end
+
+    # min X[1,1]     max y
+    # X[1,2] = 1     [0 y     [1 0
+    # X[2,1] = 0      z 0] ⪯   0 0]
+    # X+Xᵀ ⪰ 0
+    @testset "SDP with dual solution not attained without symmetry" begin
+        #solver = fixscs(solver, 10000000)
+        m = Model(solver=CSDPSolver(printlevel=0))
+        @variable(m, y)
+        @variable(m, z)
+        c = @SDconstraint(m, [0 y; z 0] <= [1 0; 0 0])
+        @objective(m, Max, y)
+
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+
+        @test isapprox(JuMP.objectivevalue(m), 0, atol=1e-5)
+        @test isapprox(JuMP.resultvalue(y), 0, atol=1e-5)
+        @test isapprox(JuMP.resultvalue(z), 0, atol=1e-5)
+
+        #X = getdual(c)
+        #@test isapprox(X[1,1], 0, atol=1e-5)
+        #@test isapprox(X[1,2], 1, atol=1e-5) # X is not symmetric !
+        #@test isapprox(X[2,1], 0, atol=1e-5)
+        #@test isapprox(getdual(y), 0, atol=1e-5)
+        #@test isapprox(getdual(z), 0, atol=1e-5)
+    end
+
+    @testset "Nonzero dual for a scalar variable with sdp solver" begin
+        m = Model(solver=CSDPSolver(printlevel=0))
+        @variable(m, x1 >= 0)
+        @variable(m, x2 >= 0)
+        @variable(m, x3 >= 0)
+        # The following constraint could be written as 2 linear constrains
+        # but and sdp constraint is used to make it a conic problem
+        c = @SDconstraint(m, [2x1-x2-x3 0; 0 x1-x2+x3] >= [3 0; 0 2])
+        @objective(m, Min, 2x1 - x2)
+
+        JuMP.solve(m)
+        @test JuMP.terminationstatus(m) == MOI.Success
+        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+
+        @test isapprox(JuMP.objectivevalue(m), 10/3, atol=1e-5)
+        @test isapprox(JuMP.resultvalue(x1), 5/3, atol=1e-5)
+        @test isapprox(JuMP.resultvalue(x2), 0, atol=1e-5)
+        @test isapprox(JuMP.resultvalue(x3), 1/3, atol=1e-5)
+
+        #@test isapprox(getdual(c), [-2/3 0; 0 -2/3], atol=1e-4)
+        #@test isapprox(getdual(x1), 0, atol=1e-5)
+        #@test isapprox(getdual(x2), 1/3, atol=1e-5)
+        #@test isapprox(getdual(x3), 0, atol=1e-5)
+    end
+
+
     @testset "No constraint" begin
         m = Model(solver=CSDPSolver(printlevel=0))
         @variable(m, X[1:3,1:3], PSD)
         @objective(m, Min, trace(X))
 
         JuMP.solve(m)
-
-        status = solve(m)
-
         @test JuMP.terminationstatus(m) == MOI.Success
         @test JuMP.primalstatus(m) == MOI.FeasiblePoint
 


### PR DESCRIPTION
Add support for SDP constraint defined with the `@SDconstraint` macro.
What is new is that in the reference returned `cref`, `cref.instanceref` is not the reference to the PSD constraint. Indeed we also need to keep a reference to the symmetry constraints to compute the dual.
Therefore, `cref.instanceref` is an `SDSymInstanceRef`. If the matrix has type `Symmetric` then we can set `cref.instanceref` to the reference to the PSD constraint of the instance. We do not do this if the matrix is symmetric but not of type `Symmetric` since that would not be type stable since the return type would depend on the value of the elements of the matrix.
That way, if the user wants all its constraints reference to have the type `ConstraintRef{JuMP.Model, MOI.ConstraintReference}`, he can use the `Base.Symmetric` type to achieve this.

Closes #1050 