### PR TITLE
Be less specific for SDP var constraint

### DIFF
--- a/src/sd.jl
+++ b/src/sd.jl
@@ -2,8 +2,8 @@ export PSDCone
 # Used in @constraint m X in PSDCone
 struct PSDCone end
 
-struct SDVariableConstraint <: AbstractConstraint
-    Q::Matrix{JuMP.Variable}
+struct SDVariableConstraint{MT<:AbstractMatrix{JuMP.Variable}} <: AbstractConstraint
+    Q::MT
 end
 
 # Used by the @variable macro. Currently cannot also be used through the @constraint macro because of the underscore


### PR DESCRIPTION
There is no need to impose `Q` to have the type `Matrix` in JuMP. In `SumOfSquares`, we create a matrix of variables using a custom type `SymMatrix <: AbstractMatrix` that only stores the elements of the upper triangle of the matrix so with this change, I can use `SDVariableConstraint`.