### PR TITLE
use tuple recursion to fix type-stability of JuMPArray getindex()

### DIFF
--- a/test/containers.jl
+++ b/test/containers.jl
@@ -91,9 +91,11 @@ end
     s2 = [:a,:b]
     plus1(x) = x + 1
 
-    A = JuMPArray([1.0,2.0], s1)
-    @test A[2] == 1.0
+    A = @inferred JuMPArray([1.0,2.0], s1)
+    @test @inferred A[2] == 1.0
     @test A[3] == 2.0
+    @test A[2,1] == 1.0
+    @test A[3,1,1,1,1] == 2.0
     @test isassigned(A, 2)
     @test !isassigned(A, 1)
     @test length.(indices(A)) == (2,)
@@ -107,8 +109,8 @@ And data, a 2-element Array{Float64,1}:
  2.0
  3.0"""
 
-    A = JuMPArray([1.0,2.0], s2)
-    @test A[:a] == 1.0
+    A = @inferred JuMPArray([1.0,2.0], s2)
+    @test @inferred A[:a] == 1.0
     @test A[:b] == 2.0
     @test length.(indices(A)) == (2,)
     B = plus1.(A)
@@ -121,13 +123,16 @@ And data, a 2-element Array{Float64,1}:
  2.0
  3.0"""
 
-    A = JuMPArray([1 2; 3 4], s1, s2)
+    A = @inferred JuMPArray([1 2; 3 4], s1, s2)
     @test length.(indices(A)) == (2,2)
-    @test A[2,:a] == 1
+    @test @inferred A[2,:a] == 1
     @test A[3,:a] == 3
     @test A[2,:b] == 2
     @test A[3,:b] == 4
-    @test A[:,:a] == JuMPArray([1,3], s1)
+    @test A[2,:a,1] == 1
+    @test A[2,:a,1,1] == 1
+    @test A[3,:a,1,1,1] == 3
+    @test @inferred A[:,:a] == JuMPArray([1,3], s1)
     @test A[2, :] == JuMPArray([1,2], s2)
     @test sprint(show, A) == """
 2-dimensional JuMPArray{Int64,2,...} with index sets:
@@ -137,7 +142,7 @@ And data, a 2×2 Array{Int64,2}:
  1  2
  3  4"""
 
-    A = JuMPArray(zeros(2,2,2,2), 2:3, [:a, :b], -1:0, ["a","b"])
+    A = @inferred JuMPArray(zeros(2,2,2,2), 2:3, [:a, :b], -1:0, ["a","b"])
     A[2,:a,-1,"a"] = 1.0
     f = 0.0
     for I in eachindex(A)


### PR DESCRIPTION
I noticed a TODO in 9466fe9bc15caae3684f980b34d52a545a6c1d12 and figured I'd try to fix it. Rather than using an `@generated` function (which is generally not recommended), I managed to solve it with the lisp-y tuple recursion approach. With this change, `getindex()` on a JuMPArray with two axes goes from 1.8 us down to 60 ns on my machine (30X improvement). 

Note that to do this I had to put the type of the lookup dicts into the JuMPArray type. This is (essentially) what AxisArrays does, too, so I think it's reasonable. 