### PR TITLE
Specify nonlinear solver

### DIFF
--- a/doc/nlp.rst
+++ b/doc/nlp.rst
@@ -29,8 +29,8 @@ locally optimal. Convexity detection is not currently provided.
 
 For example, we can solve the classical Rosenbrock problem (with a twist) as follows::
 
-    using JuMP
-    m = Model()
+    using JuMP, Ipopt
+    m = Model(solver=IpoptSolver())
     @variable(m, x, start = 0.0)
     @variable(m, y, start = 0.0)
 


### PR DESCRIPTION
The first example in the docs for Nonlinear Modeling does not work if you don't specify a solver.