### PR TITLE
Add parameter to objective

### DIFF
--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -198,7 +198,7 @@ function setobjective(m::Model, sense::Symbol, a::AffExpr)
         moisense = MOI.MaxSense
     end
     MOI.set!(m.instance, MOI.ObjectiveSense(), moisense)
-    MOI.set!(m.instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(a))
+    MOI.set!(m.instance, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(a))
     nothing
 end
 
@@ -209,7 +209,7 @@ Return an `AffExpr` object representing the objective function.
 Error if the objective is not linear.
 """
 function objectivefunction(m::Model, ::Type{AffExpr})
-    f = MOI.get(m.instance, MOI.ObjectiveFunction())::MOI.ScalarAffineFunction
+    f = MOI.get(m.instance, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())::MOI.ScalarAffineFunction{Float64}
     return AffExpr(m, f)
 end
 

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -99,7 +99,7 @@ function setobjective(m::Model, sense::Symbol, a::QuadExpr)
         moisense = MOI.MaxSense
     end
     MOI.set!(m.instance, MOI.ObjectiveSense(), moisense)
-    MOI.set!(m.instance, MOI.ObjectiveFunction(), MOI.ScalarQuadraticFunction(a))
+    MOI.set!(m.instance, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(), MOI.ScalarQuadraticFunction(a))
     nothing
 end
 
@@ -110,7 +110,7 @@ Return a `QuadExpr` object representing the objective function.
 Error if the objective is not quadratic.
 """
 function objectivefunction(m::Model, ::Type{QuadExpr})
-    f = MOI.get(m.instance, MOI.ObjectiveFunction())::MOI.ScalarQuadraticFunction
+    f = MOI.get(m.instance, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())::MOI.ScalarQuadraticFunction{Float64}
     return QuadExpr(m, f)
 end
 

--- a/src/solverinterface.jl
+++ b/src/solverinterface.jl
@@ -39,8 +39,13 @@ function attach(m::Model, solverinstance::MOI.AbstractSolverInstance)
         m.variabletosolvervariable[MOIVAR(i)] = solvervariables[i]
     end
 
-    MOI.set!(m.solverinstance, MOI.ObjectiveSense(), MOI.get(m.instance, MOI.ObjectiveSense()))
-    MOI.set!(m.solverinstance, MOI.ObjectiveFunction(), MOI.get(m.instance, MOI.ObjectiveFunction()))
+    # Copy instance attributes
+    for attr in MOI.get(m.instance, MOI.ListOfInstanceAttributesSet())
+        if MOI.canget(m.instance, attr)
+            @assert MOI.canset(solverinstance, attr)
+            MOI.set!(solverinstance, attr, MOI.get(m.instance, attr))
+        end
+    end
 
     for (F, S) in MOI.get(m.instance, MOI.ListOfConstraints())
         # do the rest in copyconstraints! which is type stable


### PR DESCRIPTION
Getting ready for https://github.com/JuliaOpt/MathOptInterface.jl/pull/198. The change in `solverinterface.jl` is not good since variable indices are not mapped but this bug was already theren is also there for the constraints and will be fixed by https://github.com/JuliaOpt/JuMP.jl/pull/1162