### PR TITLE
support SingleVariable and VectorOfVariable constraints ...

### DIFF
--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -148,6 +148,8 @@ Replaces `getvalue` for most use cases.
 """
 resultvalue(a::AffExpr) = value(a, resultvalue)
 
+# Note: No validation is performed that the variables in the AffExpr belong to
+# the same model.
 function MOI.ScalarAffineFunction(a::AffExpr)
     return MOI.ScalarAffineFunction(index.(a.vars), a.coeffs, a.constant)
 end
@@ -184,10 +186,6 @@ function MOI.VectorAffineFunction(affs::Vector{AffExpr})
     end
     MOI.VectorAffineFunction(outputindex, variables, coefficients, constant)
 end
-
-# TODO this could be interpreted as a SingleVariable objective, but that should require explict syntax
-setobjective(m::Model, sense::Symbol, x::Variable) = setobjective(m, sense, convert(AffExpr,x))
-
 
 function setobjective(m::Model, sense::Symbol, a::AffExpr)
     if sense == :Min

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -46,9 +46,9 @@
 (*)(lhs::Variable, rhs::Variable) = QuadExpr([lhs],[rhs],[1.],AffExpr(Variable[],Float64[],0.))
 # Variable--AffExpr
 (+)(lhs::V, rhs::GenericAffExpr{C,V}) where {C,V<:JuMPTypes} =
-    GenericAffExpr{C,V}(vcat(rhs.vars,lhs),vcat(rhs.coeffs,one(C)), rhs.constant)
+    GenericAffExpr{C,V}(vcat(lhs,rhs.vars),vcat(one(C),rhs.coeffs), rhs.constant)
 (-)(lhs::V, rhs::GenericAffExpr{C,V}) where {C,V<:JuMPTypes} =
-    GenericAffExpr{C,V}(vcat(rhs.vars,lhs),vcat(-rhs.coeffs,one(C)),-rhs.constant)
+    GenericAffExpr{C,V}(vcat(lhs,rhs.vars),vcat(one(C),-rhs.coeffs),-rhs.constant)
 function (*)(lhs::Variable, rhs::AffExpr)
     n = length(rhs.vars)
     if rhs.constant != 0.

--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -274,7 +274,11 @@ addtoexpr(ex::AbstractArray{T}, c::Number, x::AbstractArray) where {T<:GenericAf
 
 addtoexpr(ex, c, x) = ex + c*x
 
-@generated addtoexpr_reorder(ex, arg) = :(addtoexpr(ex, 1.0, arg))
+addtoexpr_reorder(ex, arg) = addtoexpr(ex, 1.0, arg)
+# Special case because "Val{false}()" is used as the default empty expression.
+addtoexpr_reorder(ex::Val{false}, arg) = arg
+addtoexpr_reorder(ex::Val{false}, args...) = (*)(args...)
+
 
 @generated function addtoexpr_reorder(ex, x, y)
     if x <: Union{Variable,AffExpr} && y <: Number

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -161,3 +161,5 @@ function constraintobject(cr::ConstraintRef{Model}, ::Type{QuadExpr}, ::Type{Set
     s = MOI.get(m.moibackend, MOI.ConstraintSet(), index(cr))::SetType
     return QuadExprConstraint(QuadExpr(m, f), s)
 end
+
+# TODO: VectorQuadExprConstraint

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -1,6 +1,19 @@
 
 
 @testset "Objectives" begin
+    @testset "SingleVariable objectives" begin
+        m = Model()
+        @variable(m, x)
+
+        @objective(m, Min, x)
+        @test JuMP.objectivesense(m) == :Min
+        @test JuMP.objectivefunction(m, Variable) == x
+
+        @objective(m, Max, x)
+        @test JuMP.objectivesense(m) == :Max
+        @test JuMP.objectivefunction(m, Variable) == x
+    end
+
     @testset "Linear objectives" begin
         m = Model()
         @variable(m, x)


### PR DESCRIPTION
through the macros.

Closes #1164 

This also gets us a bit closer to @blegat's dream of making JuMP agnostic to coefficient types.