### PR TITLE
Gets JuMP to compile on 0.7

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -519,7 +519,9 @@ end
 const op_hint = "Are you trying to build a nonlinear problem? Make sure you use @NLconstraint/@NLobjective."
 for (func,_) in Calculus.symbolic_derivatives_1arg(), typ in [:Variable,:AffExpr,:QuadExpr]
     errstr = "$func is not defined for type $typ. $op_hint"
-    @eval Base.$(func)(::$typ) = error($errstr)
+    if isdefined(Base, func)
+        @eval Base.$(func)(::$typ) = error($errstr)
+    end
 end
 
 *(::T,::S) where {T<:QuadExpr,S<:Union{Variable,AffExpr,QuadExpr}} =


### PR DESCRIPTION
JuMPArray printing is still broken. I also saw some errors in the macros, I don't think JuMP is usable on 0.7 yet.

Ref #1177