### PR TITLE
fix derivatives of x^1

### DIFF
--- a/src/Derivatives/forward.jl
+++ b/src/Derivatives/forward.jl
@@ -88,6 +88,9 @@ function forward_eval{T}(storage::Vector{T},partials_storage::Vector{T},nd::Vect
                 if exponent == 2
                     @inbounds storage[k] = base*base
                     @inbounds partials_storage[ix1] = 2*base
+                elseif exponent == 1
+                    @inbounds storage[k] = base
+                    @inbounds partials_storage[ix1] = 1.0
                 else
                     storage[k] = pow(base,exponent)
                     partials_storage[ix1] = exponent*pow(base,exponent-1)
@@ -295,6 +298,8 @@ function forward_eval_ϵ{N,T}(storage::Vector{T},storage_ϵ::DenseVector{Forward
                     exponent_gnum = ForwardDiff.Dual{TAG}(exponent,exponent_ϵ)
                     if exponent == 2
                         partials_storage_ϵ[ix1] = 2*base_ϵ
+                    elseif exponent == 1
+                        partials_storage_ϵ[ix1] = zero_ϵ
                     else
                         partials_storage_ϵ[ix1] = ForwardDiff.partials(exponent_gnum*pow(base_gnum,exponent_gnum-1))
                     end

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -181,7 +181,6 @@
         @test isapprox(h, correct)
     end
 
-    # TODO: Still broken!
     @testset "NaN corner case (Issue #1205)" begin
         m = Model()
         @variable(m, x)
@@ -194,7 +193,22 @@
         V = zeros(length(I))
         values = zeros(1)
         MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
-        @test_broken isapprox(dense_hessian(I, J, V, 1), [0.0])
+        @test isapprox(dense_hessian(I, J, V, 1), [0.0])
+    end
+
+    @testset "NaN corner case - ifelse (Issue #1205)" begin
+        m = Model()
+        @variable(m, x)
+
+        @NLobjective(m, Min, ifelse(true, x, x^1.0))
+
+        d = JuMP.NLPEvaluator(m)
+        MOI.initialize!(d, [:Hess])
+        I,J = MOI.hessian_lagrangian_structure(d)
+        V = zeros(length(I))
+        values = zeros(1)
+        MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
+        @test isapprox(dense_hessian(I, J, V, 1), [0.0])
     end
 
     @testset "Hessians and Hess-vec" begin


### PR DESCRIPTION
This doesn't address the underlying issue of NaN propagation through `^` but fixes the case that appeared in #1205.

Closes #1205

@jrevels 