### PR TITLE
Refactor constraint macro with buildconstraint function

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -249,7 +249,7 @@ sense_to_set(_error::Function, ::Union{Val{:(>=)}, Val{:(≥)}}) = MOI.GreaterTh
 sense_to_set(_error::Function, ::Val{:(==)}) = MOI.EqualTo(0.0)
 sense_to_set(_error::Function, ::Val{S}) where S = _error("Unrecognized sense $S")
 
-function parsebinaryconstraint(_error::Function, vectorized::Bool, ::Val{:in}, aff, set)
+function parseoneoperatorconstraint(_error::Function, vectorized::Bool, ::Val{:in}, aff, set)
     newaff, parseaff = parseExprToplevel(aff, :q)
     parsecode = :(q = Val{false}(); $parseaff)
     if vectorized
@@ -260,16 +260,16 @@ function parsebinaryconstraint(_error::Function, vectorized::Bool, ::Val{:in}, a
     parsecode, constructcall
 end
 
-function parsebinaryconstraint(_error::Function, vectorized::Bool, sense::Val, lhs, rhs)
+function parseoneoperatorconstraint(_error::Function, vectorized::Bool, sense::Val, lhs, rhs)
     # Simple comparison - move everything to the LHS
     aff = :($lhs - $rhs)
     set = sense_to_set(_error, sense)
-    parsebinaryconstraint(_error, vectorized, Val(:in), aff, set)
+    parseoneoperatorconstraint(_error, vectorized, Val(:in), aff, set)
 end
 
 function parseconstraint(_error::Function, sense::Symbol, lhs, rhs)
     (sense, vectorized) = _check_vectorized(sense)
-    vectorized, parsebinaryconstraint(_error, vectorized, Val(sense), lhs, rhs)...
+    vectorized, parseoneoperatorconstraint(_error, vectorized, Val(sense), lhs, rhs)...
 end
 
 function parseternaryconstraint(_error::Function, vectorized::Bool, lb, ::Union{Val{:(<=)}, Val{:(≤)}}, aff, rsign::Union{Val{:(<=)}, Val{:(≤)}}, ub)
@@ -494,7 +494,7 @@ macro SDconstraint(m, x)
     else
         _error("Invalid sense $sense in SDP constraint")
     end
-    parsecode, constructcall = parsebinaryconstraint(_error, false, Val(:in), aff, :(PSDCone()))
+    parsecode, constructcall = parseoneoperatorconstraint(_error, false, Val(:in), aff, :(PSDCone()))
     assert_validmodel(m, quote
         $parsecode
         addconstraint($m, $constructcall)

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -102,9 +102,13 @@ end
         @test c.func == x
         @test c.set == MOI.Interval(-1.0, 1.0)
 
+        cref = @constraint(m, 1 >= x >= 0)
+        c = JuMP.constraintobject(cref, Variable, MOI.Interval)
+        @test c.func == x
+        @test c.set == MOI.Interval(0.0, 1.0)
+
         @test_throws ErrorException @constraint(m, x <= t <= y)
         @test_throws ErrorException @constraint(m, 0 <= nothing <= 1)
-        @test macroexpand(:(@constraint(m, 1 >= x >= 0))).head == :error
         @test macroexpand(:(@constraint(1 <= x <= 2, foo=:bar))).head == :error
 
         @test JuMP.isequal_canonical(@expression(m, 3x - y - 3.3(w + 2z) + 5), 3*x - y - 3.3*w - 6.6*z + 5)


### PR DESCRIPTION
This allows JuMP extension to easily extend the `@constraint` macro by defining new `buildconstraint`, `buildbinaryconstraint` or `buildternaryconstraint` methods.
@rdeits this might be useful for ConditionalJuMP, e.g. it might allow to replace `@implies(m, (x <= 0) => (y == 0.5))` by `@constraint(m, (x <= 0) => (y == 0.5))` if you implement `buildbinaryconstraint(::Function,::Bool,  ::Val{:(=>)}, ::Any, ::Any)`