### PR TITLE
Add more constraint tests

### DIFF
--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -23,7 +23,6 @@ mutable struct GenericAffExpr{CoefType,VarType} <: AbstractJuMPScalar
     coeffs::Vector{CoefType}
     constant::CoefType
 end
-coeftype(::GenericAffExpr{C,V}) where {C,V} = C
 
 Base.zero(::Type{GenericAffExpr{C,V}}) where {C,V} = GenericAffExpr{C,V}(V[],C[],zero(C))
 Base.one(::Type{GenericAffExpr{C,V}}) where { C,V} = GenericAffExpr{C,V}(V[],C[], one(C))

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -275,7 +275,7 @@ function constructconstraint!(_error::Function, aff::AffExpr, set::S) where S <:
     return AffExprConstraint(aff, S(MOIU.getconstant(set)-offset))
 end
 
-constructconstraint!(_error::Function, x::AbstractArray, set::MOI.AbstractScalarSet) = error("Unexpected vector in scalar constraint. Did you mean to use the dot comparison operators like .==, .<=, and .>= instead?")
+constructconstraint!(_error::Function, x::AbstractArray, set::MOI.AbstractScalarSet) = _error("Unexpected vector in scalar constraint. Did you mean to use the dot comparison operators like .==, .<=, and .>= instead?")
 constructconstraint!(_error::Function, x::Vector{AffExpr}, set::MOI.AbstractVectorSet) = VectorAffExprConstraint(x, set)
 
 function constructconstraint!(_error::Function, quad::QuadExpr, set::S) where S <: Union{MOI.LessThan,MOI.GreaterThan,MOI.EqualTo}
@@ -312,7 +312,7 @@ function constructconstraint!(_error::Function, aff::AffExpr, lb::Real, ub::Real
     AffExprConstraint(aff,MOI.Interval(lb-offset,ub-offset))
 end
 
-constructconstraint!(_error::Function, q::QuadExpr, lb, ub) = error("Two-sided quadratic constraints not supported. (Try @NLconstraint instead.)")
+constructconstraint!(_error::Function, q::QuadExpr, lb, ub) = _error("Two-sided quadratic constraints not supported. (Try @NLconstraint instead.)")
 
 function constructconstraint!(_error::Function, expr, lb, ub)
     @assert !(lb isa Number) || !(ub isa Number)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -320,9 +320,6 @@ function constructconstraint!(_error::Function, expr, lb, ub)
     ub isa Number || _error(string("Expected $ub to be a number."))
 end
 
-coeftype(::Variable) = Float64
-coeftype(::T) where T<:Number = T
-
 # TODO: update 3-argument @constraint macro to pass through names like @variable
 
 """

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -316,6 +316,7 @@ constructconstraint!(q::QuadExpr, lb, ub) = error("Two-sided quadratic constrain
 
 constraint_error(args, str) = error("In @constraint($(join(args,","))): ", str)
 
+coeftype(::Variable) = Float64
 coeftype(::T) where T<:Number = T
 
 # TODO: update 3-argument @constraint macro to pass through names like @variable

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -315,6 +315,10 @@ end
 constructconstraint!(_error::Function, q::QuadExpr, lb, ub) = _error("Two-sided quadratic constraints not supported. (Try @NLconstraint instead.)")
 
 function constructconstraint!(_error::Function, expr, lb, ub)
+    # It could happen that a call is dispatched to this method with `lb` and `ub` that are `Number`,
+    # e.g. if there is not `constructconstraint!` method defined for the type of `expr`.
+    # In that case, no error will be thrown and `@constraint` will silently do nothing.
+    # We want to avoid that so we use this assert.
     @assert !(lb isa Number) || !(ub isa Number)
     lb isa Number || _error(string("Expected $lb to be a number."))
     ub isa Number || _error(string("Expected $ub to be a number."))

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -315,13 +315,11 @@ end
 constructconstraint!(_error::Function, q::QuadExpr, lb, ub) = _error("Two-sided quadratic constraints not supported. (Try @NLconstraint instead.)")
 
 function constructconstraint!(_error::Function, expr, lb, ub)
-    # It could happen that a call is dispatched to this method with `lb` and `ub` that are `Number`,
-    # e.g. if there is not `constructconstraint!` method defined for the type of `expr`.
-    # In that case, no error will be thrown and `@constraint` will silently do nothing.
-    # We want to avoid that so we use this assert.
-    @assert !(lb isa Number) || !(ub isa Number)
     lb isa Number || _error(string("Expected $lb to be a number."))
     ub isa Number || _error(string("Expected $ub to be a number."))
+    if lb isa Number && ub isa Number
+        _error("Range constraint is not supported for $expr.")
+    end
 end
 
 # TODO: update 3-argument @constraint macro to pass through names like @variable

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -25,7 +25,6 @@ mutable struct GenericQuadExpr{CoefType,VarType} <: AbstractJuMPScalar
     qcoeffs::Vector{CoefType}
     aff::GenericAffExpr{CoefType,VarType}
 end
-coeftype(::GenericQuadExpr{C,V}) where {C,V} = C
 
 Base.isempty(q::GenericQuadExpr) = (length(q.qvars1) == 0 && isempty(q.aff))
 Base.zero(::Type{GenericQuadExpr{C,V}}) where {C,V} = GenericQuadExpr(V[], V[], C[], zero(GenericAffExpr{C,V}))

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -6,18 +6,18 @@ struct PSDCone end
 # this allows to get the constraint reference, e.g.
 # @variable m x[1:2,1:2] Symmetric # x is Symmetric{Variable,Matrix{Variable}}
 # varpsd = @constraint m x in PSDCone()
-function constructconstraint!(Q::Symmetric{Variable,Matrix{Variable}}, ::PSDCone)
+function constructconstraint!(_error::Function, Q::Symmetric{Variable,Matrix{Variable}}, ::PSDCone)
     n = Base.LinAlg.checksquare(Q)
     VectorOfVariablesConstraint([Q[i, j] for j in 1:n for i in 1:j], MOI.PositiveSemidefiniteConeTriangle(n))
 end
 # @variable m x[1:2,1:2] # x is Matrix{Variable}
 # varpsd = @constraint m x in PSDCone()
-function constructconstraint!(Q::Matrix{Variable}, ::PSDCone)
+function constructconstraint!(_error::Function, Q::Matrix{Variable}, ::PSDCone)
     n = Base.LinAlg.checksquare(Q)
     VectorOfVariablesConstraint(vec(Q), MOI.PositiveSemidefiniteConeSquare(n))
 end
 
-function constructconstraint!(x::AbstractMatrix, ::PSDCone)
+function constructconstraint!(_error::Function, x::AbstractMatrix, ::PSDCone)
     n = Base.LinAlg.checksquare(x)
     # Support for non-symmetric matrices as done prior to JuMP v0.19
     # will be added once the appropriate cone has been added in MathOptInterface

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -11,7 +11,6 @@ struct Variable <: AbstractJuMPScalar
     m::Model
     index::MOIVAR
 end
-coeftype(::Variable) = Float64
 
 function MOI.delete!(m::Model, v::Variable)
     @assert m === v.m

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -11,6 +11,7 @@ struct Variable <: AbstractJuMPScalar
     m::Model
     index::MOIVAR
 end
+coeftype(::Variable) = Float64
 
 function MOI.delete!(m::Model, v::Variable)
     @assert m === v.m

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -59,4 +59,59 @@ end
         end
     end
 
+    @testset "Check @constraint basics" begin
+        m = Model()
+        @variable(m, w)
+        @variable(m, x)
+        @variable(m, y)
+        @variable(m, z)
+        t = 10.0
+
+        cref = @constraint(m, 3x - y == 3.3(w + 2z) + 5)
+        c = JuMP.constraintobject(cref, AffExpr, MOI.EqualTo)
+        @test JuMP.isequal_canonical(c.func, 3*x - y - 3.3*w - 6.6*z)
+        @test c.set == MOI.EqualTo(5.0)
+
+        cref = @constraint(m, 3x - y == (w + 2z)*3.3 + 5)
+        c = JuMP.constraintobject(cref, AffExpr, MOI.EqualTo)
+        @test JuMP.isequal_canonical(c.func, 3*x - y - 3.3*w - 6.6*z)
+        @test c.set == MOI.EqualTo(5.0)
+
+        cref = @constraint(m, (x+y)/2 == 1)
+        c = JuMP.constraintobject(cref, AffExpr, MOI.EqualTo)
+        @test JuMP.isequal_canonical(c.func, 0.5*x + 0.5*y)
+        @test c.set == MOI.EqualTo(1.0)
+
+        cref = @constraint(m, -1 <= x-y <= t)
+        c = JuMP.constraintobject(cref, AffExpr, MOI.Interval)
+        @test JuMP.isequal_canonical(c.func, x - y)
+        @test c.set == MOI.Interval(-1.0, t)
+
+        cref = @constraint(m, -1 <= x+1 <= 1)
+        c = JuMP.constraintobject(cref, AffExpr, MOI.Interval)
+        @test JuMP.isequal_canonical(c.func, 1x)
+        @test c.set == MOI.Interval(-2.0, 0.0)
+
+        cref = @constraint(m, -1 <= x <= 1)
+        c = JuMP.constraintobject(cref, Variable, MOI.Interval)
+        @test c.func == x
+        @test c.set == MOI.Interval(-1.0, 1.0)
+
+        cref = @constraint(m, -1 <= x <= sum(0.5 for i = 1:2))
+        c = JuMP.constraintobject(cref, Variable, MOI.Interval)
+        @test c.func == x
+        @test c.set == MOI.Interval(-1.0, 1.0)
+
+        @test_throws ErrorException @constraint(m, x <= t <= y)
+        @test macroexpand(:(@constraint(m, 1 >= x >= 0))).head == :error
+        @test macroexpand(:(@constraint(1 <= x <= 2, foo=:bar))).head == :error
+
+        @test JuMP.isequal_canonical(@expression(m, 3x - y - 3.3(w + 2z) + 5), 3*x - y - 3.3*w - 6.6*z + 5)
+        @test JuMP.isequal_canonical(@expression(m, quad, (w+3)*(2x+1)+10), 2*w*x + 6*x + w + 13)
+
+        cref = @constraint(m, 3 + 5*7 <= 0)
+        c = JuMP.constraintobject(cref, AffExpr, MOI.LessThan)
+        @test JuMP.isequal_canonical(c.func, zero(AffExpr))
+        @test c.set == MOI.LessThan(-38.0)
+    end
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -103,6 +103,7 @@ end
         @test c.set == MOI.Interval(-1.0, 1.0)
 
         @test_throws ErrorException @constraint(m, x <= t <= y)
+        @test_throws ErrorException @constraint(m, 0 <= nothing <= 1)
         @test macroexpand(:(@constraint(m, 1 >= x >= 0))).head == :error
         @test macroexpand(:(@constraint(1 <= x <= 2, foo=:bar))).head == :error
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -16,9 +16,9 @@ end
     @testset "constructconstraint! on variable" begin
         m = Model()
         @variable(m, x)
-        @test JuMP.constructconstraint!(x, MOI.GreaterThan(0.0)) isa JuMP.SingleVariableConstraint{MOI.GreaterThan{Float64}}
-        @test JuMP.constructconstraint!(x, MOI.LessThan(0.0)) isa JuMP.SingleVariableConstraint{MOI.LessThan{Float64}}
-        @test JuMP.constructconstraint!(x, MOI.EqualTo(0)) isa JuMP.SingleVariableConstraint{MOI.EqualTo{Int}}
+        @test JuMP.constructconstraint!(error, x, MOI.GreaterThan(0.0)) isa JuMP.SingleVariableConstraint{MOI.GreaterThan{Float64}}
+        @test JuMP.constructconstraint!(error, x, MOI.LessThan(0.0)) isa JuMP.SingleVariableConstraint{MOI.LessThan{Float64}}
+        @test JuMP.constructconstraint!(error, x, MOI.EqualTo(0)) isa JuMP.SingleVariableConstraint{MOI.EqualTo{Int}}
     end
 
     @testset "Extension of @variable with constructvariable! #1029" begin

--- a/test/old/macros.jl
+++ b/test/old/macros.jl
@@ -68,42 +68,6 @@ end
         @test sumexpr.args[2].args[3] == :(j = 1:M)
     end
 
-    @testset "Check @constraint basics" begin
-        m = Model()
-        @variable(m, w)
-        @variable(m, x)
-        @variable(m, y)
-        @variable(m, z)
-        t = 10
-
-        @constraint(m, 3x - y == 3.3(w + 2z) + 5)
-        @test string(m.linconstr[end]) == "3 x - y - 3.3 w - 6.6 z $eq 5"
-        @constraint(m, 3x - y == (w + 2z)*3.3 + 5)
-        @test string(m.linconstr[end]) == "3 x - y - 3.3 w - 6.6 z $eq 5"
-        @constraint(m, (x+y)/2 == 1)
-        @test string(m.linconstr[end]) == "0.5 x + 0.5 y $eq 1"
-        @constraint(m, -1 <= x-y <= t)
-        @test string(m.linconstr[end]) == "-1 $leq x - y $leq 10"
-        @constraint(m, -1 <= x+1 <= 1)
-        @test string(m.linconstr[end]) == "-2 $leq x $leq 0"
-        @constraint(m, -1 <= x <= 1)
-        @test string(m.linconstr[end]) == "-1 $leq x $leq 1"
-        @constraint(m, -1 <= x <= sum(0.5 for i = 1:2))
-        @test string(m.linconstr[end]) == "-1 $leq x $leq 1"
-        @test_throws ErrorException @constraint(m, x <= t <= y)
-        @test macroexpand(:(@constraint(m, 1 >= x >= 0))).head == :error
-        @test macroexpand(:(@constraint(1 <= x <= 2, foo=:bar))).head == :error
-
-        @expression(m, aff, 3x - y - 3.3(w + 2z) + 5)
-        @test string(aff) == "3 x - y - 3.3 w - 6.6 z + 5"
-
-        @constraint(m, 3 + 5*7 <= 0)
-        @test string(m.linconstr[end]) == "0 $leq -38"
-
-        @expression(m, qaff, (w+3)*(2x+1)+10)
-        @test string(qaff) == "2 w*x + 6 x + w + 13"
-    end
-
     @testset "Checking @variable with reverse direction bounds" begin
         m = Model()
         @variable(m, 3.2 >= x >= 1)


### PR DESCRIPTION
Due to the use of `Val{false}`, `aff` can now be a variable or a number in range constraints hence we also need to define `coeftype` for these.