### PR TITLE
Fix tests of macro errors in Julia v0.7

### DIFF
--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -194,14 +194,14 @@ end
         m = Model()
         @test_throws ErrorException @variable(m, unequal[1:5,1:6], PSD)
         # Some of these errors happen at compile time, so we can't use @test_throws
-        @test macroexpand(:(@variable(m, notone[1:5,2:6], PSD))).head == :error
-        @test macroexpand(:(@variable(m, oneD[1:5], PSD))).head == :error
-        @test macroexpand(:(@variable(m, threeD[1:5,1:5,1:5], PSD))).head == :error
-        @test macroexpand(:(@variable(m, psd[2] <= rand(2,2), PSD))).head == :error
-        @test macroexpand(:(@variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), PSD))).head == :error
-        @test macroexpand(:(@variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), Symmetric))).head == :error
-        @test macroexpand(:(@variable(m, -ones(4,4) <= foo[1:4,1:4] <= ones(4,5), Symmetric))).head == :error
-        @test macroexpand(:(@variable(m, -rand(5,5) <= nonsymmetric[1:5,1:5] <= rand(5,5), Symmetric))).head == :error
+        @test_macro_throws @variable(m, notone[1:5,2:6], PSD)
+        @test_macro_throws @variable(m, oneD[1:5], PSD)
+        @test_macro_throws @variable(m, threeD[1:5,1:5,1:5], PSD)
+        @test_macro_throws @variable(m, psd[2] <= rand(2,2), PSD)
+        @test_macro_throws @variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), PSD)
+        @test_macro_throws @variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), Symmetric)
+        @test_macro_throws @variable(m, -ones(4,4) <= foo[1:4,1:4] <= ones(4,5), Symmetric)
+        @test_macro_throws @variable(m, -rand(5,5) <= nonsymmetric[1:5,1:5] <= rand(5,5), Symmetric)
     end
 
     @testset "[macros] sum(generator)" begin

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -194,14 +194,14 @@ end
         m = Model()
         @test_throws ErrorException @variable(m, unequal[1:5,1:6], PSD)
         # Some of these errors happen at compile time, so we can't use @test_throws
-        @test_macro_throws @variable(m, notone[1:5,2:6], PSD)
-        @test_macro_throws @variable(m, oneD[1:5], PSD)
-        @test_macro_throws @variable(m, threeD[1:5,1:5,1:5], PSD)
-        @test_macro_throws @variable(m, psd[2] <= rand(2,2), PSD)
-        @test_macro_throws @variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), PSD)
-        @test_macro_throws @variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), Symmetric)
-        @test_macro_throws @variable(m, -ones(4,4) <= foo[1:4,1:4] <= ones(4,5), Symmetric)
-        @test_macro_throws @variable(m, -rand(5,5) <= nonsymmetric[1:5,1:5] <= rand(5,5), Symmetric)
+        @test_macro_throws ErrorException @variable(m, notone[1:5,2:6], PSD)
+        @test_macro_throws ErrorException @variable(m, oneD[1:5], PSD)
+        @test_macro_throws ErrorException @variable(m, threeD[1:5,1:5,1:5], PSD)
+        @test_macro_throws ErrorException @variable(m, psd[2] <= rand(2,2), PSD)
+        @test_macro_throws ErrorException @variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), PSD)
+        @test_macro_throws ErrorException @variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), Symmetric)
+        @test_macro_throws ErrorException @variable(m, -ones(4,4) <= foo[1:4,1:4] <= ones(4,5), Symmetric)
+        @test_macro_throws ErrorException @variable(m, -rand(5,5) <= nonsymmetric[1:5,1:5] <= rand(5,5), Symmetric)
     end
 
     @testset "[macros] sum(generator)" begin

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -109,7 +109,7 @@ end
 
         @test_throws ErrorException @constraint(m, x <= t <= y)
         @test_throws ErrorException @constraint(m, 0 <= nothing <= 1)
-        @test_macro_throws @constraint(1 <= x <= 2, foo=:bar)
+        @test_macro_throws ErrorException @constraint(1 <= x <= 2, foo=:bar)
 
         @test JuMP.isequal_canonical(@expression(m, 3x - y - 3.3(w + 2z) + 5), 3*x - y - 3.3*w - 6.6*z + 5)
         @test JuMP.isequal_canonical(@expression(m, quad, (w+3)*(2x+1)+10), 2*w*x + 6*x + w + 13)

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -109,7 +109,7 @@ end
 
         @test_throws ErrorException @constraint(m, x <= t <= y)
         @test_throws ErrorException @constraint(m, 0 <= nothing <= 1)
-        @test macroexpand(:(@constraint(1 <= x <= 2, foo=:bar))).head == :error
+        @test_macro_throws @constraint(1 <= x <= 2, foo=:bar)
 
         @test JuMP.isequal_canonical(@expression(m, 3x - y - 3.3(w + 2z) + 5), 3*x - y - 3.3*w - 6.6*z + 5)
         @test JuMP.isequal_canonical(@expression(m, quad, (w+3)*(2x+1)+10), 2*w*x + 6*x + w + 13)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,12 +20,8 @@ const MOIU = MOI.Utilities
 
 # Test that the macro call `m` throws an error exception during pre-compilation
 macro test_macro_throws(m)
-    if VERSION >= v"0.7.0-DEV.1676" # See https://github.com/JuliaLang/julia/pull/23533
-        # See https://discourse.julialang.org/t/test-throws-with-macros-after-pr-23533/5878
-        :(@test_throws ErrorException try @eval $m catch err; throw(err.error) end)
-    else
-        :(@test macroexpand(m).head == :error)
-    end
+    # See https://discourse.julialang.org/t/test-throws-with-macros-after-pr-23533/5878
+    :(@test_throws ErrorException try @eval $m catch err; throw(err.error) end)
 end
 
 include("derivatives.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,16 @@ const MOI = MathOptInterface
 const MOIT = MOI.Test
 const MOIU = MOI.Utilities
 
+# Test that the macro call `m` throws an error exception during pre-compilation
+macro test_macro_throws(m)
+    if VERSION >= v"0.7.0-DEV.1676" # See https://github.com/JuliaLang/julia/pull/23533
+        # See https://discourse.julialang.org/t/test-throws-with-macros-after-pr-23533/5878
+        :(@test_throws ErrorException try @eval $m catch err; throw(err.error) end)
+    else
+        :(@test macroexpand(m).head == :error)
+    end
+end
+
 include("derivatives.jl")
 include("derivatives_coloring.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,9 +19,9 @@ const MOIT = MOI.Test
 const MOIU = MOI.Utilities
 
 # Test that the macro call `m` throws an error exception during pre-compilation
-macro test_macro_throws(m)
+macro test_macro_throws(errortype, m)
     # See https://discourse.julialang.org/t/test-throws-with-macros-after-pr-23533/5878
-    :(@test_throws ErrorException try @eval $m catch err; throw(err.error) end)
+    :(@test_throws $errortype try @eval $m catch err; throw(err.error) end)
 end
 
 include("derivatives.jl")


### PR DESCRIPTION
The macroexpand way to test if a macro throws an error during pre-compilation does not work on Julia v0.7 because of https://github.com/JuliaLang/julia/pull/23533. One solution is suggested [here](https://discourse.julialang.org/t/test-throws-with-macros-after-pr-23533/5878)