### PR TITLE
Introduce AbstractVariableRef

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -289,10 +289,10 @@ end
 
 include("variables.jl")
 
-Base.zero(::Type{VariableRef}) = AffExpr(VariableRef[],Float64[],0.0)
-Base.zero(::VariableRef) = zero(VariableRef)
-Base.one(::Type{VariableRef}) = AffExpr(VariableRef[],Float64[],1.0)
-Base.one(::VariableRef) = one(VariableRef)
+Base.zero(::Type{V}) where V<:AbstractVariableRef = zero(GenericAffExpr{Float64, V})
+Base.zero(v::AbstractVariableRef) = zero(typeof(v))
+Base.one(::Type{V}) where V<:AbstractVariableRef = one(GenericAffExpr{Float64, V})
+Base.one(v::AbstractVariableRef) = one(typeof(v))
 
 mutable struct VariableNotOwnedError <: Exception
     context::String
@@ -463,7 +463,7 @@ function Base.setindex!(m::JuMP.Model, value, name::Symbol)
 end
 
 # usage warnings
-function operator_warn(lhs::AffExpr,rhs::AffExpr)
+function operator_warn(lhs::GenericAffExpr,rhs::GenericAffExpr)
     if length(lhs.vars) > 50 || length(rhs.vars) > 50
         if length(lhs.vars) > 1
             m = lhs.vars[1].m

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -128,6 +128,8 @@ function isequal_canonical(aff::GenericAffExpr{C,V}, other::GenericAffExpr{C,V})
     return isequal(d1,d2) && aff.constant == other.constant
 end
 
+Base.convert(::Type{GenericAffExpr{T,V}}, v::V)    where {T,V} = GenericAffExpr([v], [one(T)], zero(T))
+Base.convert(::Type{GenericAffExpr{T,V}}, v::Real) where {T,V} = GenericAffExpr(VariableRef[], T[], T(v))
 
 # Alias for (Float64, VariableRef), the specific GenericAffExpr used by JuMP
 const AffExpr = GenericAffExpr{Float64,VariableRef}

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -135,13 +135,13 @@ Base.convert(::Type{GenericAffExpr{T,V}}, v::Real) where {T,V} = GenericAffExpr(
 
 # Alias for (Float64, VariableRef), the specific GenericAffExpr used by JuMP
 const AffExpr = GenericAffExpr{Float64,VariableRef}
-AffExpr() = zero(AffExpr)
 
 Base.convert(::Type{AffExpr}, v::VariableRef) = AffExpr([v], [1.], 0.)
 Base.convert(::Type{AffExpr}, v::Real) = AffExpr(VariableRef[], Float64[], v)
+GenericAffExpr{C, V}() where {C, V} = zero(GenericAffExpr{C, V})
 
 # Check all coefficients are finite, i.e. not NaN, not Inf, not -Inf
-function assert_isfinite(a::AffExpr)
+function assert_isfinite(a::GenericAffExpr)
     coeffs = a.coeffs
     for i in 1:length(a.vars)
         isfinite(coeffs[i]) || error("Invalid coefficient $(coeffs[i]) on variable $(a.vars[i])")
@@ -149,12 +149,12 @@ function assert_isfinite(a::AffExpr)
 end
 
 """
-    resultvalue(v::AffExpr)
+    resultvalue(v::GenericAffExpr)
 
-Evaluate an `AffExpr` given the result returned by a solver.
+Evaluate an `GenericAffExpr` given the result returned by a solver.
 Replaces `getvalue` for most use cases.
 """
-resultvalue(a::AffExpr) = value(a, resultvalue)
+resultvalue(a::GenericAffExpr) = value(a, resultvalue)
 
 # Note: No validation is performed that the variables in the AffExpr belong to
 # the same model.
@@ -221,8 +221,8 @@ end
 
 # Copy an affine expression to a new model by converting all the
 # variables to the new model's variables
-function Base.copy(a::AffExpr, new_model::Model)
-    AffExpr(copy(a.vars, new_model), copy(a.coeffs), a.constant)
+function Base.copy(a::GenericAffExpr, new_model::Model)
+    GenericAffExpr(copy(a.vars, new_model), copy(a.coeffs), a.constant)
 end
 
 # TODO GenericAffExprConstraint

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -24,6 +24,8 @@ mutable struct GenericAffExpr{CoefType,VarType} <: AbstractJuMPScalar
     constant::CoefType
 end
 
+variablereftype(::GenericAffExpr{C, V}) where {C, V} = V
+
 Base.iszero(a::GenericAffExpr) = isempty(a.vars) && iszero(a.constant)
 Base.zero(::Type{GenericAffExpr{C,V}}) where {C,V} = GenericAffExpr{C,V}(V[],C[],zero(C))
 Base.one(::Type{GenericAffExpr{C,V}}) where { C,V} = GenericAffExpr{C,V}(V[],C[], one(C))
@@ -107,7 +109,7 @@ function Base.isequal(aff::GenericAffExpr{C,V},other::GenericAffExpr{C,V}) where
     return true
 end
 
-# Check if two AffExprs are equal regardless of the order, and after merging duplicates
+# Check if two GenericAffExprs are equal regardless of the order, and after merging duplicates
 # Mostly useful for testing.
 function isequal_canonical(aff::GenericAffExpr{C,V}, other::GenericAffExpr{C,V}) where {C,V}
     function canonicalize(a)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -461,18 +461,18 @@ Base.:*(x::AbstractArray{T}) where {T<:JuMPTypes} = x
 ###############################################################################
 # Add nonlinear function fallbacks for JuMP built-in types
 const op_hint = "Are you trying to build a nonlinear problem? Make sure you use @NLconstraint/@NLobjective."
-for (func,_) in Calculus.symbolic_derivatives_1arg(), typ in [:AbstractVariableRef,:AffExpr,:QuadExpr]
+for (func,_) in Calculus.symbolic_derivatives_1arg(), typ in [:AbstractVariableRef,:GenericAffExpr,:GenericQuadExpr]
     errstr = "$func is not defined for type $typ. $op_hint"
     if isdefined(Base, func)
         @eval Base.$(func)(::$typ) = error($errstr)
     end
 end
 
-Base.:*(::T,::S) where {T<:QuadExpr,S<:Union{AbstractVariableRef,AffExpr,QuadExpr}} =
+Base.:*(::T,::S) where {T<:GenericQuadExpr,S<:Union{AbstractVariableRef,GenericAffExpr,GenericQuadExpr}} =
     error( "*(::$T,::$S) is not defined. $op_hint")
-Base.:*(lhs::QuadExpr, rhs::QuadExpr) =
-    error( "*(::QuadExpr,::QuadExpr) is not defined. $op_hint")
-Base.:*(::S,::T) where {T<:QuadExpr,S<:Union{AbstractVariableRef,AffExpr,QuadExpr}} =
+Base.:*(lhs::GenericQuadExpr, rhs::GenericQuadExpr) =
+    error( "*(::GenericQuadExpr,::GenericQuadExpr) is not defined. $op_hint")
+Base.:*(::S,::T) where {T<:GenericQuadExpr,S<:Union{AbstractVariableRef,GenericAffExpr,GenericQuadExpr}} =
     error( "*(::$S,::$T) is not defined. $op_hint")
-Base.:/(::S,::T) where {S<:Union{Number,AbstractVariableRef,AffExpr,QuadExpr},T<:Union{AbstractVariableRef,AffExpr,QuadExpr}} =
+Base.:/(::S,::T) where {S<:Union{Number,AbstractVariableRef,GenericAffExpr,GenericQuadExpr},T<:Union{AbstractVariableRef,GenericAffExpr,GenericQuadExpr}} =
     error( "/(::$S,::$T) is not defined. $op_hint")

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -74,9 +74,9 @@ function Base.:^(lhs::Union{AbstractVariableRef,GenericAffExpr}, rhs::Integer)
     if rhs == 2
         return lhs*lhs
     elseif rhs == 1
-        return GenericQuadExpr(lhs)
+        return GenericQuadExpr{Float64, variablereftype(lhs)}(lhs)
     elseif rhs == 0
-        return GenericQuadExpr(1.0)
+        return one(GenericQuadExpr{Float64, variablereftype(lhs)})
     else
         error("Only exponents of 0, 1, or 2 are currently supported. Are you trying to build a nonlinear problem? Make sure you use @NLconstraint/@NLobjective.")
     end

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -83,7 +83,7 @@ end
 
 # Alias for (Float64, VariableRef)
 const QuadExpr = GenericQuadExpr{Float64,VariableRef}
-Base.convert(::Type{QuadExpr}, v::Union{Real,VariableRef,AffExpr}) = QuadExpr(VariableRef[], VariableRef[], Float64[], AffExpr(v))
+Base.convert(::Type{QuadExpr}, v::Union{Real,VariableRef,GenericAffExpr}) = QuadExpr(VariableRef[], VariableRef[], Float64[], AffExpr(v))
 QuadExpr() = zero(QuadExpr)
 
 function MOI.ScalarQuadraticFunction(q::QuadExpr)
@@ -93,7 +93,7 @@ end
 
 function QuadExpr(m::Model, f::MOI.ScalarQuadraticFunction)
     scaledcoef = [(v1 == v2) ? coef/2 : coef for (v1, v2, coef) in zip(f.quadratic_rowvariables, f.quadratic_colvariables, f.quadratic_coefficients)]
-    return QuadExpr(VariableRef.(m,f.quadratic_rowvariables), VariableRef.(m, f.quadratic_colvariables), scaledcoef, AffExpr(VariableRef.(m,f.affine_variables), f.affine_coefficients, f.constant))
+    return QuadExpr(VariableRef.(m,f.quadratic_rowvariables), VariableRef.(m, f.quadratic_colvariables), scaledcoef, GenericAffExpr(VariableRef.(m,f.affine_variables), f.affine_coefficients, f.constant))
 end
 
 function setobjective(m::Model, sense::Symbol, a::QuadExpr)

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -83,8 +83,8 @@ end
 
 # Alias for (Float64, VariableRef)
 const QuadExpr = GenericQuadExpr{Float64,VariableRef}
-Base.convert(::Type{QuadExpr}, v::Union{Real,VariableRef,GenericAffExpr}) = QuadExpr(VariableRef[], VariableRef[], Float64[], AffExpr(v))
-QuadExpr() = zero(QuadExpr)
+Base.convert(::Type{GenericQuadExpr{C, V}}, v::Union{Real,VariableRef,GenericAffExpr}) where {C, V} = GenericQuadExpr(V[], V[], C[], GenericAffExpr{C, V}(v))
+GenericQuadExpr{C, V}() where {C, V} = zero(GenericQuadExpr{C, V})
 
 function MOI.ScalarQuadraticFunction(q::QuadExpr)
     scaledcoef = [(v1 == v2) ? 2coef : coef for (v1,v2,coef) in zip(q.qvars1, q.qvars2, q.qcoeffs)]
@@ -121,8 +121,8 @@ end
 
 # Copy a quadratic expression to a new model by converting all the
 # variables to the new model's variables
-function Base.copy(q::QuadExpr, new_model::Model)
-    QuadExpr(copy(q.qvars1, new_model), copy(q.qvars2, new_model),
+function Base.copy(q::GenericQuadExpr, new_model::Model)
+    GenericQuadExpr(copy(q.qvars1, new_model), copy(q.qvars2, new_model),
                 copy(q.qcoeffs), copy(q.aff, new_model))
 end
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -25,7 +25,7 @@ end
 """
     AbstractVariableRef
 
-Variable returned by [`addvariable`](@ref). Affine (resp. quadratic) operations with variables of type `V<:AbstractVariableRef` and coefficients of type `T` creates a `GenericAffExpr{T,V}` (resp. `GenericQuadExpr{T,V}`).
+Variable returned by [`addvariable`](@ref). Affine (resp. quadratic) operations with variables of type `V<:AbstractVariableRef` and coefficients of type `T` create a `GenericAffExpr{T,V}` (resp. `GenericQuadExpr{T,V}`).
 """
 abstract type AbstractVariableRef <: AbstractJuMPScalar end
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -29,6 +29,8 @@ Variable returned by [`addvariable`](@ref). Affine (resp. quadratic) operations 
 """
 abstract type AbstractVariableRef <: AbstractJuMPScalar end
 
+variablereftype(v::AbstractVariableRef) = typeof(v)
+
 """
     VariableRef <: AbstractVariableRef
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -22,11 +22,18 @@ struct ScalarVariable{S, T, U, V} <: AbstractVariable
     info::VariableInfo{S, T, U, V}
 end
 
+"""
+    AbstractVariableRef
+
+Variable returned by [`addvariable`](@ref). Affine (resp. quadratic) operations with variables of type `V<:AbstractVariableRef` and coefficients of type `T` creates a `GenericAffExpr{T,V}` (resp. `GenericQuadExpr{T,V}`).
+"""
 abstract type AbstractVariableRef <: AbstractJuMPScalar end
 
-#############################################################################
-# VariableRef
-# Holds a reference to the model and the corresponding MOI.VariableIndex.
+"""
+    VariableRef <: AbstractVariableRef
+
+Holds a reference to the model and the corresponding MOI.VariableIndex.
+"""
 struct VariableRef <: AbstractVariableRef
     m::Model
     index::MOIVAR

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -22,10 +22,12 @@ struct ScalarVariable{S, T, U, V} <: AbstractVariable
     info::VariableInfo{S, T, U, V}
 end
 
+abstract type AbstractVariableRef <: AbstractJuMPScalar end
+
 #############################################################################
 # VariableRef
 # Holds a reference to the model and the corresponding MOI.VariableIndex.
-struct VariableRef <: AbstractJuMPScalar
+struct VariableRef <: AbstractVariableRef
     m::Model
     index::MOIVAR
 end


### PR DESCRIPTION
JuMP extensions may define new variable types returned by `addvariable` that should also behave like classical variables for standard arithmetic operations (e.g. as discussed with @mlubin on Gitter, StructJuMP may create its own variable type not tied to MOI).
This PR creates the `AbstractVariableRef` for holding variables as returned by `addvariable`/`@variable`. It also generalize some operations defined in `operators.jl` to work on any `AbstractVariableRef`