### PR TITLE
Fix inconsistency between setstart and setstartvalue

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -48,7 +48,7 @@ export
     #getvalue, setvalue,
     #getdual,
     #setcategory, getcategory,
-    setstart,
+    setstartvalue,
     linearindex,
     # Expressions and constraints
     linearterms,

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -409,7 +409,7 @@ Replaces `getvalue` for most use cases.
 resultvalue(v::VariableRef) = MOI.get(v.m, MOI.VariablePrimal(), v)
 hasresultvalues(m::Model) = MOI.canget(m, MOI.VariablePrimal(), VariableRef)
 
-@Base.deprecate setvalue(v::VariableRef, val::Number) setstart(v, val)
+@Base.deprecate setvalue(v::VariableRef, val::Number) setstartvalue(v, val)
 
 """
     addvariable(m::Model, v::AbstractVariable, name::String="")


### PR DESCRIPTION
The function name is `setstartvalue` the we export `setstart` and use `setstart` in the depwarn