### PR TITLE
Add issue template. Copied from Julialang/julia.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,7 +6,10 @@ If the bug you're experiencing is solver-specific (e.g., it only happens when yo
 the issue is best raised at the relevent solver-wrapper repository. If you are unsure, you should
 raise the problem on Discourse.
 
-If you've confirmed that the behaviour is a bug, and it relates to JuMP, this is the right place.
+If you're reasonably sure that the behavior is a bug, and it relates to JuMP, this is the right place.
 Be sure to include as much relevant information as possible, including a [minimal reproducible example](https://stackoverflow.com/help/mcve).
+
+Alternatively, if you have a feature request for JuMP, this is also the right place. Just make it clear 
+by making the title of your issue `Feature Request: my cool new feature`.
 
 Thanks for contributing to JuMP!

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,11 @@ If you have a question or are unsure if the behavior you're experiencing is a bu
 please search or post to our Discourse site: https://discourse.julialang.org/c/domain/opt. We use
 the GitHub issue tracker for bug reports and feature requests only.
 
-If you're submitting a bug report, be sure to include as much relevant information as
-possible, including a [minimal reproducible example](https://stackoverflow.com/help/mcve).
+If the bug you're experiencing is solver-specific (e.g., it only happens when you use Gurobi),
+the issue is best raised at the relevent solver-wrapper repository. If you are unsure, you should
+raise the problem on Discourse.
+
+If you've confirmed that the behaviour is a bug, and it relates to JuMP, this is the right place.
+Be sure to include as much relevant information as possible, including a [minimal reproducible example](https://stackoverflow.com/help/mcve).
 
 Thanks for contributing to JuMP!

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,8 +3,8 @@ please search or post to our Discourse site: https://discourse.julialang.org/c/d
 the GitHub issue tracker for bug reports and feature requests only.
 
 If the bug you're experiencing is solver-specific (e.g., it only happens when you use Gurobi),
-the issue is best raised at the relevant solver-wrapper repository. If you are unsure, you should
-raise the problem on Discourse.
+the issue is best raised at the relevant solver-wrapper repository (e.g., [Gurobi.jl](https://github.com/JuliaOpt/Gurobi.jl)). If you are
+unsure, you should raise the problem on Discourse.
 
 If you're reasonably sure that the behavior is a bug, and it relates to JuMP, this is the right place.
 Be sure to include as much relevant information as possible, including a [minimal reproducible example](https://stackoverflow.com/help/mcve).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+If you have a question or are unsure if the behavior you're experiencing is a bug,
+please search or post to our Discourse site: https://discourse.julialang.org/c/domain/opt. We use
+the GitHub issue tracker for bug reports and feature requests only.
+
+If you're submitting a bug report, be sure to include as much relevant information as
+possible, including a [minimal reproducible example](https://stackoverflow.com/help/mcve).
+
+Thanks for contributing to JuMP!

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@ please search or post to our Discourse site: https://discourse.julialang.org/c/d
 the GitHub issue tracker for bug reports and feature requests only.
 
 If the bug you're experiencing is solver-specific (e.g., it only happens when you use Gurobi),
-the issue is best raised at the relevent solver-wrapper repository. If you are unsure, you should
+the issue is best raised at the relevant solver-wrapper repository. If you are unsure, you should
 raise the problem on Discourse.
 
 If you're reasonably sure that the behavior is a bug, and it relates to JuMP, this is the right place.


### PR DESCRIPTION
This should help steer people towards Discourse as their first port of call.

Ref https://github.com/JuliaLang/julia/blob/master/.github/ISSUE_TEMPLATE.md