### PR TITLE
Fix power in expression

### DIFF
--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -497,9 +497,9 @@ function parseExpr(x, aff::Symbol, lcoeffs::Vector, rcoeffs::Vector, newaff::Sym
                 push!(blk.args, :($newaff = addtoexpr_reorder($aff, $(Expr(:call,:*,lcoeffs...,newaff_,newaff_,rcoeffs...)))))
                 return newaff, blk
             elseif x.args[3] == 1
-                return parseExpr(x.args[2], aff, lcoeffs, rcoeffs)
+                return parseExpr(:(QuadExpr($(x.args[2]))), aff, lcoeffs, rcoeffs)
             elseif x.args[3] == 0
-                return parseExpr(1, aff, lcoeffs, rcoeffs)
+                return parseExpr(:(QuadExpr(1)), aff, lcoeffs, rcoeffs)
             else
                 blk = Expr(:block)
                 s = gensym()

--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -493,8 +493,8 @@ function parseExpr(x, aff::Symbol, lcoeffs::Vector, rcoeffs::Vector, newaff::Sym
                 blk = Expr(:block)
                 s = gensym()
                 newaff_, parsed = parseExprToplevel(x.args[2], s)
-                push!(blk.args, :($s = 0.0; $parsed))
-                push!(blk.args, :($newaff = $aff + $(Expr(:call,:*,lcoeffs...,newaff_,newaff_,rcoeffs...))))
+                push!(blk.args, :($s = Val(false); $parsed))
+                push!(blk.args, :($newaff = addtoexpr_reorder($aff, $(Expr(:call,:*,lcoeffs...,newaff_,newaff_,rcoeffs...)))))
                 return newaff, blk
             elseif x.args[3] == 1
                 return parseExpr(x.args[2], aff, lcoeffs, rcoeffs)

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -140,10 +140,15 @@ Base.transpose(t::MySumType) = MySumType(t.a)
             @test_throws MethodError aff ≥ 1
             @test_expression_with_string aff - 1 "7.1 x + 1.5"
             @test_expression_with_string aff^2 "50.41 x² + 35.5 x + 6.25"
+            @test_expression_with_string (7.1*x + 2.5)^2 "50.41 x² + 35.5 x + 6.25"
             @test_expression_with_string aff^1 "7.1 x + 2.5"
+            @test_expression_with_string (7.1*x + 2.5)^1 "7.1 x + 2.5"
             @test_expression_with_string aff^0 "1"
+            @test_expression_with_string (7.1*x + 2.5)^0 "1"
             @test_throws ErrorException aff^3
+            @test_throws ErrorException (7.1*x + 2.5)^3
             @test_throws ErrorException aff^1.5
+            @test_throws ErrorException (7.1*x + 2.5)^1.5
             # 3-2 AffExpr--Variable
             @test_expression_with_string aff + z "7.1 x + z + 2.5"
             @test_expression_with_string aff - z "7.1 x - z + 2.5"


### PR DESCRIPTION
`s = Val(false)` was not necessary for the fix but it is consistent with our will to replace the `0.0` with `Val(false)`.
The addition of `QuadExpr` conversion is for consistency with
https://github.com/JuliaOpt/JuMP.jl/blob/master/src/operators.jl#L74-L84

Currently, `aff^1`, `(x+1)^1` and `@expression m aff^1` and return a `QuadExpr` but `@expression m (x+1)^1` returns an `AffExpr`.
Closes #1286 