### PR TITLE
Add test for unary multiplication

### DIFF
--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -443,8 +443,8 @@ function parseExpr(x, aff::Symbol, lcoeffs::Vector, rcoeffs::Vector, newaff::Sym
                 blk = Expr(:block)
                 s = gensym()
                 newaff_, parsed = parseExprToplevel(x.args[2], s)
-                push!(blk.args, :($s = 0.0; $parsed))
-                push!(blk.args, :($newaff = $aff + $(Expr(:call,:*,lcoeffs...,Expr(:call,:^,newaff_,esc(x.args[3])),rcoeffs...))))
+                push!(blk.args, :($s = Val(false); $parsed))
+                push!(blk.args, :($newaff = addtoexpr_reorder($aff, $(Expr(:call,:*,lcoeffs...,Expr(:call,:^,newaff_,esc(x.args[3])),rcoeffs...)))))
                 return newaff, blk
             end
         elseif x.head == :call && x.args[1] == :/

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -1,7 +1,25 @@
+# For "expression^3 and unary*"
+struct PowVariable <: JuMP.AbstractJuMPScalar
+    pow::Int
+end
+Base.:^(x::PowVariable, i::Int) = PowVariable(x.pow*i)
+Base.:*(x::PowVariable, y::PowVariable) = PowVariable(x.pow + y.pow)
+Base.copy(x::PowVariable) = x
+
 @testset "value for GenericAffExpr" begin
     expr1 = JuMP.GenericAffExpr([3, 2], [-5., 4.], 3.)
     @test @inferred(JuMP.value(expr1, -)) == 10.
     expr2 = JuMP.GenericAffExpr(Int[], Int[], 2)
     @test typeof(@inferred(JuMP.value(expr2, i -> 1.0))) == Float64
     @test @inferred(JuMP.value(expr2, i -> 1.0)) == 2.0
+end
+
+@testset "expression^3 and unary*" begin
+    m = Model()
+    x = PowVariable(1)
+    # Calls (*)((x*x)^6)
+    y = @expression m (x*x)^3
+    @test y.pow == 6
+    z = @inferred (x*x)^3
+    @test z.pow == 6
 end


### PR DESCRIPTION
The only place where unary multiplication can be called is
https://github.com/JuliaOpt/JuMP.jl/blob/5cb9ba3e6fe04d262b28fd28e19e27ce0c375487/src/parseexpr.jl#L508
however, for Variable/AffExpr/QuadExpr, the `^i` will throw an error if `!(i in [1, 2, 3])` but this line is only reached for exponents different to 1, 2, 3.
So the only way to test this is with a new `AbstractJuMPScalar` :)
I had to make a few changes in `parseExpr` so that we don't have to deffine addition with `Float64` to `PowVariable`.