### PR TITLE
Remove duplicate GenericAffExpr from JuMPTypes

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -495,7 +495,6 @@ end
 
 # TODO why do we need this?
 const JuMPTypes = Union{AbstractJuMPScalar,
-                        GenericAffExpr,
                         NonlinearExpression}
                     #    Norm,
                     #    QuadExpr,


### PR DESCRIPTION
It is already part of it as it is a subtype of `AbstractJuMPScalar`