### PR TITLE
Refactor AffExpr and QuadExpr to use OrderedDict for internal storage.

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -21,6 +21,7 @@ const MOI = MathOptInterface
 const MOIU = MOI.Utilities
 
 import Calculus
+import DataStructures.OrderedDict
 using ForwardDiff
 include("Derivatives/Derivatives.jl")
 using .Derivatives
@@ -464,9 +465,9 @@ end
 
 # usage warnings
 function operator_warn(lhs::GenericAffExpr,rhs::GenericAffExpr)
-    if length(lhs.vars) > 50 || length(rhs.vars) > 50
-        if length(lhs.vars) > 1
-            m = lhs.vars[1].m
+    if length(linearterms(lhs)) > 50 || length(linearterms(rhs)) > 50
+        if length(linearterms(lhs)) > 1
+            m = first(linearterms(lhs))[1].m
             m.operator_counter += 1
             if m.operator_counter > 20000
                 Base.warn_once("The addition operator has been used on JuMP expressions a large number of times. This warning is safe to ignore but may indicate that model generation is slower than necessary. For performance reasons, you should not add expressions in a loop. Instead of x += y, use append!(x,y) to modify x in place. If y is a single variable, you may also use push!(x, coef, y) in place of x += coef*y.")

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -310,9 +310,10 @@ function verify_ownership(m::Model, vec::Vector{VariableRef})
     return true
 end
 
-Base.copy(v::VariableRef, new_model::Model) = VariableRef(new_model, v.col)
+Base.copy(v::VariableRef, new_model::Model) = VariableRef(new_model, v.index)
 Base.copy(x::Nothing, new_model::Model) = nothing
-Base.copy(v::AbstractArray{VariableRef}, new_model::Model) = (var -> VariableRef(new_model, var.col)).(v)
+# TODO: Replace with vectorized copy?
+Base.copy(v::AbstractArray{VariableRef}, new_model::Model) = (var -> VariableRef(new_model, var.index)).(v)
 
 
 function optimizerindex(v::VariableRef)

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -79,7 +79,7 @@ Base.copy(a::GenericAffExpr) = GenericAffExpr(copy(a.constant), copy(a.terms))
 
 GenericAffExpr{C, V}() where {C, V} = zero(GenericAffExpr{C, V})
 
-function map_coefficients!(a::GenericAffExpr, f::Function)
+function map_coefficients_inplace!(f::Function, a::GenericAffExpr)
     # The iterator remains valid if existing elements are updated.
     for (coef, var) in linearterms(a)
         a.terms[var] = f(coef)
@@ -88,8 +88,8 @@ function map_coefficients!(a::GenericAffExpr, f::Function)
     return a
 end
 
-function map_coefficients(a::GenericAffExpr, f::Function)
-    return map_coefficients!(copy(a), f)
+function map_coefficients(f::Function, a::GenericAffExpr)
+    return map_coefficients_inplace!(f, copy(a))
 end
 
 Base.sizehint!(a::GenericAffExpr, n::Int) = sizehint!(a.terms, n)

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -15,23 +15,83 @@
 # Operator overloads in src/operators.jl
 #############################################################################
 
+# Utilities for OrderedDict
+function add_or_set!(dict::OrderedDict{K,V}, k::K, v::V) where {K,V}
+    # TODO: This unnecessarily requires two lookups for k.
+    # TODO: Decide if we want to drop zeros here.
+    dict[k] = get!(dict, k, zero(V)) + v
+    return dict
+end
+
+function new_ordered_dict(::Type{K}, ::Type{V}, kv::AbstractArray{<:Pair}) where {K,V}
+    dict = OrderedDict{K,V}()
+    sizehint!(dict, length(kv))
+    for pair in kv
+        add_or_set!(dict, convert(K, pair.first), convert(V, pair.second))
+    end
+    return dict
+end
+
+function new_ordered_dict(::Type{K}, ::Type{V}, kv::Pair...) where {K,V}
+    dict = OrderedDict{K,V}()
+    sizehint!(dict, length(kv))
+    for pair in kv
+        add_or_set!(dict, convert(K, pair.first), convert(V, pair.second))
+    end
+    return dict
+end
+
+
+
 #############################################################################
 # GenericAffExpr
 # ∑ aᵢ xᵢ  +  c
 mutable struct GenericAffExpr{CoefType,VarType} <: AbstractJuMPScalar
-    vars::Vector{VarType}
-    coeffs::Vector{CoefType}
     constant::CoefType
+    terms::OrderedDict{VarType,CoefType}
 end
 
 variablereftype(::GenericAffExpr{C, V}) where {C, V} = V
 
-Base.iszero(a::GenericAffExpr) = isempty(a.vars) && iszero(a.constant)
-Base.zero(::Type{GenericAffExpr{C,V}}) where {C,V} = GenericAffExpr{C,V}(V[],C[],zero(C))
-Base.one(::Type{GenericAffExpr{C,V}}) where { C,V} = GenericAffExpr{C,V}(V[],C[], one(C))
+function GenericAffExpr(constant::V, kv::AbstractArray{Pair{K,V}}) where {K,V}
+    result = GenericAffExpr{V,K}(constant, new_ordered_dict(K, V, kv))
+end
+
+function GenericAffExpr(constant::V, kv::Pair{K,V}...) where {K,V}
+    return GenericAffExpr{V,K}(constant, new_ordered_dict(K, V, kv...))
+end
+
+function GenericAffExpr{V,K}(constant, kv::AbstractArray{<:Pair}) where {K,V}
+    return GenericAffExpr{V,K}(convert(V, constant), new_ordered_dict(K, V, kv))
+end
+
+function GenericAffExpr{V,K}(constant, kv::Pair...) where {K,V}
+    return GenericAffExpr{V,K}(convert(V, constant), new_ordered_dict(K, V, kv...))
+end
+
+Base.iszero(a::GenericAffExpr) = isempty(a.terms) && iszero(a.constant)
+Base.zero(::Type{GenericAffExpr{C,V}}) where {C,V} = GenericAffExpr{C,V}(zero(C), OrderedDict{V,C}())
+Base.one(::Type{GenericAffExpr{C,V}}) where {C,V}  = GenericAffExpr{C,V}(one(C), OrderedDict{V,C}())
 Base.zero(a::GenericAffExpr) = zero(typeof(a))
 Base.one( a::GenericAffExpr) =  one(typeof(a))
-Base.copy(a::GenericAffExpr) = GenericAffExpr(copy(a.vars),copy(a.coeffs),copy(a.constant))
+Base.copy(a::GenericAffExpr) = GenericAffExpr(copy(a.constant), copy(a.terms))
+
+GenericAffExpr{C, V}() where {C, V} = zero(GenericAffExpr{C, V})
+
+function map_coefficients!(a::GenericAffExpr, f::Function)
+    # The iterator remains valid if existing elements are updated.
+    for (coef, var) in linearterms(a)
+        a.terms[var] = f(coef)
+    end
+    a.constant = f(a.constant)
+    return a
+end
+
+function map_coefficients(a::GenericAffExpr, f::Function)
+    return map_coefficients!(copy(a), f)
+end
+
+Base.sizehint!(a::GenericAffExpr, n::Int) = sizehint!(a.terms, n)
 
 """
     value(a::GenericAffExpr, map::Function)
@@ -42,48 +102,58 @@ function value(a::GenericAffExpr{T, V}, map::Function) where {T, V}
     S = Base.promote_op(map, V)
     U = Base.promote_op(*, T, S)
     ret = U(a.constant)
-    for it in eachindex(a.vars)
-        ret += a.coeffs[it] * map(a.vars[it])
+    for (var, coef) in a.terms
+        ret += coef * map(var)
     end
     ret
 end
 
-# Old iterator protocol - iterates over tuples (aᵢ,xᵢ)
+# Iterator protocol - iterates over tuples (aᵢ,xᵢ)
 struct LinearTermIterator{GAE<:GenericAffExpr}
     aff::GAE
 end
 
 """
-    linearterms(aff::GenericAffExpr)
+    linearterms(aff::GenericAffExpr{C, V})
 
-Provides an iterator over the `(a_i::C,x_i::V)` terms in affine expression ``\\sum_i a_i x_i + b``.
+Provides an iterator over coefficient-variable tuples `(a_i::C, x_i::V)` in the
+linear part of the affine expression.
 """
 linearterms(aff::GenericAffExpr) = LinearTermIterator(aff)
 
-Base.start(lti::LinearTermIterator) = 1
-Base.done( lti::LinearTermIterator, state::Int) = state > length(lti.aff.vars)
-Base.next( lti::LinearTermIterator, state::Int) = ((lti.aff.coeffs[state], lti.aff.vars[state]), state+1)
+reorder_iterator(p::Pair, state::Int) = ((p.second, p.first), state)
 
-"""
-    Base.push!{C,V}(aff::GenericAffExpr{C,V}, new_coeff::C, new_var::V)
+Base.start(lti::LinearTermIterator) = start(lti.aff.terms)
+Base.done( lti::LinearTermIterator, state::Int) = done(lti.aff.terms, state)
+Base.next( lti::LinearTermIterator, state::Int) = reorder_iterator(next(lti.aff.terms, state)...)
+Base.length(lti::LinearTermIterator) = length(lti.aff.terms)
 
-An efficient way to grow an affine expression by one term. For example, to add `5x` to an existing expression `aff`, use `push!(aff, 5.0, x)`. This is significantly more efficient than `aff += 5.0*x`.
+# TODO: Consider renaming. push! is an unusual name to update a term in a
+# dictionary.
 """
-function Base.push!(aff::GenericAffExpr{C,V}, new_coeff::C, new_var::V) where {C,V}
-    push!(aff.coeffs, new_coeff)
-    push!(aff.vars, new_var)
+    Base.push!{C,V}(aff::GenericAffExpr{C,V}, new_coef::C, new_var::V)
+
+An efficient way to add to an affine expression in place. For example, to add
+`5x` to an existing expression `aff`, use `push!(aff, 5.0, x)`. This is
+*significantly* more efficient than `aff += 5.0*x`.
+"""
+function Base.push!(aff::GenericAffExpr{C,V}, new_coef::C, new_var::V) where {C,V}
+    add_or_set!(aff.terms, new_var, new_coef)
     aff
 end
 
-# Add an affine expression to an existing affine expression
+# TODO: Consider renaming. append! is an unusual name to add two expressions.
 """
     Base.append!{C,V}(aff::GenericAffExpr{C,V}, other::GenericAffExpr{C,V})
 
-Efficiently append the terms of an affine expression to an existing affine expression. For example, given `aff = 5.0*x` and `other = 7.0*y + 3.0*z`, we can grow `aff` using `append!(aff, other)` which results in `aff` equaling `5x + 7y + 3z`. This is significantly more efficient than using `aff += other`.
+Efficiently append the terms of an affine expression to an existing affine
+expression. For example, given `aff = 5.0*x` and `other = 7.0*y + 3.0*z`,
+we can add to `aff` in place by using `append!(aff, other)`.This results in
+`aff` equal to `5x + 7y + 3z`. `append!` is *significantly* more efficient than
+`aff += other`.
 """
 function Base.append!(aff::GenericAffExpr{C,V}, other::GenericAffExpr{C,V}) where {C,V}
-    append!(aff.vars, other.vars)
-    append!(aff.coeffs, other.coeffs)
+    merge!(+, aff.terms, other.terms)
     aff.constant += other.constant
     aff
 end
@@ -100,51 +170,39 @@ end
 Base.append!(aff::GenericAffExpr{C,V}, other::V) where {C,V} = push!(aff,one(C),other)
 
 function Base.isequal(aff::GenericAffExpr{C,V},other::GenericAffExpr{C,V}) where {C,V}
-    isequal(aff.constant, other.constant)  || return false
-    length(aff.vars) == length(other.vars) || return false
-    for i in 1:length(aff.vars)
-        isequal(aff.vars[i],   other.vars[i])   || return false
-        isequal(aff.coeffs[i], other.coeffs[i]) || return false
-    end
-    return true
+    return isequal(aff.constant, other.constant) && isequal(aff.terms, other.terms)
 end
 
-# Check if two GenericAffExprs are equal regardless of the order, and after merging duplicates
-# Mostly useful for testing.
+function Base.dropzeros(aff::GenericAffExpr)
+    result = copy(aff)
+    for (coef, var) in linearterms(aff)
+        if iszero(coef)
+            delete!(result.terms, var)
+        end
+    end
+    return result
+end
+
+# Check if two AffExprs are equal after dropping zeros and disregarding the
+# order. Mostly useful for testing.
 function isequal_canonical(aff::GenericAffExpr{C,V}, other::GenericAffExpr{C,V}) where {C,V}
-    function canonicalize(a)
-        d = Dict{V,C}()
-        @assert length(a.vars) == length(a.coeffs)
-        for k in 1:length(a.vars)
-            d[a.vars[k]] = a.coeffs[k] + get(d, a.vars[k], zero(C))
-        end
-        for k in keys(d)
-            if iszero(d[k])
-                delete!(d, k)
-            end
-        end
-        return d
-    end
-    d1 = canonicalize(aff)
-    d2 = canonicalize(other)
-    return isequal(d1,d2) && aff.constant == other.constant
+    aff_nozeros = dropzeros(aff)
+    other_nozeros = dropzeros(other)
+    # Note: This depends on equality of OrderedDicts ignoring order.
+    # This is the current behavior, but it seems questionable.
+    return isequal(aff_nozeros.terms, other_nozeros.terms) && aff.constant == other.constant
 end
 
-Base.convert(::Type{GenericAffExpr{T,V}}, v::V)    where {T,V} = GenericAffExpr([v], [one(T)], zero(T))
-Base.convert(::Type{GenericAffExpr{T,V}}, v::Real) where {T,V} = GenericAffExpr(VariableRef[], T[], T(v))
+Base.convert(::Type{GenericAffExpr{T,V}}, v::V)    where {T,V} = GenericAffExpr(zero(T), v => one(T))
+Base.convert(::Type{GenericAffExpr{T,V}}, v::Real) where {T,V} = GenericAffExpr{T,V}(convert(T, v))
 
 # Alias for (Float64, VariableRef), the specific GenericAffExpr used by JuMP
 const AffExpr = GenericAffExpr{Float64,VariableRef}
 
-Base.convert(::Type{AffExpr}, v::VariableRef) = AffExpr([v], [1.], 0.)
-Base.convert(::Type{AffExpr}, v::Real) = AffExpr(VariableRef[], Float64[], v)
-GenericAffExpr{C, V}() where {C, V} = zero(GenericAffExpr{C, V})
-
 # Check all coefficients are finite, i.e. not NaN, not Inf, not -Inf
-function assert_isfinite(a::GenericAffExpr)
-    coeffs = a.coeffs
-    for i in 1:length(a.vars)
-        isfinite(coeffs[i]) || error("Invalid coefficient $(coeffs[i]) on variable $(a.vars[i])")
+function assert_isfinite(a::AffExpr)
+    for (coef, var) in linearterms(a)
+        isfinite(coef) || error("Invalid coefficient $coef on variable $var.")
     end
 end
 
@@ -159,11 +217,24 @@ resultvalue(a::GenericAffExpr) = value(a, resultvalue)
 # Note: No validation is performed that the variables in the AffExpr belong to
 # the same model.
 function MOI.ScalarAffineFunction(a::AffExpr)
-    return MOI.ScalarAffineFunction(index.(a.vars), a.coeffs, a.constant)
+    vars = MOIVAR[]
+    coefs = Float64[]
+    sizehint!(vars, length(a.terms))
+    sizehint!(coefs, length(a.terms))
+    for (coef, var) in linearterms(a)
+        push!(vars, index(var))
+        push!(coefs, coef)
+    end
+    return MOI.ScalarAffineFunction(vars, coefs, a.constant)
 end
 
 function AffExpr(m::Model, f::MOI.ScalarAffineFunction)
-    return AffExpr(VariableRef.(m,f.variables), f.coefficients, f.constant)
+    aff = AffExpr()
+    for i in 1:length(f.variables)
+        push!(aff, f.coefficients[i], VariableRef(m,f.variables[i]))
+    end
+    aff.constant = f.constant
+    return aff
 end
 
 """
@@ -173,16 +244,18 @@ Fills the vectors outputindex, variables, coefficients at indices starting at `o
 The output index for all terms is `oi`.
 """
 function _fillvaf!(outputindex, variables, coefficients, offset::Int, oi::Int, aff::AffExpr)
-    for i in 1:length(aff.vars)
+    i = 1
+    for (coef, var) in linearterms(aff)
         outputindex[offset+i] = oi
-        variables[offset+i] = index(aff.vars[i])
-        coefficients[offset+i] = aff.coeffs[i]
+        variables[offset+i] = index(var)
+        coefficients[offset+i] = coef
+        i += 1
     end
-    offset + length(aff.vars)
+    offset + length(aff.terms)
 end
 
 function MOI.VectorAffineFunction(affs::Vector{AffExpr})
-    len = sum(aff -> length(aff.vars), affs)
+    len = sum(aff -> length(linearterms(aff)), affs)
     outputindex = Vector{Int}(len)
     variables = Vector{MOIVAR}(len)
     coefficients = Vector{Float64}(len)
@@ -222,7 +295,12 @@ end
 # Copy an affine expression to a new model by converting all the
 # variables to the new model's variables
 function Base.copy(a::GenericAffExpr, new_model::Model)
-    GenericAffExpr(copy(a.vars, new_model), copy(a.coeffs), a.constant)
+    result = zero(a)
+    for (coef, var) in linearterms(a)
+        push!(result, coef, copy(v, new_model))
+    end
+    result.constant = a.constant
+    return result
 end
 
 # TODO GenericAffExprConstraint

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -18,7 +18,8 @@
 # Utilities for OrderedDict
 function add_or_set!(dict::OrderedDict{K,V}, k::K, v::V) where {K,V}
     # TODO: This unnecessarily requires two lookups for k.
-    # TODO: Decide if we want to drop zeros here.
+    # TODO: Decide if we want to drop zeros here after understanding the
+    # performance implications.
     dict[k] = get!(dict, k, zero(V)) + v
     return dict
 end

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -54,7 +54,7 @@ end
 variablereftype(::GenericAffExpr{C, V}) where {C, V} = V
 
 function GenericAffExpr(constant::V, kv::AbstractArray{Pair{K,V}}) where {K,V}
-    result = GenericAffExpr{V,K}(constant, new_ordered_dict(K, V, kv))
+    return GenericAffExpr{V,K}(constant, new_ordered_dict(K, V, kv))
 end
 
 function GenericAffExpr(constant::V, kv::Pair{K,V}...) where {K,V}
@@ -180,6 +180,10 @@ function Base.dropzeros(aff::GenericAffExpr)
             delete!(result.terms, var)
         end
     end
+    if iszero(result.constant)
+        # This is to work around isequal(0.0, -0.0) == false.
+        result.constant = zero(typeof(result.constant))
+    end
     return result
 end
 
@@ -190,7 +194,7 @@ function isequal_canonical(aff::GenericAffExpr{C,V}, other::GenericAffExpr{C,V})
     other_nozeros = dropzeros(other)
     # Note: This depends on equality of OrderedDicts ignoring order.
     # This is the current behavior, but it seems questionable.
-    return isequal(aff_nozeros.terms, other_nozeros.terms) && aff.constant == other.constant
+    return isequal(aff_nozeros, other_nozeros)
 end
 
 Base.convert(::Type{GenericAffExpr{T,V}}, v::V)    where {T,V} = GenericAffExpr(zero(T), v => one(T))

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -163,8 +163,7 @@ function add_to_expression!(aff::GenericAffExpr{C,V}, other::GenericAffExpr{C,V}
     aff.constant += other.constant
     aff
 end
-# TODO: do we need this?
-#add_to_expression!(aff::GenericAffExpr{C,C}, other::C) where {C} = error() # for ambiguity
+
 function add_to_expression!(aff::GenericAffExpr{C,V}, other::C) where {C,V}
     aff.constant += other
     aff
@@ -226,6 +225,7 @@ resultvalue(a::GenericAffExpr) = value(a, resultvalue)
 # Note: No validation is performed that the variables in the AffExpr belong to
 # the same model.
 function MOI.ScalarAffineFunction(a::AffExpr)
+    assert_isfinite(a)
     vars = MOIVAR[]
     coefs = Float64[]
     sizehint!(vars, length(a.terms))
@@ -306,7 +306,7 @@ end
 function Base.copy(a::GenericAffExpr, new_model::Model)
     result = zero(a)
     for (coef, var) in linearterms(a)
-        add_to_expression!(result, coef, copy(v, new_model))
+        add_to_expression!(result, coef, copy(var, new_model))
     end
     result.constant = a.constant
     return result

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -33,7 +33,7 @@ function Base.:-(lhs::Number, rhs::GenericAffExpr)
     result.constant += lhs
     return result
 end
-Base.:*(lhs::Number, rhs::GenericAffExpr) = map_coefficients(rhs, c -> lhs * c)
+Base.:*(lhs::Number, rhs::GenericAffExpr) = map_coefficients(c -> lhs * c, rhs)
 # Number--QuadExpr
 Base.:+(lhs::Number, rhs::GenericQuadExpr) = GenericQuadExpr(lhs+rhs.aff, copy(rhs.terms))
 function Base.:-(lhs::Number, rhs::GenericQuadExpr)
@@ -41,13 +41,13 @@ function Base.:-(lhs::Number, rhs::GenericQuadExpr)
     result.aff.constant += lhs
     return result
 end
-Base.:*(lhs::Number, rhs::GenericQuadExpr) = map_coefficients(rhs, c -> lhs * c)
+Base.:*(lhs::Number, rhs::GenericQuadExpr) = map_coefficients(c -> lhs * c, rhs)
 
 # AbstractVariableRef (or, AbstractJuMPScalar)
 # TODO: What is the role of AbstractJuMPScalar??
 Base.:+(lhs::AbstractJuMPScalar) = lhs
 Base.:-(lhs::AbstractVariableRef) = GenericAffExpr(0.0, lhs => -1.0)
-Base.:*(lhs::AbstractVariableRef) = lhs # make this more generic so extensions don't have to define unary multiplication for our macros
+Base.:*(lhs::AbstractJuMPScalar) = lhs # make this more generic so extensions don't have to define unary multiplication for our macros
 # AbstractVariableRef--Number
 Base.:+(lhs::AbstractVariableRef, rhs::Number) = (+)( rhs,lhs)
 Base.:-(lhs::AbstractVariableRef, rhs::Number) = (+)(-rhs,lhs)
@@ -108,12 +108,12 @@ end
 
 # GenericAffExpr
 Base.:+(lhs::GenericAffExpr) = lhs
-Base.:-(lhs::GenericAffExpr) = map_coefficients(lhs, -)
+Base.:-(lhs::GenericAffExpr) = map_coefficients(-, lhs)
 # GenericAffExpr--Number
 Base.:+(lhs::GenericAffExpr, rhs::Number) = (+)(+rhs,lhs)
 Base.:-(lhs::GenericAffExpr, rhs::Number) = (+)(-rhs,lhs)
 Base.:*(lhs::GenericAffExpr, rhs::Number) = (*)(rhs,lhs)
-Base.:/(lhs::GenericAffExpr, rhs::Number) = map_coefficients(lhs, c -> c/rhs)
+Base.:/(lhs::GenericAffExpr, rhs::Number) = map_coefficients(c -> c/rhs, lhs)
 function Base.:^(lhs::Union{AbstractVariableRef,GenericAffExpr}, rhs::Integer)
     if rhs == 2
         return lhs*lhs
@@ -221,12 +221,12 @@ end
 
 # GenericQuadExpr
 Base.:+(lhs::GenericQuadExpr) = lhs
-Base.:-(lhs::GenericQuadExpr) = map_coefficients(lhs, -)
+Base.:-(lhs::GenericQuadExpr) = map_coefficients(-, lhs)
 # GenericQuadExpr--Number
 Base.:+(lhs::GenericQuadExpr, rhs::Number) = (+)(+rhs,lhs)
 Base.:-(lhs::GenericQuadExpr, rhs::Number) = (+)(-rhs,lhs)
 Base.:*(lhs::GenericQuadExpr, rhs::Number) = (*)(rhs,lhs)
-Base.:/(lhs::GenericQuadExpr, rhs::Number) = (*)(1.0/rhs,lhs)
+Base.:/(lhs::GenericQuadExpr, rhs::Number) = (*)(inv(rhs),lhs)
 # GenericQuadExpr--AbstractVariableRef
 Base.:+(q::GenericQuadExpr, v::AbstractVariableRef) = GenericQuadExpr(q.aff+v, copy(q.terms))
 Base.:-(q::GenericQuadExpr, v::AbstractVariableRef) = GenericQuadExpr(q.aff-v, copy(q.terms))

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -18,63 +18,107 @@
 
 # Number
 # Number--Number obviously already taken care of!
-# Number--AbstractVariableRef
-Base.:+(lhs::Number, rhs::AbstractVariableRef) = GenericAffExpr([rhs],[+1.],convert(Float64,lhs))
-Base.:-(lhs::Number, rhs::AbstractVariableRef) = GenericAffExpr([rhs],[-1.],convert(Float64,lhs))
-Base.:*(lhs::Number, rhs::AbstractVariableRef) = GenericAffExpr([rhs],[convert(Float64,lhs)], 0.)
+# Number--VariableRef
+Base.:+(lhs::Number, rhs::AbstractVariableRef) = GenericAffExpr(convert(Float64, lhs), rhs => 1.0)
+Base.:-(lhs::Number, rhs::AbstractVariableRef) = GenericAffExpr(convert(Float64, lhs), rhs => -1.0)
+Base.:*(lhs::Number, rhs::AbstractVariableRef) = GenericAffExpr(0.0, rhs => convert(Float64,lhs))
 # Number--GenericAffExpr
-Base.:+(lhs::Number, rhs::GenericAffExpr) = GenericAffExpr(copy(rhs.vars),copy(rhs.coeffs),lhs+rhs.constant)
-Base.:-(lhs::Number, rhs::GenericAffExpr) = GenericAffExpr(copy(rhs.vars),    -rhs.coeffs ,lhs-rhs.constant)
-Base.:*(lhs::Number, rhs::GenericAffExpr) = GenericAffExpr(copy(rhs.vars),[lhs*rhs.coeffs[i] for i=1:length(rhs.coeffs)],lhs*rhs.constant)
-# Number--GenericQuadExpr
-Base.:+(lhs::Number, rhs::GenericQuadExpr) = GenericQuadExpr(copy(rhs.qvars1),copy(rhs.qvars2),copy(rhs.qcoeffs),lhs+rhs.aff)
-Base.:-(lhs::Number, rhs::GenericQuadExpr) = GenericQuadExpr(copy(rhs.qvars1),copy(rhs.qvars2),    -rhs.qcoeffs ,lhs-rhs.aff)
-Base.:*(lhs::Number, rhs::GenericQuadExpr) = GenericQuadExpr(copy(rhs.qvars1),copy(rhs.qvars2), lhs*rhs.qcoeffs ,lhs*rhs.aff)
+function Base.:+(lhs::Number, rhs::GenericAffExpr)
+    result = copy(rhs)
+    result.constant += lhs
+    return result
+end
+function Base.:-(lhs::Number, rhs::GenericAffExpr)
+    result = -rhs
+    result.constant += lhs
+    return result
+end
+Base.:*(lhs::Number, rhs::GenericAffExpr) = map_coefficients(rhs, c -> lhs * c)
+# Number--QuadExpr
+Base.:+(lhs::Number, rhs::GenericQuadExpr) = GenericQuadExpr(lhs+rhs.aff, copy(rhs.terms))
+function Base.:-(lhs::Number, rhs::GenericQuadExpr)
+    result = -rhs
+    result.aff.constant += lhs
+    return result
+end
+Base.:*(lhs::Number, rhs::GenericQuadExpr) = map_coefficients(rhs, c -> lhs * c)
 
 # AbstractVariableRef (or, AbstractJuMPScalar)
+# TODO: What is the role of AbstractJuMPScalar??
 Base.:+(lhs::AbstractJuMPScalar) = lhs
-Base.:-(lhs::AbstractVariableRef) = GenericAffExpr([lhs],[-1.0],0.0)
-Base.:*(lhs::AbstractJuMPScalar) = lhs # make this more generic so extensions don't have to define unary multiplication for our macros
+Base.:-(lhs::AbstractVariableRef) = GenericAffExpr(0.0, lhs => -1.0)
+Base.:*(lhs::AbstractVariableRef) = lhs # make this more generic so extensions don't have to define unary multiplication for our macros
 # AbstractVariableRef--Number
 Base.:+(lhs::AbstractVariableRef, rhs::Number) = (+)( rhs,lhs)
 Base.:-(lhs::AbstractVariableRef, rhs::Number) = (+)(-rhs,lhs)
 Base.:*(lhs::AbstractVariableRef, rhs::Number) = (*)(rhs,lhs)
 Base.:/(lhs::AbstractVariableRef, rhs::Number) = (*)(1./rhs,lhs)
 # AbstractVariableRef--AbstractVariableRef
-Base.:+(lhs::V, rhs::V) where V<:AbstractVariableRef = GenericAffExpr([lhs,rhs], [1.,+1.], 0.)
-Base.:-(lhs::V, rhs::V) where V<:AbstractVariableRef = GenericAffExpr([lhs,rhs], [1.,-1.], 0.)
-Base.:*(lhs::V, rhs::V) where V<:AbstractVariableRef = GenericQuadExpr{Float64,V}([lhs],[rhs],[1.],zero(GenericAffExpr{Float64,V}))
+Base.:+(lhs::V, rhs::V) where V <: AbstractVariableRef = GenericAffExpr(0.0, lhs => 1.0, rhs => 1.0)
+Base.:-(lhs::V, rhs::V) where V <: AbstractVariableRef = GenericAffExpr(0.0, lhs => 1.0, rhs => -1.0)
+function Base.:*(lhs::V, rhs::V) where V <: AbstractVariableRef
+    GenericQuadExpr(GenericAffExpr{Float64, V}(), UnorderedPair(lhs, rhs) => 1.0)
+end
 # AbstractVariableRef--GenericAffExpr
-Base.:+(lhs::V, rhs::GenericAffExpr{C,V}) where {C,V<:JuMPTypes} =
-    GenericAffExpr{C,V}(vcat(lhs,rhs.vars),vcat(one(C),rhs.coeffs), rhs.constant)
-Base.:-(lhs::V, rhs::GenericAffExpr{C,V}) where {C,V<:JuMPTypes} =
-    GenericAffExpr{C,V}(vcat(lhs,rhs.vars),vcat(one(C),-rhs.coeffs),-rhs.constant)
-function Base.:*(lhs::V, rhs::GenericAffExpr{T,V}) where {T,V}
-    n = length(rhs.vars)
-    if !iszero(rhs.constant)
-        ret = GenericQuadExpr{T,V}([lhs for i=1:n],copy(rhs.vars),copy(rhs.coeffs),GenericAffExpr{T,V}([lhs], [rhs.constant], zero(T)))
-    else
-        ret = GenericQuadExpr{T,V}([lhs for i=1:n],copy(rhs.vars),copy(rhs.coeffs),zero(GenericAffExpr{T,V}))
+function Base.:+(lhs::V, rhs::GenericAffExpr{C,V}) where {C, V <: AbstractVariableRef}
+    # For the variables to have the proper order in the result, we need to push the lhs first.
+    result = zero(rhs)
+    result.constant = rhs.constant
+    sizehint!(result, length(linearterms(rhs)) + 1)
+    push!(result, one(C), lhs)
+    for (coef, var) in linearterms(rhs)
+        push!(result, coef, var)
     end
+    return result
+end
+
+function Base.:-(lhs::V, rhs::GenericAffExpr{C,V}) where {C,V <: AbstractVariableRef}
+    # For the variables to have the proper order in the result, we need to push the lhs first.
+    result = zero(rhs)
+    result.constant = -rhs.constant
+    sizehint!(result, length(linearterms(rhs)) + 1)
+    push!(result, one(C), lhs)
+    for (coef, var) in linearterms(rhs)
+        push!(result, -coef, var)
+    end
+    return result
+end
+
+function Base.:*(lhs::V, rhs::GenericAffExpr{C,V}) where {C, V <: AbstractVariableRef}
+    if !iszero(rhs.constant)
+        result = GenericQuadExpr{C,V}(lhs*rhs.constant)
+    else
+        result = zero(GenericQuadExpr{C,V})
+    end
+    for (coef, var) in linearterms(rhs)
+        push!(result, coef, lhs, var)
+    end
+    return result
 end
 Base.:/(lhs::AbstractVariableRef, rhs::GenericAffExpr) = error("Cannot divide a variable by an affine expression")
 # AbstractVariableRef--GenericQuadExpr
-Base.:+(v::AbstractVariableRef, q::GenericQuadExpr) = GenericQuadExpr(copy(q.qvars1),copy(q.qvars2),copy(q.qcoeffs),v+q.aff)
-Base.:-(v::AbstractVariableRef, q::GenericQuadExpr) = GenericQuadExpr(copy(q.qvars1),copy(q.qvars2),    -q.qcoeffs ,v-q.aff)
+Base.:+(v::AbstractVariableRef, q::GenericQuadExpr) = QuadExpr(v+q.aff, copy(q.terms))
+function Base.:-(v::AbstractVariableRef, q::GenericQuadExpr)
+    result = -q
+    # This makes an unnecessary copy of aff, but it's important for v to appear
+    # first.
+    result.aff = v + result.aff
+    return result
+end
 
 # GenericAffExpr
 Base.:+(lhs::GenericAffExpr) = lhs
-Base.:-(lhs::GenericAffExpr) = GenericAffExpr(lhs.vars, -lhs.coeffs, -lhs.constant)
+Base.:-(lhs::GenericAffExpr) = map_coefficients(lhs, -)
 # GenericAffExpr--Number
 Base.:+(lhs::GenericAffExpr, rhs::Number) = (+)(+rhs,lhs)
 Base.:-(lhs::GenericAffExpr, rhs::Number) = (+)(-rhs,lhs)
 Base.:*(lhs::GenericAffExpr, rhs::Number) = (*)(rhs,lhs)
-Base.:/(lhs::GenericAffExpr, rhs::Number) = (*)(inv(rhs),lhs)
+Base.:/(lhs::GenericAffExpr, rhs::Number) = map_coefficients(lhs, c -> c/rhs)
 function Base.:^(lhs::Union{AbstractVariableRef,GenericAffExpr}, rhs::Integer)
     if rhs == 2
         return lhs*lhs
     elseif rhs == 1
-        return GenericQuadExpr{Float64, variablereftype(lhs)}(lhs)
+        return convert(GenericQuadExpr{Float64, variablereftype(lhs)}, lhs)
     elseif rhs == 0
         return one(GenericQuadExpr{Float64, variablereftype(lhs)})
     else
@@ -83,120 +127,152 @@ function Base.:^(lhs::Union{AbstractVariableRef,GenericAffExpr}, rhs::Integer)
 end
 Base.:^(lhs::Union{AbstractVariableRef,GenericAffExpr}, rhs::Number) = error("Only exponents of 0, 1, or 2 are currently supported. Are you trying to build a nonlinear problem? Make sure you use @NLconstraint/@NLobjective.")
 # GenericAffExpr--AbstractVariableRef
-Base.:+(lhs::GenericAffExpr{C,V}, rhs::V) where {C,V<:JuMPTypes} = GenericAffExpr{C,V}(vcat(lhs.vars,rhs),vcat(lhs.coeffs,one(C)), lhs.constant)
-Base.:-(lhs::GenericAffExpr{C,V}, rhs::V) where {C,V<:JuMPTypes} = GenericAffExpr{C,V}(vcat(lhs.vars,rhs),vcat(lhs.coeffs,-one(C)),lhs.constant)
-# Don't fall back on AbstractVariableRef*GenericAffExpr to preserve lhs/rhs consistency (appears in printing)
-function Base.:*(lhs::GenericAffExpr{T,V}, rhs::V) where {T,V}
-    n = length(lhs.vars)
+function Base.:+(lhs::GenericAffExpr{C,V}, rhs::V) where {C, V <: AbstractVariableRef}
+    return push!(copy(lhs), one(C), rhs)
+end
+function Base.:-(lhs::GenericAffExpr{C,V}, rhs::V) where {C, V <: AbstractVariableRef}
+    return push!(copy(lhs), -one(C), rhs)
+end
+# Don't fall back on AbstractVariableRef*GenericAffExpr to preserve lhs/rhs
+# consistency (appears in printing).
+function Base.:*(lhs::GenericAffExpr{C,V}, rhs::V) where {C, V <: AbstractVariableRef}
     if !iszero(lhs.constant)
-        ret = GenericQuadExpr(copy(lhs.vars),[rhs for i=1:n],copy(lhs.coeffs),GenericAffExpr([rhs], [lhs.constant], zero(T)))
+        result = GenericQuadExpr{C,V}(lhs.constant*rhs)
     else
-        ret = GenericQuadExpr(copy(lhs.vars),[rhs for i=1:n],copy(lhs.coeffs),zero(GenericAffExpr{T,V}))
+        result = zero(GenericQuadExpr{C,V})
     end
+    for (coef, var) in linearterms(lhs)
+        push!(result, coef, var, rhs)
+    end
+    return result
 end
 Base.:/(lhs::GenericAffExpr, rhs::AbstractVariableRef) = error("Cannot divide affine expression by a variable")
-# GenericAffExpr--GenericAffExpr
-Base.:+(lhs::GenericAffExpr{C,V}, rhs::GenericAffExpr{C,V}) where {C,V<:JuMPTypes} = (operator_warn(lhs,rhs); GenericAffExpr(vcat(lhs.vars,rhs.vars),vcat(lhs.coeffs, rhs.coeffs),lhs.constant+rhs.constant))
-Base.:-(lhs::GenericAffExpr{C,V}, rhs::GenericAffExpr{C,V}) where {C,V<:JuMPTypes} = GenericAffExpr(vcat(lhs.vars,rhs.vars),vcat(lhs.coeffs,-rhs.coeffs),lhs.constant-rhs.constant)
-function Base.:*(lhs::GenericAffExpr{T,V}, rhs::GenericAffExpr{T,V}) where {T,V}
-    ret = zero(GenericQuadExpr{T,V})
+# AffExpr--AffExpr
+function Base.:+(lhs::GenericAffExpr{C,V}, rhs::GenericAffExpr{C,V}) where {C,V<:JuMPTypes}
+    operator_warn(lhs,rhs)
+    result_terms = copy(lhs.terms)
+    # merge() returns a Dict(), so we need to call merge!() instead.
+    # Note: merge!() doesn't appear to call sizehint!(). Is this important?
+    merge!(+, result_terms, rhs.terms)
+    return GenericAffExpr(lhs.constant + rhs.constant, result_terms)
+end
+
+function Base.:-(lhs::GenericAffExpr{C,V}, rhs::GenericAffExpr{C,V}) where {C,V<:JuMPTypes}
+    result = copy(lhs)
+    result.constant -= rhs.constant
+    sizehint!(result, length(linearterms(lhs)) + length(linearterms(rhs)))
+    for (coef, var) in linearterms(rhs)
+        push!(result, -coef, var)
+    end
+    return result
+end
+
+function Base.:*(lhs::GenericAffExpr{C,V}, rhs::GenericAffExpr{C,V}) where {C,V<:JuMPTypes}
+    result = zero(GenericQuadExpr{C,V})
+
+    lhs_length = length(linearterms(lhs))
+    rhs_length = length(linearterms(rhs))
 
     # Quadratic terms
-    n = length(lhs.coeffs)
-    m = length(rhs.coeffs)
-    sizehint!(ret.qvars1, n*m)
-    sizehint!(ret.qvars2, n*m)
-    sizehint!(ret.qcoeffs, n*m)
-    for i = 1:n
-        for j = 1:m
-            push!(ret.qvars1,  lhs.vars[i])
-            push!(ret.qvars2,  rhs.vars[j])
-            push!(ret.qcoeffs, lhs.coeffs[i]*rhs.coeffs[j])
+    for (lhscoef, lhsvar) in linearterms(lhs)
+        for (rhscoef, rhsvar) in linearterms(rhs)
+            push!(result, lhscoef*rhscoef, lhsvar, rhsvar)
         end
     end
 
     # Try to preallocate space for aff
     if !iszero(lhs.constant) && !iszero(rhs.constant)
-        sizehint!(ret.aff.vars, n+m)
-        sizehint!(ret.aff.coeffs, n+m)
+        sizehint!(result.aff, lhs_length + rhs_length)
     elseif !iszero(lhs.constant)
-        sizehint!(ret.aff.vars, n)
-        sizehint!(ret.aff.coeffs, n)
+        sizehint!(result.aff, rhs_length)
     elseif !iszero(rhs.constant)
-        sizehint!(ret.aff.vars, m)
-        sizehint!(ret.aff.coeffs, m)
+        sizehint!(result.aff, lhs_length)
     end
 
-    # [LHS constant] * RHS
+    # [LHS constant] * [RHS linear terms]
     if !iszero(lhs.constant)
         c = lhs.constant
-        for j = 1:m
-            push!(ret.aff.vars,   rhs.vars[j])
-            push!(ret.aff.coeffs, rhs.coeffs[j] * c)
+        for (rhscoef, rhsvar) in linearterms(rhs)
+            push!(result.aff, c*rhscoef, rhsvar)
         end
-        ret.aff.constant += c * rhs.constant
     end
 
-    # [RHS constant] * LHS
+    # [RHS constant] * [LHS linear terms]
     if !iszero(rhs.constant)
         c = rhs.constant
-        for i = 1:n
-            push!(ret.aff.vars,   lhs.vars[i])
-            push!(ret.aff.coeffs, lhs.coeffs[i] * c)
+        for (lhscoef, lhsvar) in linearterms(lhs)
+            push!(result.aff, c*lhscoef, lhsvar)
         end
-        # Don't do the following line
-        #ret.aff.constant += c * lhs.constant
-        # If lhs.constant is 0, its a waste of time
-        # If lhs.constant is non-zero, its already done
     end
 
-    return ret
+    result.aff.constant = lhs.constant * rhs.constant
+
+    return result
 end
 # GenericAffExpr--GenericQuadExpr
-Base.:+(a::GenericAffExpr, q::GenericQuadExpr) = GenericQuadExpr(copy(q.qvars1),copy(q.qvars2),copy(q.qcoeffs),a+q.aff)
-Base.:-(a::GenericAffExpr, q::GenericQuadExpr) = GenericQuadExpr(copy(q.qvars1),copy(q.qvars2),    -q.qcoeffs ,a-q.aff)
+Base.:+(a::GenericAffExpr, q::GenericQuadExpr) = GenericQuadExpr(a+q.aff, copy(q.terms))
+function Base.:-(a::GenericAffExpr, q::GenericQuadExpr)
+    result = -q
+    # This makes an unnecessary copy of aff, but it's important for a to appear
+    # first.
+    result.aff = a + result.aff
+    return result
+end
 
 # GenericQuadExpr
 Base.:+(lhs::GenericQuadExpr) = lhs
-Base.:-(lhs::GenericQuadExpr{T}) where T = zero(T)-lhs
+Base.:-(lhs::GenericQuadExpr) = map_coefficients(lhs, -)
 # GenericQuadExpr--Number
 Base.:+(lhs::GenericQuadExpr, rhs::Number) = (+)(+rhs,lhs)
 Base.:-(lhs::GenericQuadExpr, rhs::Number) = (+)(-rhs,lhs)
 Base.:*(lhs::GenericQuadExpr, rhs::Number) = (*)(rhs,lhs)
-Base.:/(lhs::GenericQuadExpr, rhs::Number) = (*)(inv(rhs),lhs)
+Base.:/(lhs::GenericQuadExpr, rhs::Number) = (*)(1.0/rhs,lhs)
 # GenericQuadExpr--AbstractVariableRef
-Base.:+(q::GenericQuadExpr, v::AbstractVariableRef) = (+)(v,q)
-Base.:-(q::GenericQuadExpr, v::AbstractVariableRef) = GenericQuadExpr(copy(q.qvars1),copy(q.qvars2),copy(q.qcoeffs),q.aff-v)
+Base.:+(q::GenericQuadExpr, v::AbstractVariableRef) = GenericQuadExpr(q.aff+v, copy(q.terms))
+Base.:-(q::GenericQuadExpr, v::AbstractVariableRef) = GenericQuadExpr(q.aff-v, copy(q.terms))
 Base.:*(q::GenericQuadExpr, v::AbstractVariableRef) = error("Cannot multiply a quadratic expression by a variable")
 Base.:/(q::GenericQuadExpr, v::AbstractVariableRef) = error("Cannot divide a quadratic expression by a variable")
 # GenericQuadExpr--GenericAffExpr
-Base.:+(q::GenericQuadExpr, a::GenericAffExpr) = GenericQuadExpr(copy(q.qvars1),copy(q.qvars2),copy(q.qcoeffs),q.aff+a)
-Base.:-(q::GenericQuadExpr, a::GenericAffExpr) = GenericQuadExpr(copy(q.qvars1),copy(q.qvars2),copy(q.qcoeffs),q.aff-a)
+Base.:+(q::GenericQuadExpr, a::GenericAffExpr) = GenericQuadExpr(q.aff+a, copy(q.terms))
+Base.:-(q::GenericQuadExpr, a::GenericAffExpr) = GenericQuadExpr(q.aff-a, copy(q.terms))
 Base.:*(q::GenericQuadExpr, a::GenericAffExpr) = error("Cannot multiply a quadratic expression by an aff. expression")
 Base.:/(q::GenericQuadExpr, a::GenericAffExpr) = error("Cannot divide a quadratic expression by an aff. expression")
 # GenericQuadExpr--GenericQuadExpr
-Base.:+(q1::GenericQuadExpr, q2::GenericQuadExpr) = GenericQuadExpr( vcat(q1.qvars1, q2.qvars1),     vcat(q1.qvars2, q2.qvars2),
-                                                                     vcat(q1.qcoeffs, q2.qcoeffs),   q1.aff + q2.aff)
-Base.:-(q1::GenericQuadExpr, q2::GenericQuadExpr) = GenericQuadExpr( vcat(q1.qvars1, q2.qvars1),     vcat(q1.qvars2, q2.qvars2),
-                                                                     vcat(q1.qcoeffs, -q2.qcoeffs),  q1.aff - q2.aff)
+function Base.:+(q1::GenericQuadExpr, q2::GenericQuadExpr)
+    result = copy(q1)
+    for (coef, var1, var2) in quadterms(q2)
+        push!(result, coef, var1, var2)
+    end
+    for (coef, var) in linearterms(q2)
+        push!(result, coef, var)
+    end
+    result.aff.constant += q2.aff.constant
+    return result
+end
+function Base.:-(q1::GenericQuadExpr, q2::GenericQuadExpr)
+    result = copy(q1)
+    for (coef, var1, var2) in quadterms(q2)
+        push!(result, -coef, var1, var2)
+    end
+    for (coef, var) in linearterms(q2)
+        push!(result, -coef, var)
+    end
+    result.aff.constant -= q2.aff.constant
+    return result
+end
 
-Base.:(==)(lhs::GenericAffExpr,rhs::GenericAffExpr) = (lhs.vars == rhs.vars) && (lhs.coeffs == rhs.coeffs) && (lhs.constant == rhs.constant)
-Base.:(==)(lhs::GenericQuadExpr,rhs::GenericQuadExpr) = (lhs.qvars1 == rhs.qvars1) && (lhs.qvars2 == rhs.qvars2) && (lhs.qcoeffs == rhs.qcoeffs) && (lhs.aff == rhs.aff)
+Base.:(==)(lhs::GenericAffExpr,rhs::GenericAffExpr) = (lhs.terms == rhs.terms) && (lhs.constant == rhs.constant)
+Base.:(==)(lhs::GenericQuadExpr,rhs::GenericQuadExpr) = (lhs.terms == rhs.terms) && (lhs.aff == rhs.aff)
 
 #############################################################################
 # Helpers to initialize memory for GenericAffExpr/GenericQuadExpr
 #############################################################################
 
-_sizehint_expr!(q::GenericAffExpr, n::Int) = begin
-        sizehint!(q.vars,   length(q.vars)   + n)
-        sizehint!(q.coeffs, length(q.coeffs) + n)
-        nothing
-end
+_sizehint_expr!(a::GenericAffExpr, n::Int) = sizehint!(a, n)
 
-_sizehint_expr!(q::GenericQuadExpr, n::Int) = begin
-        sizehint!(q.qvars1,  length(q.qvars1)  + n)
-        sizehint!(q.qvars2,  length(q.qvars2)  + n)
-        sizehint!(q.qcoeffs, length(q.qcoeffs) + n)
+# TODO: Why do we allocate the same size for the quadratic and affine parts?
+function _sizehint_expr!(q::GenericQuadExpr, n::Int)
+        sizehint!(q.terms,  length(q.terms) + n)
         _sizehint_expr!(q.aff, n)
         nothing
 end
@@ -210,7 +286,7 @@ _sizehint_expr!(q, n) = nothing
 #############################################################################
 
 # TODO: specialize sum for Dict and JuMPArray of JuMP objects?
-Base.sum(j::Array{<:AbstractVariableRef}) = GenericAffExpr(vec(j), ones(length(j)), 0.0)
+Base.sum(vars::Array{<:AbstractVariableRef}) = GenericAffExpr(0.0, [v => 1.0 for v in vars])
 Base.sum(j::AbstractArray{<:AbstractVariableRef}) = sum([j[i] for i in eachindex(j)]) # to handle non-one-indexed arrays.
 function Base.sum(affs::AbstractArray{T}) where T<:GenericAffExpr
     new_aff = zero(T)

--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -60,7 +60,11 @@ function destructive_add!(ex::Number, c::Number, x::T) where T<:GenericQuadExpr
     end
 end
 
-destructive_add!(ex::Number, c::VariableRef, x::VariableRef) = QuadExpr([c],[x],[1.0],zero(AffExpr))
+function destructive_add!(ex::Number, c::VariableRef, x::VariableRef)
+    result = c*x
+    result.aff.constant += ex
+    result
+end
 
 function destructive_add!(ex::Number, c::T, x::T) where T<:GenericAffExpr
     q = c*x
@@ -230,8 +234,7 @@ function destructive_add!(quad::GenericQuadExpr{C,V},c::Number,x::GenericQuadExp
 end
 
 function destructive_add!(ex::GenericQuadExpr{C,V}, c::GenericAffExpr{C,V}, x::GenericAffExpr{C,V}) where {C,V}
-    q = c*x
-    destructive_add!(ex, 1.0, q)
+    destructive_add!(ex, 1.0, c*x)
 end
 
 # Catch nonlinear expressions and parameters being used in addconstraint, etc.

--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -36,7 +36,7 @@ function addtoexpr(ex::Number, c::Number, x::T) where T<:GenericAffExpr
     if iszero(c)
         convert(T, ex)
     else
-        x = map_coefficients(x, coef -> c*coef)
+        x = c*x
         x.constant += ex
         x
     end

--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -22,16 +22,23 @@ function parseIdxSet(arg::Expr)
     error("Invalid syntax: $arg")
 end
 
-# TODO: addtoexpr should be refactored to be more coherent with push!, append!,
-# and operators.jl.
+"""
+    destructive_add!(expression, terms...)
 
-# addtoexpr(ex::Number, c::Number) = ex + c
+Returns the result of `expression + (*)(terms...)` and possibly destroys
+`expression` (i.e., reusing its storage for the result, if possible). For
+example `result = destructive_add!(expression, 2, x)` sets `result` to the value
+of `expression + 2*x`. `expression` should not be referred to after this call.
 
-addtoexpr(ex::Number, c::Number, x::Number) = ex + c*x
+Note: Discarding the result of `destructive_add!` suggests an improper usage.
+"""
+function destuctive_add! end
 
-addtoexpr(ex::Number, c::Number, x::VariableRef) = AffExpr(ex, x => c)
+destructive_add!(ex::Number, c::Number, x::Number) = ex + c*x
 
-function addtoexpr(ex::Number, c::Number, x::T) where T<:GenericAffExpr
+destructive_add!(ex::Number, c::Number, x::VariableRef) = AffExpr(ex, x => c)
+
+function destructive_add!(ex::Number, c::Number, x::T) where T<:GenericAffExpr
     # It's only safe to mutate the first argument.
     if iszero(c)
         convert(T, ex)
@@ -42,7 +49,7 @@ function addtoexpr(ex::Number, c::Number, x::T) where T<:GenericAffExpr
     end
 end
 
-function addtoexpr(ex::Number, c::Number, x::T) where T<:GenericQuadExpr
+function destructive_add!(ex::Number, c::Number, x::T) where T<:GenericQuadExpr
     # It's only safe to mutate the first argument.
     if iszero(c)
         T(ex)
@@ -53,21 +60,21 @@ function addtoexpr(ex::Number, c::Number, x::T) where T<:GenericQuadExpr
     end
 end
 
-addtoexpr(ex::Number, c::VariableRef, x::VariableRef) = QuadExpr([c],[x],[1.0],zero(AffExpr))
+destructive_add!(ex::Number, c::VariableRef, x::VariableRef) = QuadExpr([c],[x],[1.0],zero(AffExpr))
 
-function addtoexpr(ex::Number, c::T, x::T) where T<:GenericAffExpr
+function destructive_add!(ex::Number, c::T, x::T) where T<:GenericAffExpr
     q = c*x
     q.aff.constant += ex
     q
 end
 
-function addtoexpr(ex::Number, c::GenericAffExpr{C,V}, x::V) where {C,V}
+function destructive_add!(ex::Number, c::GenericAffExpr{C,V}, x::V) where {C,V}
     q = c*x
     q.aff.constant += ex
     q
 end
 
-function addtoexpr(ex::Number, c::T, x::Number) where T<:GenericQuadExpr
+function destructive_add!(ex::Number, c::T, x::Number) where T<:GenericQuadExpr
     if iszero(x)
         convert(T, ex)
     else
@@ -77,21 +84,21 @@ function addtoexpr(ex::Number, c::T, x::Number) where T<:GenericQuadExpr
     end
 end
 
-function addtoexpr(aff::GenericAffExpr, c::Number, x::Number)
+function destructive_add!(aff::GenericAffExpr, c::Number, x::Number)
     aff.constant += c*x
     aff
 end
 
-function addtoexpr(aff::GenericAffExpr{C,V}, c::Number, x::V) where {C,V}
-    push!(aff, convert(C, c), x)
+function destructive_add!(aff::GenericAffExpr{C,V}, c::Number, x::V) where {C,V}
+    add_to_expression!(aff, convert(C, c), x)
     aff
 end
 
-function addtoexpr(aff::GenericAffExpr{C,V},c::Number,x::GenericAffExpr{C,V}) where {C,V}
+function destructive_add!(aff::GenericAffExpr{C,V},c::Number,x::GenericAffExpr{C,V}) where {C,V}
     if !iszero(c)
         sizehint!(aff, length(linearterms(aff)) + length(linearterms(x)))
         for (coef, var) in linearterms(x)
-            push!(aff, c*coef, var)
+            add_to_expression!(aff, c*coef, var)
         end
         aff.constant += c*x.constant
     end
@@ -99,132 +106,132 @@ function addtoexpr(aff::GenericAffExpr{C,V},c::Number,x::GenericAffExpr{C,V}) wh
 end
 
 # help w/ ambiguity
-addtoexpr(aff::GenericAffExpr{C,V}, c::Number, x::Number) where {C,V<:Number} = aff + c*x
+destructive_add!(aff::GenericAffExpr{C,V}, c::Number, x::Number) where {C,V<:Number} = aff + c*x
 
-function addtoexpr(aff::GenericAffExpr{C,V}, c::V, x::Number) where {C,V}
+function destructive_add!(aff::GenericAffExpr{C,V}, c::V, x::Number) where {C,V}
     if !iszero(x)
-        push!(aff, convert(C, x), c)
+        add_to_expression!(aff, convert(C, x), c)
     end
     aff
 end
 
-addtoexpr(aff::GenericAffExpr{C,V},c::V,x::V) where {C,V} =
+destructive_add!(aff::GenericAffExpr{C,V},c::V,x::V) where {C,V} =
     GenericQuadExpr{C,V}(aff, UnorderedPair(c,x) => 1.0)
 
 # TODO: add generic versions of following two methods
-function addtoexpr(aff::AffExpr,c::AffExpr,x::VariableRef)
+function destructive_add!(aff::AffExpr,c::AffExpr,x::VariableRef)
     quad = c*x
-    addtoexpr(quad.aff, 1.0, aff)
+    quad.aff = destructive_add!(quad.aff, 1.0, aff)
     quad
 end
 
-function addtoexpr(aff::AffExpr,c::VariableRef,x::AffExpr)
+function destructive_add!(aff::AffExpr,c::VariableRef,x::AffExpr)
     quad = c*x
-    addtoexpr(quad.aff, 1.0, aff)
+    # TODO: Consider implementing the add_to_expression! method for cases like
+    # this and below.
+    quad.aff = destructive_add!(quad.aff, 1.0, aff)
     quad
 end
 
-function addtoexpr(aff::GenericAffExpr{C,V},c::GenericAffExpr{C,V},x::Number) where {C,V}
-    addtoexpr(aff, x, c)
+function destructive_add!(aff::GenericAffExpr{C,V},c::GenericAffExpr{C,V},x::Number) where {C,V}
+    destructive_add!(aff, x, c)
 end
 
-function addtoexpr(aff::GenericAffExpr{C,V}, c::GenericQuadExpr{C,V}, x::Number) where {C,V}
+function destructive_add!(aff::GenericAffExpr{C,V}, c::GenericQuadExpr{C,V}, x::Number) where {C,V}
     if iszero(x)
         GenericQuadExpr{C,V}(aff)
     else
         result = c*x
-        append!(result.aff, aff)
+        add_to_expression!(result.aff, aff)
         result
     end
 end
 
-function addtoexpr(aff::GenericAffExpr{C,V}, c::Number, x::GenericQuadExpr{C,V}) where {C,V}
+function destructive_add!(aff::GenericAffExpr{C,V}, c::Number, x::GenericQuadExpr{C,V}) where {C,V}
     if iszero(c)
         GenericQuadExpr{C,V}(aff)
     else
         result = c*x
-        append!(result.aff, aff)
+        add_to_expression!(result.aff, aff)
         result
     end
 end
 
-function addtoexpr(ex::GenericAffExpr{C,V}, c::GenericAffExpr{C,V}, x::GenericAffExpr{C,V}) where {C,V}
+function destructive_add!(ex::GenericAffExpr{C,V}, c::GenericAffExpr{C,V}, x::GenericAffExpr{C,V}) where {C,V}
     q = convert(GenericQuadExpr{C,V}, ex)
-    addtoexpr(q, one(C), c*x)
-    q
+    destructive_add!(q, one(C), c*x)
 end
 
-function addtoexpr(quad::GenericQuadExpr{C,V},c::Number,x::V) where {C,V}
+function destructive_add!(quad::GenericQuadExpr{C,V},c::Number,x::V) where {C,V}
     if !iszero(c)
-        push!(quad.aff, convert(C, c), x)
+        add_to_expression!(quad.aff, convert(C, c), x)
     end
     quad
 end
 
-function addtoexpr(quad::GenericQuadExpr,c::Number,x::Number)
+function destructive_add!(quad::GenericQuadExpr,c::Number,x::Number)
     quad.aff.constant += c*x
     quad
 end
 
-function addtoexpr(quad::GenericQuadExpr{C,V},x::V,y::V) where {C,V}
-    push!(quad, one(C), x, y)
+function destructive_add!(quad::GenericQuadExpr{C,V},x::V,y::V) where {C,V}
+    add_to_expression!(quad, one(C), x, y)
     quad
 end
 
-function addtoexpr(quad::GenericQuadExpr{C,V},c::Number,x::GenericAffExpr{C,V}) where {C,V}
-    addtoexpr(quad.aff, c, x)
+function destructive_add!(quad::GenericQuadExpr{C,V},c::Number,x::GenericAffExpr{C,V}) where {C,V}
+    quad.aff = destructive_add!(quad.aff, c, x)
     quad
 end
 
-function addtoexpr(quad::GenericQuadExpr{C,V},c::GenericAffExpr{C,V},x::Number) where {C,V}
-    addtoexpr(quad.aff,c,x)
+function destructive_add!(quad::GenericQuadExpr{C,V},c::GenericAffExpr{C,V},x::Number) where {C,V}
+    quad.aff = destructive_add!(quad.aff,c,x)
     quad
 end
 
-function addtoexpr(quad::GenericQuadExpr{C,V},c::GenericAffExpr{C,V},x::V) where {C,V}
+function destructive_add!(quad::GenericQuadExpr{C,V},c::GenericAffExpr{C,V},x::V) where {C,V}
     for (coef, var) in linearterms(c)
-        push!(quad, coef, var, x)
+        add_to_expression!(quad, coef, var, x)
     end
     if !iszero(c.constant)
-        addtoexpr(quad.aff,c.constant,x)
+        quad.aff = destructive_add!(quad.aff,c.constant,x)
     end
     quad
 end
 
-function addtoexpr(quad::GenericQuadExpr{C,V},c::V,x::GenericAffExpr{C,V}) where {C,V}
+function destructive_add!(quad::GenericQuadExpr{C,V},c::V,x::GenericAffExpr{C,V}) where {C,V}
     for (coef, var) in linearterms(x)
-        push!(quad, coef, c, var)
+        add_to_expression!(quad, coef, c, var)
     end
     if !iszero(x.constant)
-        addtoexpr(quad.aff,c,x.constant)
+        quad.aff = destructive_add!(quad.aff,c,x.constant)
     end
     quad
 end
 
-function addtoexpr(quad::GenericQuadExpr{C,V},c::GenericQuadExpr{C,V},x::Number) where {C,V}
+function destructive_add!(quad::GenericQuadExpr{C,V},c::GenericQuadExpr{C,V},x::Number) where {C,V}
     if !iszero(x)
         for (coef, var1, var2) in quadterms(c)
-            push!(quad, x*coef, var1, var2)
+            add_to_expression!(quad, x*coef, var1, var2)
         end
-        addtoexpr(quad.aff,c.aff,x)
+        quad.aff = destructive_add!(quad.aff,c.aff,x)
     end
     quad
 end
 
-function addtoexpr(quad::GenericQuadExpr{C,V},c::Number,x::GenericQuadExpr{C,V}) where {C,V}
+function destructive_add!(quad::GenericQuadExpr{C,V},c::Number,x::GenericQuadExpr{C,V}) where {C,V}
     if !iszero(c)
         for (coef, var1, var2) in quadterms(x)
-            push!(quad, c*coef, var1, var2)
+            add_to_expression!(quad, c*coef, var1, var2)
         end
-        addtoexpr(quad.aff,c,x.aff)
+        quad.aff = destructive_add!(quad.aff,c,x.aff)
     end
     quad
 end
 
-function addtoexpr(ex::GenericQuadExpr{C,V}, c::GenericAffExpr{C,V}, x::GenericAffExpr{C,V}) where {C,V}
+function destructive_add!(ex::GenericQuadExpr{C,V}, c::GenericAffExpr{C,V}, x::GenericAffExpr{C,V}) where {C,V}
     q = c*x
-    addtoexpr(ex, 1.0, q)
-    ex
+    destructive_add!(ex, 1.0, q)
 end
 
 # Catch nonlinear expressions and parameters being used in addconstraint, etc.
@@ -233,42 +240,48 @@ const _NLExpr = Union{NonlinearExpression,NonlinearParameter}
 _nlexprerr() = error("""Cannot use nonlinear expression or parameter in @constraint or @objective.
                         Use @NLconstraint or @NLobjective instead.""")
 # Following three definitions avoid ambiguity warnings
-addtoexpr(expr::GenericQuadExpr{C,V}, c::GenericAffExpr{C,V}, x::V) where {C,V<:_NLExpr} = _nlexprerr()
-addtoexpr(expr::GenericQuadExpr{C,V}, c::Number, x::V) where {C,V<:_NLExpr} = _nlexprerr()
-addtoexpr(expr::GenericQuadExpr{C,V}, c::V, x::GenericAffExpr{C,V}) where {C,V<:_NLExpr} = _nlexprerr()
+destructive_add!(expr::GenericQuadExpr{C,V}, c::GenericAffExpr{C,V}, x::V) where {C,V<:_NLExpr} = _nlexprerr()
+destructive_add!(expr::GenericQuadExpr{C,V}, c::Number, x::V) where {C,V<:_NLExpr} = _nlexprerr()
+destructive_add!(expr::GenericQuadExpr{C,V}, c::V, x::GenericAffExpr{C,V}) where {C,V<:_NLExpr} = _nlexprerr()
 for T1 in (GenericAffExpr,GenericQuadExpr), T2 in (Number,VariableRef,GenericAffExpr,GenericQuadExpr)
-    @eval addtoexpr(::$T1, ::$T2, ::_NLExpr) = _nlexprerr()
-    @eval addtoexpr(::$T1, ::_NLExpr, ::$T2) = _nlexprerr()
+    @eval destructive_add!(::$T1, ::$T2, ::_NLExpr) = _nlexprerr()
+    @eval destructive_add!(::$T1, ::_NLExpr, ::$T2) = _nlexprerr()
 end
 
-addtoexpr(ex::AbstractArray{T}, c::AbstractArray, x::AbstractArray) where {T<:GenericAffExpr} = append!.(ex, c*x)
-addtoexpr(ex::AbstractArray{T}, c::AbstractArray, x::Number) where {T<:GenericAffExpr} = append!.(ex, c*x)
-addtoexpr(ex::AbstractArray{T}, c::Number, x::AbstractArray) where {T<:GenericAffExpr} = append!.(ex, c*x)
+function destructive_add!(ex::AbstractArray{T}, c::AbstractArray, x::AbstractArray) where {T<:GenericAffExpr}
+    add_to_expression!.(ex, c*x)
+end
+function destructive_add!(ex::AbstractArray{T}, c::AbstractArray, x::Number) where {T<:GenericAffExpr}
+    add_to_expression!.(ex, c*x)
+end
+function destructive_add!(ex::AbstractArray{T}, c::Number, x::AbstractArray) where {T<:GenericAffExpr}
+    add_to_expression!.(ex, c*x)
+end
 
-addtoexpr(ex, c, x) = ex + c*x
+destructive_add!(ex, c, x) = ex + c*x
 
-addtoexpr_reorder(ex, arg) = addtoexpr(ex, 1.0, arg)
+reorder_for_destructive_add(ex, arg) = destructive_add!(ex, 1.0, arg)
 # Special case because "Val{false}()" is used as the default empty expression.
-addtoexpr_reorder(ex::Val{false}, arg) = copy(arg)
-addtoexpr_reorder(ex::Val{false}, args...) = (*)(args...)
+reorder_for_destructive_add(ex::Val{false}, arg) = copy(arg)
+reorder_for_destructive_add(ex::Val{false}, args...) = (*)(args...)
 
 
-@generated function addtoexpr_reorder(ex, x, y)
+@generated function reorder_for_destructive_add(ex, x, y)
     if x <: Union{VariableRef,AffExpr} && y <: Number
-        :(addtoexpr(ex, y, x))
+        :(destructive_add!(ex, y, x))
     else
-        :(addtoexpr(ex, x, y))
+        :(destructive_add!(ex, x, y))
     end
 end
 
-@generated function addtoexpr_reorder(ex, args...)
+@generated function reorder_for_destructive_add(ex, args...)
     n = length(args)
     @assert n ≥ 3
     varidx = find(t -> (t == VariableRef || t == AffExpr), collect(args))
     allscalar = all(t -> (t <: Number), args[setdiff(1:n, varidx)])
     idx = (allscalar && length(varidx) == 1) ? varidx[1] : n
     coef = Expr(:call, :*, [:(args[$i]) for i in setdiff(1:n,idx)]...)
-    :(addtoexpr(ex, $coef, args[$idx]))
+    :(destructive_add!(ex, $coef, args[$idx]))
 end
 
 # takes a generator statement and returns a properly nested for loop
@@ -342,7 +355,7 @@ parseExprToplevel(x, aff::Symbol) = parseExpr(x, aff, [], [])
 function parseExpr(x, aff::Symbol, lcoeffs::Vector, rcoeffs::Vector, newaff::Symbol=gensym())
     if !isa(x,Expr)
         # at the lowest level
-        callexpr = Expr(:call,:addtoexpr_reorder,aff,lcoeffs...,esc(x),rcoeffs...)
+        callexpr = Expr(:call,:reorder_for_destructive_add,aff,lcoeffs...,esc(x),rcoeffs...)
         return newaff, :($newaff = $callexpr)
     else
         if x.head == :call && x.args[1] == :+
@@ -396,7 +409,7 @@ function parseExpr(x, aff::Symbol, lcoeffs::Vector, rcoeffs::Vector, newaff::Sym
                         x.args[i] = esc(x.args[i])
                     end
                 end
-                callexpr = Expr(:call,:addtoexpr_reorder,aff,lcoeffs...,x.args[2:end]...,rcoeffs...)
+                callexpr = Expr(:call,:reorder_for_destructive_add,aff,lcoeffs...,x.args[2:end]...,rcoeffs...)
                 push!(blk.args, :($newaff = $callexpr))
                 return newaff, blk
             end
@@ -406,7 +419,7 @@ function parseExpr(x, aff::Symbol, lcoeffs::Vector, rcoeffs::Vector, newaff::Sym
                 s = gensym()
                 newaff_, parsed = parseExprToplevel(x.args[2], s)
                 push!(blk.args, :($s = Val(false); $parsed))
-                push!(blk.args, :($newaff = addtoexpr_reorder($aff, $(Expr(:call,:*,lcoeffs...,newaff_,newaff_,rcoeffs...)))))
+                push!(blk.args, :($newaff = reorder_for_destructive_add($aff, $(Expr(:call,:*,lcoeffs...,newaff_,newaff_,rcoeffs...)))))
                 return newaff, blk
             elseif x.args[3] == 1
                 return parseExpr(:(QuadExpr($(x.args[2]))), aff, lcoeffs, rcoeffs)
@@ -417,7 +430,7 @@ function parseExpr(x, aff::Symbol, lcoeffs::Vector, rcoeffs::Vector, newaff::Sym
                 s = gensym()
                 newaff_, parsed = parseExprToplevel(x.args[2], s)
                 push!(blk.args, :($s = Val(false); $parsed))
-                push!(blk.args, :($newaff = addtoexpr_reorder($aff, $(Expr(:call,:*,lcoeffs...,Expr(:call,:^,newaff_,esc(x.args[3])),rcoeffs...)))))
+                push!(blk.args, :($newaff = reorder_for_destructive_add($aff, $(Expr(:call,:*,lcoeffs...,Expr(:call,:^,newaff_,esc(x.args[3])),rcoeffs...)))))
                 return newaff, blk
             end
         elseif x.head == :call && x.args[1] == :/
@@ -431,7 +444,7 @@ function parseExpr(x, aff::Symbol, lcoeffs::Vector, rcoeffs::Vector, newaff::Sym
             error_curly(x)
         else # at lowest level?
             !isexpr(x,:comparison) || error("Unexpected comparison in expression $x")
-            callexpr = Expr(:call,:addtoexpr_reorder,aff,lcoeffs...,esc(x),rcoeffs...)
+            callexpr = Expr(:call,:reorder_for_destructive_add,aff,lcoeffs...,esc(x),rcoeffs...)
             return newaff, :($newaff = $callexpr)
         end
     end

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -102,7 +102,7 @@ Base.done(qti::QuadTermIterator, state::Int) = done(qti.quad.terms, state)
 Base.next(qti::QuadTermIterator, state::Int) = reorder_iterator(next(qti.quad.terms, state)...)
 Base.length(qti::QuadTermIterator) = length(qti.quad.terms)
 
-function Base.push!(quad::GenericQuadExpr{C,V}, new_coef::C, new_var1::V, new_var2::V) where {C,V}
+function add_to_expression!(quad::GenericQuadExpr{C,V}, new_coef::C, new_var1::V, new_var2::V) where {C,V}
     # Node: OrderedDict updates the *key* as well. That is, if there was a
     # previous value for UnorderedPair(new_var2, new_var1), it's key will now be
     # UnorderedPair(new_var1, new_var2) (because these are defined as equal).
@@ -111,14 +111,14 @@ function Base.push!(quad::GenericQuadExpr{C,V}, new_coef::C, new_var1::V, new_va
     quad
 end
 
-function Base.push!(quad::GenericQuadExpr{C, V}, new_coef::C, new_var::V) where {C,V}
-    push!(quad.aff, new_coef, new_var)
+function add_to_expression!(quad::GenericQuadExpr{C, V}, new_coef::C, new_var::V) where {C,V}
+    add_to_expression!(quad.aff, new_coef, new_var)
     quad
 end
 
-function Base.append!(q::GenericQuadExpr{T,S}, other::GenericQuadExpr{T,S}) where {T,S}
+function add_to_expression!(q::GenericQuadExpr{T,S}, other::GenericQuadExpr{T,S}) where {T,S}
     merge!(+, q.terms, other.terms)
-    append!(q.aff, other.aff)
+    add_to_expression!(q.aff, other.aff)
     q
 end
 
@@ -192,7 +192,7 @@ function QuadExpr(m::Model, f::MOI.ScalarQuadraticFunction)
         if v1 == v2
             coef /= 2
         end
-        push!(quad, coef, VariableRef(m, v1), VariableRef(m, v2))
+        add_to_expression!(quad, coef, VariableRef(m, v1), VariableRef(m, v2))
     end
     return quad
 end

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -148,9 +148,7 @@ end
 function isequal_canonical(quad::GenericQuadExpr{CoefType,VarType}, other::GenericQuadExpr{CoefType,VarType}) where {CoefType,VarType}
     quad_nozeros = dropzeros(quad)
     other_nozeros = dropzeros(other)
-    return isequal(quad_nozeros.terms, other_nozeros.terms) &&
-           isequal(quad_nozeros.aff.terms, other_nozeros.aff.terms) &&
-           isequal(quad_nozeros.aff.constant, other_nozeros.aff.constant)
+    return isequal(quad_nozeros, other_nozeros)
 end
 
 # Alias for (Float64, VariableRef)
@@ -161,6 +159,7 @@ end
 GenericQuadExpr{C, V}() where {C, V} = zero(GenericQuadExpr{C, V})
 
 function MOI.ScalarQuadraticFunction(q::QuadExpr)
+    assert_isfinite(q)
     qvars1 = MOIVAR[]
     qvars2 = MOIVAR[]
     coefs = Float64[]

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -16,84 +16,185 @@
 #############################################################################
 
 
-#############################################################################
+struct UnorderedPair{T}
+    a::T
+    b::T
+end
+
+Base.hash(p::UnorderedPair, h::UInt) = hash(hash(p.a) + hash(p.b), h)
+function Base.isequal(p1::UnorderedPair, p2::UnorderedPair)
+    return (p1.a == p2.a && p1.b == p2.b) || (p1.a == p2.b && p1.b == p2.a)
+end
+
 # GenericQuadExpr
 # ∑qᵢⱼ xᵢⱼ  +  ∑ aᵢ xᵢ  +  c
 mutable struct GenericQuadExpr{CoefType,VarType} <: AbstractJuMPScalar
-    qvars1::Vector{VarType}
-    qvars2::Vector{VarType}
-    qcoeffs::Vector{CoefType}
     aff::GenericAffExpr{CoefType,VarType}
+    terms::OrderedDict{UnorderedPair{VarType}, CoefType}
 end
 
-Base.iszero(q::GenericQuadExpr) = isempty(q.qvars1) && iszero(q.aff)
-Base.zero(::Type{GenericQuadExpr{C,V}}) where {C,V} = GenericQuadExpr(V[], V[], C[], zero(GenericAffExpr{C,V}))
-Base.one(::Type{GenericQuadExpr{C,V}}) where {C,V}  = GenericQuadExpr(V[], V[], C[],  one(GenericAffExpr{C,V}))
+function GenericQuadExpr(aff::GenericAffExpr{V,K}, kv::AbstractArray{Pair{UnorderedPair{K},V}}) where {K,V}
+    return GenericQuadExpr{V,K}(aff, new_ordered_dict(UnorderedPair{K}, V, kv))
+end
+
+function GenericQuadExpr(aff::GenericAffExpr{V,K}, kv::Pair{UnorderedPair{K},V}...) where {K,V}
+    return GenericQuadExpr{V,K}(aff, new_ordered_dict(UnorderedPair{K}, V, kv...))
+end
+
+function GenericAffExpr{V,K}(aff::GenericAffExpr{V,K}, kv::AbstractArray{<:Pair}) where {K,V}
+    return GenericQuadExpr{V,K}(aff, new_ordered_dict(UnorderedPair{K}, V, kv))
+end
+
+function GenericQuadExpr{V,K}(aff::GenericAffExpr{V,K}, kv::Pair...) where {K,V}
+    return GenericQuadExpr{V,K}(aff, new_ordered_dict(UnorderedPair{K}, V, kv...))
+end
+
+Base.iszero(q::GenericQuadExpr) = isempty(q.terms) && iszero(q.aff)
+function Base.zero(::Type{GenericQuadExpr{C,V}}) where {C,V}
+    return GenericQuadExpr(zero(GenericAffExpr{C,V}), OrderedDict{UnorderedPair{V}, C}())
+end
+function Base.one(::Type{GenericQuadExpr{C,V}}) where {C,V}
+    return GenericQuadExpr(one(GenericAffExpr{C,V}), OrderedDict{UnorderedPair{V}, C}())
+end
 Base.zero(q::GenericQuadExpr) = zero(typeof(q))
-Base.one(q::GenericQuadExpr)  =  one(typeof(q))
-Base.copy(q::GenericQuadExpr) = GenericQuadExpr(copy(q.qvars1),copy(q.qvars2),copy(q.qcoeffs),copy(q.aff))
+Base.one(q::GenericQuadExpr)  = one(typeof(q))
+Base.copy(q::GenericQuadExpr) = GenericQuadExpr(copy(q.aff), copy(q.terms))
+
+function map_coefficients!(q::GenericQuadExpr, f::Function)
+    # The iterator remains valid if existing elements are updated.
+    for (key, value) in q.terms
+        q.terms[key] = f(value)
+    end
+    map_coefficients!(q.aff, f)
+    return q
+end
+
+function map_coefficients(q::GenericQuadExpr, f::Function)
+    return map_coefficients!(copy(q), f)
+end
+
+"""
+    linearterms(aff::GenericQuadExpr{C, V})
+
+Provides an iterator over tuples `(coefficient::C, variable::V)` in the
+linear part of the quadratic expression.
+"""
+linearterms(quad::GenericQuadExpr) = LinearTermIterator(quad.aff)
+
+struct QuadTermIterator{GQE<:GenericQuadExpr}
+    quad::GQE
+end
+
+"""
+    quadterms(quad::GenericQuadExpr{C, V})
+
+Provides an iterator over tuples `(coefficient::C, var_1::V, var_2::V)` in the
+quadratic part of the quadratic expression.
+"""
+quadterms(quad::GenericQuadExpr) = QuadTermIterator(quad)
+
+function reorder_iterator(p::Pair{UnorderedPair{V},C}, state::Int) where {C,V}
+    return ((p.second, p.first.a, p.first.b), state)
+end
+
+Base.start(qti::QuadTermIterator) = start(qti.quad.terms)
+Base.done(qti::QuadTermIterator, state::Int) = done(qti.quad.terms, state)
+Base.next(qti::QuadTermIterator, state::Int) = reorder_iterator(next(qti.quad.terms, state)...)
+Base.length(qti::QuadTermIterator) = length(qti.quad.terms)
+
+function Base.push!(quad::GenericQuadExpr{C,V}, new_coef::C, new_var1::V, new_var2::V) where {C,V}
+    # Node: OrderedDict updates the *key* as well. That is, if there was a
+    # previous value for UnorderedPair(new_var2, new_var1), it's key will now be
+    # UnorderedPair(new_var1, new_var2) (because these are defined as equal).
+    key = UnorderedPair(new_var1, new_var2)
+    add_or_set!(quad.terms, key, new_coef)
+    quad
+end
+
+function Base.push!(quad::GenericQuadExpr{C, V}, new_coef::C, new_var::V) where {C,V}
+    push!(quad.aff, new_coef, new_var)
+    quad
+end
 
 function Base.append!(q::GenericQuadExpr{T,S}, other::GenericQuadExpr{T,S}) where {T,S}
-    append!(q.qvars1, other.qvars1)
-    append!(q.qvars2, other.qvars2)
-    append!(q.qcoeffs, other.qcoeffs)
+    merge!(+, q.terms, other.terms)
     append!(q.aff, other.aff)
     q
 end
 
 function assert_isfinite(q::GenericQuadExpr)
     assert_isfinite(q.aff)
-    for i in 1:length(q.qcoeffs)
-        isfinite(q.qcoeffs[i]) || error("Invalid coefficient $(q.qcoeffs[i]) on quadratic term $(q.qvars1[i])*$(q.qvars2[i])")
+    for (coef, var1, var2) in quadterms(q)
+        isfinite(coef) || error("Invalid coefficient $coef on quadratic term $var1*$var2.")
     end
 end
 
-function Base.isequal(q::GenericQuadExpr{T,S},other::GenericQuadExpr{T,S}) where {T,S}
-    isequal(q.aff,other.aff)   || return false
-    length(q.qvars1) == length(other.qvars1) || return false
-    for i in 1:length(q.qvars1)
-        isequal(q.qvars1[i],  other.qvars1[i]) || return false
-        isequal(q.qvars2[i],  other.qvars2[i]) || return false
-        isequal(q.qcoeffs[i],other.qcoeffs[i]) || return false
-    end
-    return true
+function Base.isequal(q::GenericQuadExpr{T,S}, other::GenericQuadExpr{T,S}) where {T,S}
+    return isequal(q.aff,other.aff) && isequal(q.terms, other.terms)
 end
 
-# Check if two QuadExprs are equal regardless of the order, and after merging duplicates
+function Base.dropzeros(quad::GenericQuadExpr)
+    quad_terms = copy(quad.terms)
+    for (key, value) in quad.terms
+        if iszero(value)
+            delete!(quad_terms, key)
+        end
+    end
+    return GenericQuadExpr(dropzeros(quad.aff), quad_terms)
+end
+
+# Check if two QuadExprs are equal regardless of the order, and after dropping zeros.
 # Mostly useful for testing.
 function isequal_canonical(quad::GenericQuadExpr{CoefType,VarType}, other::GenericQuadExpr{CoefType,VarType}) where {CoefType,VarType}
-    function canonicalize(q)
-        d = Dict{Set{VarType},CoefType}()
-        @assert length(q.qvars1) == length(q.qvars2) == length(q.qcoeffs)
-        for (v1,v2,c) in zip(q.qvars1, q.qvars2, q.qcoeffs)
-            vset = Set((v1,v2))
-            d[vset] = c + get(d, vset, zero(CoefType))
-        end
-        for k in keys(d)
-            if iszero(d[k])
-                delete!(d, k)
-            end
-        end
-        return d
-    end
-    d1 = canonicalize(quad)
-    d2 = canonicalize(other)
-    return isequal(d1,d2) && isequal_canonical(quad.aff, other.aff)
+    quad_nozeros = dropzeros(quad)
+    other_nozeros = dropzeros(other)
+    return isequal(quad_nozeros.terms, other_nozeros.terms) &&
+           isequal(quad_nozeros.aff.terms, other_nozeros.aff.terms) &&
+           isequal(quad_nozeros.aff.constant, other_nozeros.aff.constant)
 end
 
 # Alias for (Float64, VariableRef)
 const QuadExpr = GenericQuadExpr{Float64,VariableRef}
-Base.convert(::Type{GenericQuadExpr{C, V}}, v::Union{Real,VariableRef,GenericAffExpr}) where {C, V} = GenericQuadExpr(V[], V[], C[], GenericAffExpr{C, V}(v))
+function Base.convert(::Type{GenericQuadExpr{C, V}}, v::Union{Real,VariableRef,GenericAffExpr}) where {C, V}
+    return GenericQuadExpr(convert(GenericAffExpr{C, V}, v))
+end
 GenericQuadExpr{C, V}() where {C, V} = zero(GenericQuadExpr{C, V})
 
 function MOI.ScalarQuadraticFunction(q::QuadExpr)
-    scaledcoef = [(v1 == v2) ? 2coef : coef for (v1,v2,coef) in zip(q.qvars1, q.qvars2, q.qcoeffs)]
-    return MOI.ScalarQuadraticFunction(index.(q.aff.vars), q.aff.coeffs, index.(q.qvars1), index.(q.qvars2), scaledcoef, q.aff.constant)
+    qvars1 = MOIVAR[]
+    qvars2 = MOIVAR[]
+    coefs = Float64[]
+    sizehint!(qvars1, length(quadterms(q)))
+    sizehint!(qvars2, length(quadterms(q)))
+    sizehint!(coefs, length(quadterms(q)))
+    for (coef, var1, var2) in quadterms(q)
+        push!(qvars1, index(var1))
+        push!(qvars2, index(var2))
+        if var1 == var2
+            push!(coefs, 2coef)
+        else
+            push!(coefs, coef)
+        end
+    end
+    moi_aff = MOI.ScalarAffineFunction(q.aff)
+    return MOI.ScalarQuadraticFunction(moi_aff.variables, moi_aff.coefficients,
+                                       qvars1, qvars2, coefs, moi_aff.constant)
 end
 
 function QuadExpr(m::Model, f::MOI.ScalarQuadraticFunction)
-    scaledcoef = [(v1 == v2) ? coef/2 : coef for (v1, v2, coef) in zip(f.quadratic_rowvariables, f.quadratic_colvariables, f.quadratic_coefficients)]
-    return QuadExpr(VariableRef.(m,f.quadratic_rowvariables), VariableRef.(m, f.quadratic_colvariables), scaledcoef, GenericAffExpr(VariableRef.(m,f.affine_variables), f.affine_coefficients, f.constant))
+    quad = QuadExpr(AffExpr(m, MOI.ScalarAffineFunction(f.affine_variables,
+                                                        f.affine_coefficients,
+                                                        f.constant)))
+    for i in 1:length(f.quadratic_rowvariables)
+        v1 = f.quadratic_rowvariables[i]
+        v2 = f.quadratic_colvariables[i]
+        coef = f.quadratic_coefficients[i]
+        if v1 == v2
+            coef /= 2
+        end
+        push!(quad, coef, VariableRef(m, v1), VariableRef(m, v2))
+    end
+    return quad
 end
 
 function setobjective(m::Model, sense::Symbol, a::QuadExpr)

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -60,17 +60,17 @@ Base.zero(q::GenericQuadExpr) = zero(typeof(q))
 Base.one(q::GenericQuadExpr)  = one(typeof(q))
 Base.copy(q::GenericQuadExpr) = GenericQuadExpr(copy(q.aff), copy(q.terms))
 
-function map_coefficients!(q::GenericQuadExpr, f::Function)
+function map_coefficients_inplace!(f::Function, q::GenericQuadExpr)
     # The iterator remains valid if existing elements are updated.
     for (key, value) in q.terms
         q.terms[key] = f(value)
     end
-    map_coefficients!(q.aff, f)
+    map_coefficients_inplace!(f, q.aff)
     return q
 end
 
-function map_coefficients(q::GenericQuadExpr, f::Function)
-    return map_coefficients!(copy(q), f)
+function map_coefficients(f::Function, q::GenericQuadExpr)
+    return map_coefficients_inplace!(f, copy(q))
 end
 
 """

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -53,6 +53,12 @@ end
 
 MOI.isvalid(m::Model, v::VariableRef) = (v.m === m) && MOI.isvalid(m.moibackend, v.index)
 
+# The default hash is slow. It's important for the performance of AffExpr to
+# define our own.
+# https://github.com/JuliaOpt/MathOptInterface.jl/issues/234#issuecomment-366868878
+Base.hash(v::VariableRef, h::UInt) = hash(object_id(v.m), hash(v.index.value, h))
+Base.isequal(v1::VariableRef, v2::VariableRef) = v1.m === v2.m && v1.index == v2.index
+
 
 """
     VariableToValueMap{T}

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -118,7 +118,7 @@
         for i in 1:2
             for j in 1:2
                 c = JuMP.constraintobject(cref[i,j], AffExpr, MOI.LessThan)
-                @test JuMP.isequal_canonical(c.func, AffExpr(x[i,j]))
+                @test JuMP.isequal_canonical(c.func, convert(AffExpr, x[i,j]))
                 @test c.set == MOI.LessThan(UB[i,j] - 1)
             end
         end

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -167,6 +167,24 @@ Base.copy(x::PowVariable) = x
         @test_expression_with_string JuMP.destructive_add!(x^2 + x, x + 0, x + 1) "2 x² + 2 x"
     end
 
+    @testset "(+)(::AffExpr)" begin
+        m = Model()
+        @variable(m, x)
+        @test_expression_with_string (+)(x + 1) "x + 1"
+    end
+
+    @testset "(+)(::QuadExpr)" begin
+        m = Model()
+        @variable(m, x)
+        @test_expression_with_string (+)(x^2 + 1) "x² + 1"
+    end
+
+    @testset "sum(::Vector{VariableRef})" begin
+        m = Model()
+        @variable(m, x[1:2])
+        @test_expression_with_string sum(x) "x[1] + x[2]"
+    end
+
     @testset "expression^3 and unary*" begin
         m = Model()
         x = PowVariable(1)

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -1,5 +1,5 @@
 # For "expression^3 and unary*"
-struct PowVariable <: JuMP.AbstractJuMPScalar
+struct PowVariable <: JuMP.AbstractVariableRef
     pow::Int
 end
 Base.:^(x::PowVariable, i::Int) = PowVariable(x.pow*i)
@@ -8,9 +8,9 @@ Base.copy(x::PowVariable) = x
 
 @testset "Expression" begin
     @testset "value for GenericAffExpr" begin
-        expr1 = JuMP.GenericAffExpr([3, 2], [-5., 4.], 3.)
-        @test @inferred(JuMP.value(expr1, -)) == 10.
-        expr2 = JuMP.GenericAffExpr(Int[], Int[], 2)
+        expr1 = JuMP.GenericAffExpr(3.0, 3 => -5.0, 2 => 4.0)
+        @test @inferred(JuMP.value(expr1, -)) == 10.0
+        expr2 = JuMP.GenericAffExpr{Int,Int}(2)
         @test typeof(@inferred(JuMP.value(expr2, i -> 1.0))) == Float64
         @test @inferred(JuMP.value(expr2, i -> 1.0)) == 2.0
     end

--- a/test/old/expr.jl
+++ b/test/old/expr.jl
@@ -60,28 +60,4 @@ using Base.Test
         @test isapprox(getvalue(x[1]*x[1]-2x[2]*x[1]+3x[2]+1), 4.0)
     end
 
-    @testset "Test expression iterators" begin
-        m = Model()
-        @variable(m, x[1:10])
-
-        a1 = 1*x[1] + 2*x[2]
-        k = 1
-        for (coeff,var) in linearterms(a1)
-            if k == 1
-                @test coeff == 1
-                @test var === x[1]
-            elseif k == 2
-                @test coeff == 2
-                @test var === x[2]
-            end
-            k += 1
-        end
-
-        k = 0
-        a2 = zero(AffExpr)
-        for (coeff, var) in linearterms(a2)
-            k += 1
-        end
-        @test k == 0
-    end
 end

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -202,6 +202,9 @@ Base.transpose(t::MySumType) = MySumType(t.a)
         end
 
         # 4. QuadExpr
+        # TODO: This test block and others above should be rewritten to be
+        # self-contained. The definitions of q, w, and aff2 are too far to
+        # easily check correctness of the tests.
         @testset "QuadExpr--???" begin
             # 4-0 QuadExpr unary
             @test_expression_with_string +q "2.5 y*z + 7.1 x + 2.5"
@@ -214,7 +217,7 @@ Base.transpose(t::MySumType) = MySumType(t.a)
             @test q == q
             @test_expression_with_string aff2 - q "-2.5 y*z + 1.2 y - 7.1 x - 1.3"
             # 4-2 QuadExpr--Variable
-            @test_expression_with_string q + w "2.5 y*z + w + 7.1 x + 2.5"
+            @test_expression_with_string q + w "2.5 y*z + 7.1 x + w + 2.5"
             @test_expression_with_string q - w "2.5 y*z + 7.1 x - w + 2.5"
             @test_throws ErrorException q*w
             @test_throws ErrorException q/w

--- a/test/print.jl
+++ b/test/print.jl
@@ -48,6 +48,8 @@ end
         io_test(REPLMode, ex, "2 x[1] + 2 y[2,3]")
         io_test(IJuliaMode, ex, "2 x_{1} + 2 y_{2,3}")
 
+        # TODO: These tests shouldn't depend on order of the two variables in
+        # quadratic terms, i.e., x*y vs y*x.
         ex = @expression(mod, (x[1]+x[2])*(y[2,2]+3.0))
         io_test(REPLMode, ex, "x[1]*y[2,2] + x[2]*y[2,2] + 3 x[1] + 3 x[2]")
         io_test(IJuliaMode, ex, "x_{1}\\times y_{2,2} + x_{2}\\times y_{2,2} + 3 x_{1} + 3 x_{2}")
@@ -61,8 +63,8 @@ end
         io_test(IJuliaMode, ex, "x_{1}\\times y_{2,2} + x_{2}\\times y_{2,2} + z$(ijulia[:sq]) + 3 x_{1} + 3 x_{2} - 1")
 
         ex = @expression(mod, -z*x[1] - x[1]*z + x[1]*x[2] + 0*z^2)
-        io_test(REPLMode, ex, "-2 z*x[1] + x[1]*x[2]")
-        io_test(IJuliaMode, ex, "-2 z\\times x_{1} + x_{1}\\times x_{2}")
+        io_test(REPLMode, ex, "-2 x[1]*z + x[1]*x[2]")
+        io_test(IJuliaMode, ex, "-2 x_{1}\\times z + x_{1}\\times x_{2}")
     end
 
     @testset "VariableRef" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,8 @@ const MOI = MathOptInterface
 const MOIT = MOI.Test
 const MOIU = MOI.Utilities
 
+# TODO: This should be defined in JuMP source with the other versions of
+# isequal_canonical.
 function JuMP.isequal_canonical(x::AbstractArray{<:JuMP.AbstractJuMPScalar}, y::AbstractArray{<:JuMP.AbstractJuMPScalar})
     size(x) == size(y) && all(JuMP.isequal_canonical.(x, y))
 end


### PR DESCRIPTION
This means that duplicates are no longer possible. I left zeros in there for now. We might decide to always remove them. I also expect some bikeshedding on the API (`push!`/`append!` are weird names now).

See https://github.com/JuliaOpt/MathOptInterface.jl/issues/234#issuecomment-366868878 for initial benchmarks. I haven't benchmarked the new setup but paid attention to implementing things efficiently. It's not obvious how to do a fair comparison given that `master` doesn't currently remove duplicates, and too much has changed since 0.18.

We can probably close https://github.com/JuliaOpt/MathOptInterface.jl/issues/234 by saying that solvers don't need to accept duplicates.

I'll track down any coverage gaps if the diff is not 100% covered.

@rdeits @vtjeng @ExpandingMan 

