### PR TITLE
Test and fix JuMP extensibility

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -422,6 +422,7 @@ function registercon(m::AbstractModel, conname::Symbol, value)
 end
 registercon(m::AbstractModel, conname, value) = error("Invalid constraint name $conname")
 
+# This function needs to be implemented by all `AbstractModel`s
 object_dictionary(m::Model) = m.objdict
 
 function registerobject(m::AbstractModel, name::Symbol, value, errorstring::String)

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -303,8 +303,8 @@ end
 
 # TODO GenericAffExprConstraint
 
-struct AffExprConstraint{S <: MOI.AbstractScalarSet} <: AbstractConstraint
-    func::AffExpr
+struct AffExprConstraint{V <: AbstractVariableRef, S <: MOI.AbstractScalarSet} <: AbstractConstraint
+    func::GenericAffExpr{Float64, V}
     set::S
 end
 
@@ -314,8 +314,8 @@ moi_function_and_set(c::AffExprConstraint) = (MOI.ScalarAffineFunction(c.func), 
 #addconstraint(m::Model, c::Array{AffExprConstraint}) =
 #    error("The operators <=, >=, and == can only be used to specify scalar constraints. If you are trying to add a vectorized constraint, use the element-wise dot comparison operators (.<=, .>=, or .==) instead")
 
-struct VectorAffExprConstraint{S <: MOI.AbstractVectorSet} <: AbstractConstraint
-    func::Vector{AffExpr}
+struct VectorAffExprConstraint{V <: AbstractVariableRef, S <: MOI.AbstractVectorSet} <: AbstractConstraint
+    func::Vector{GenericAffExpr{Float64, V}}
     set::S
 end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -376,6 +376,7 @@ end
 
 # TODO: update 3-argument @constraint macro to pass through names like @variable
 
+# This function needs to be implemented by all `AbstractModel`s
 constrainttype(m::Model) = ConstraintRef{typeof(m)}
 
 """
@@ -855,6 +856,7 @@ esc_nonconstant(x) = esc(x)
 
 # Returns the type of what `addvariable(::Model, buildvariable(...))` would return where `...` represents the positional arguments.
 # Example: `@variable m [1:3] foo` will allocate an vector of element type `variabletype(m, foo)`
+# Note: it needs to be implemented by all `AbstractModel`s
 variabletype(m::Model) = VariableRef
 # Returns a new variable. Additional positional arguments can be used to dispatch the call to a different method.
 # The return type should only depends on the positional arguments for `variabletype` to make sense. See the @variable macro doc for more details.

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -376,6 +376,8 @@ end
 
 # TODO: update 3-argument @constraint macro to pass through names like @variable
 
+constrainttype(m::Model) = ConstraintRef{typeof(m)}
+
 """
     @constraint(m::Model, con)
 
@@ -447,8 +449,10 @@ macro constraint(args...)
         $parsecode
         $(refcall) = $constraintcall
     end
+    # Determine the return type of addconstraint. This is needed for JuMP extensions for which this is different than ConstraintRef
+    contype = :( constrainttype($m) )
     return assert_validmodel(m, quote
-        $(getloopedcode(variable, code, condition, idxvars, idxsets, :ConstraintRef, requestedcontainer))
+        $(getloopedcode(variable, code, condition, idxvars, idxsets, contype, requestedcontainer))
         $(if anonvar
             variable
         else

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1084,7 +1084,7 @@ macro variable(args...)
     addkwargs!(buildcall, extra_kwargs)
     variablecall = :( addvariable($m, $buildcall, $(namecall(basename, idxvars))) )
     code = :( $(refcall) = $variablecall )
-    # Determine the return type of buildvariable. This is needed to create the container holding them.
+    # Determine the return type of addvariable. This is needed to create the container holding them.
     vartype = :( variabletype($m, $(extra...)) )
 
     if symmetric

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -97,7 +97,7 @@ function Base.:*(lhs::V, rhs::GenericAffExpr{C,V}) where {C, V <: AbstractVariab
 end
 Base.:/(lhs::AbstractVariableRef, rhs::GenericAffExpr) = error("Cannot divide a variable by an affine expression")
 # AbstractVariableRef--GenericQuadExpr
-Base.:+(v::AbstractVariableRef, q::GenericQuadExpr) = QuadExpr(v+q.aff, copy(q.terms))
+Base.:+(v::AbstractVariableRef, q::GenericQuadExpr) = GenericQuadExpr(v+q.aff, copy(q.terms))
 function Base.:-(v::AbstractVariableRef, q::GenericQuadExpr)
     result = -q
     # This makes an unnecessary copy of aff, but it's important for v to appear

--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -270,7 +270,7 @@ destructive_add_with_reorder!(ex::Val{false}, args...) = (*)(args...)
 
 
 @generated function destructive_add_with_reorder!(ex, x, y)
-    if x <: Union{VariableRef,AffExpr} && y <: Number
+    if x <: Union{AbstractVariableRef,GenericAffExpr} && y <: Number
         :(destructive_add!(ex, y, x))
     else
         :(destructive_add!(ex, x, y))
@@ -280,7 +280,7 @@ end
 @generated function destructive_add_with_reorder!(ex, args...)
     n = length(args)
     @assert n ≥ 3
-    varidx = find(t -> (t == VariableRef || t == AffExpr), collect(args))
+    varidx = find(t -> (t <: AbstractVariableRef || t <: GenericAffExpr), collect(args))
     allscalar = all(t -> (t <: Number), args[setdiff(1:n, varidx)])
     idx = (allscalar && length(varidx) == 1) ? varidx[1] : n
     coef = Expr(:call, :*, [:(args[$i]) for i in setdiff(1:n,idx)]...)

--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -425,9 +425,9 @@ function parseExpr(x, aff::Symbol, lcoeffs::Vector, rcoeffs::Vector, newaff::Sym
                 push!(blk.args, :($newaff = destructive_add_with_reorder!($aff, $(Expr(:call,:*,lcoeffs...,newaff_,newaff_,rcoeffs...)))))
                 return newaff, blk
             elseif x.args[3] == 1
-                return parseExpr(:(QuadExpr($(x.args[2]))), aff, lcoeffs, rcoeffs)
+                return parseExpr(:(JuMP.GenericQuadExpr($(x.args[2]))), aff, lcoeffs, rcoeffs)
             elseif x.args[3] == 0
-                return parseExpr(:(QuadExpr(1)), aff, lcoeffs, rcoeffs)
+                return parseExpr(:(JuMP.GenericQuadExpr(one($(x.args[2])))), aff, lcoeffs, rcoeffs)
             else
                 blk = Expr(:block)
                 s = gensym()

--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -60,7 +60,7 @@ function destructive_add!(ex::Number, c::Number, x::T) where T<:GenericQuadExpr
     end
 end
 
-function destructive_add!(ex::Number, c::VariableRef, x::VariableRef)
+function destructive_add!(ex::Number, c::AbstractVariableRef, x::AbstractVariableRef)
     result = c*x
     result.aff.constant += ex
     result

--- a/src/print.jl
+++ b/src/print.jl
@@ -110,36 +110,33 @@ end
 #------------------------------------------------------------------------
 ## VariableRef
 #------------------------------------------------------------------------
-Base.show(io::IO, v::VariableRef) = print(io, var_str(REPLMode,v))
-Base.show(io::IO, ::MIME"text/latex", v::VariableRef) =
+Base.show(io::IO, v::AbstractVariableRef) = print(io, var_str(REPLMode,v))
+Base.show(io::IO, ::MIME"text/latex", v::AbstractVariableRef) =
     print(io, var_str(IJuliaMode,v,mathmode=false))
-function var_str(::Type{REPLMode}, v::VariableRef; mathmode=true)
-    name = MOI.get(v.m, MOI.VariableName(), v)
-    if name != ""
-        return name
+function var_str(::Type{REPLMode}, v::AbstractVariableRef; mathmode=true)
+    var_name = name(v)
+    if !isempty(var_name)
+        return var_name
     else
         return "noname"
     end
 end
-function var_str(::Type{IJuliaMode}, v::VariableRef; mathmode=true)
-    name = MOI.get(v.m, MOI.VariableName(), v)
-    if name != ""
+function var_str(::Type{IJuliaMode}, v::AbstractVariableRef; mathmode=true)
+    var_name = name(v)
+    if !isempty(var_name)
         # TODO: This is wrong if variable name constains extra "]"
-        return math(replace(replace(name,"[","_{",1),"]","}"), mathmode)
+        return math(replace(replace(var_name,"[","_{",1),"]","}"), mathmode)
     else
         return math("noname", mathmode)
     end
 end
 
 
-#------------------------------------------------------------------------
-## AffExpr  (not GenericAffExpr)
-#------------------------------------------------------------------------
-Base.show(io::IO, a::AffExpr) = print(io, aff_str(REPLMode,a))
-Base.show(io::IO, ::MIME"text/latex", a::AffExpr) =
+Base.show(io::IO, a::GenericAffExpr) = print(io, aff_str(REPLMode,a))
+Base.show(io::IO, ::MIME"text/latex", a::GenericAffExpr) =
     print(io, math(aff_str(IJuliaMode,a),false))
 # Generic string converter, called by mode-specific handlers
-function aff_str(mode, a::AffExpr, show_constant=true)
+function aff_str(mode, a::GenericAffExpr{C, V}, show_constant=true) where {C, V}
     # If the expression is empty, return the constant (or 0)
     if length(linearterms(a)) == 0
         return show_constant ? str_round(a.constant) : "0"

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -153,7 +153,7 @@ end
 
 # Alias for (Float64, VariableRef)
 const QuadExpr = GenericQuadExpr{Float64,VariableRef}
-function Base.convert(::Type{GenericQuadExpr{C, V}}, v::Union{Real,VariableRef,GenericAffExpr}) where {C, V}
+function Base.convert(::Type{GenericQuadExpr{C, V}}, v::Union{Real,GenericVariableRef,GenericAffExpr}) where {C, V}
     return GenericQuadExpr(convert(GenericAffExpr{C, V}, v))
 end
 GenericQuadExpr{C, V}() where {C, V} = zero(GenericQuadExpr{C, V})

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -218,8 +218,8 @@ end
 ##########################################################################
 # TODO: GenericQuadExprConstraint
 
-struct QuadExprConstraint{S <: MOI.AbstractScalarSet} <: AbstractConstraint
-    func::QuadExpr
+struct QuadExprConstraint{V <: AbstractVariableRef, S <: MOI.AbstractScalarSet} <: AbstractConstraint
+    func::GenericQuadExpr{Float64, V}
     set::S
 end
 

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -153,7 +153,7 @@ end
 
 # Alias for (Float64, VariableRef)
 const QuadExpr = GenericQuadExpr{Float64,VariableRef}
-function Base.convert(::Type{GenericQuadExpr{C, V}}, v::Union{Real,GenericVariableRef,GenericAffExpr}) where {C, V}
+function Base.convert(::Type{GenericQuadExpr{C, V}}, v::Union{Real,AbstractVariableRef,GenericAffExpr}) where {C, V}
     return GenericQuadExpr(convert(GenericAffExpr{C, V}, v))
 end
 GenericQuadExpr{C, V}() where {C, V} = zero(GenericQuadExpr{C, V})

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -6,7 +6,7 @@ struct PSDCone end
 # this allows to get the constraint reference, e.g.
 # @variable m x[1:2,1:2] Symmetric # x is Symmetric{VariableRef,Matrix{VariableRef}}
 # varpsd = @constraint m x in PSDCone()
-function buildconstraint(_error::Function, Q::Symmetric{<:AbstractVariableRef, Matrix{<:AbstractVariableRef}}, ::PSDCone)
+function buildconstraint(_error::Function, Q::Symmetric{V, Matrix{V}}, ::PSDCone) where V<:AbstractVariableRef
     n = Base.LinAlg.checksquare(Q)
     VectorOfVariablesConstraint([Q[i, j] for j in 1:n for i in 1:j], MOI.PositiveSemidefiniteConeTriangle(n))
 end

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -6,13 +6,13 @@ struct PSDCone end
 # this allows to get the constraint reference, e.g.
 # @variable m x[1:2,1:2] Symmetric # x is Symmetric{VariableRef,Matrix{VariableRef}}
 # varpsd = @constraint m x in PSDCone()
-function buildconstraint(_error::Function, Q::Symmetric{VariableRef,Matrix{VariableRef}}, ::PSDCone)
+function buildconstraint(_error::Function, Q::Symmetric{<:AbstractVariableRef, Matrix{<:AbstractVariableRef}}, ::PSDCone)
     n = Base.LinAlg.checksquare(Q)
     VectorOfVariablesConstraint([Q[i, j] for j in 1:n for i in 1:j], MOI.PositiveSemidefiniteConeTriangle(n))
 end
 # @variable m x[1:2,1:2] # x is Matrix{VariableRef}
 # varpsd = @constraint m x in PSDCone()
-function buildconstraint(_error::Function, Q::Matrix{VariableRef}, ::PSDCone)
+function buildconstraint(_error::Function, Q::Matrix{<:AbstractVariableRef}, ::PSDCone)
     n = Base.LinAlg.checksquare(Q)
     VectorOfVariablesConstraint(vec(Q), MOI.PositiveSemidefiniteConeSquare(n))
 end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -106,7 +106,7 @@ function VariableRef(m::Model)
 end
 
 # Name setter/getters
-# These functions need to be implemented by all `AbstractModel`s
+# These functions need to be implemented for all `AbstractVariableRef`s
 """
     name(v::VariableRef)::String
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -129,7 +129,7 @@ MOI.VectorOfVariables(vars::Vector{VariableRef}) = MOI.VectorOfVariables(index.(
 VariableRef(m::Model, f::MOI.SingleVariable) = VariableRef(m, f.variable)
 
 function setobjective(m::Model, sense::Symbol, x::VariableRef)
-    # TODO: This code is repeated here, for AffExpr, and for QuadExpr.
+    # TODO: This code is repeated here, for GenericAffExpr, and for GenericQuadExpr.
     if sense == :Min
         moisense = MOI.MinSense
     else
@@ -151,15 +151,15 @@ function objectivefunction(m::Model, ::Type{VariableRef})
     return VariableRef(m, f)
 end
 
-struct SingleVariableConstraint{S <: MOI.AbstractScalarSet} <: AbstractConstraint
-    func::VariableRef
+struct SingleVariableConstraint{V <: AbstractVariableRef, S <: MOI.AbstractScalarSet} <: AbstractConstraint
+    func::V
     set::S
 end
 
 moi_function_and_set(c::SingleVariableConstraint) = (MOI.SingleVariable(c.func), c.set)
 
-struct VectorOfVariablesConstraint{S <: MOI.AbstractVectorSet} <: AbstractConstraint
-    func::Vector{VariableRef}
+struct VectorOfVariablesConstraint{V <: AbstractVariableRef, S <: MOI.AbstractVectorSet} <: AbstractConstraint
+    func::Vector{V}
     set::S
 end
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -106,7 +106,7 @@ function VariableRef(m::Model)
 end
 
 # Name setter/getters
-
+# These functions need to be implemented by all `AbstractModel`s
 """
     name(v::VariableRef)::String
 

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -56,7 +56,7 @@ end
 # Names
 JuMP.name(vref::MyVariableRef) = vref.model.varnames[vref.idx]
 function JuMP.setname(vref::MyVariableRef, name::String)
-    cref.model.varnames[vref.idx] = name
+    vref.model.varnames[vref.idx] = name
 end
 JuMP.name(cref::MyConstraintRef) = cref.model.connames[cref.idx]
 function JuMP.setname(cref::MyConstraintRef, name::String)

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -34,6 +34,8 @@ struct MyVariableRef <: JuMP.AbstractVariableRef
     idx::Int       # Index in `model.variables`
 end
 Base.copy(v::MyVariableRef) = v
+Base.:(==)(v::MyVariableRef, w::MyVariableRef) = v.model === w.model && v.idx == w.idx
+JuMP.isequal_canonical(v::MyVariableRef, w::MyVariableRef) = v == w
 JuMP.variabletype(::MyModel) = MyVariableRef
 function JuMP.addvariable(m::MyModel, v::JuMP.AbstractVariable, name::String="")
     m.nextvaridx += 1

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -49,6 +49,10 @@ function MOI.delete!(m::MyModel, vref::MyVariableRef)
     delete!(m.varnames, vref.idx)
 end
 MOI.isvalid(m::MyModel, vref::MyVariableRef) = vref.idx in keys(m.variables)
+JuMP.startvalue(vref::MyVariableRef) = vref.model.variables[vref.idx].info.start
+function JuMP.setstartvalue(vref::MyVariableRef, start)
+    vref.model.variables[vref.idx].info.start = start
+end
 
 # Constraints
 struct MyConstraintRef

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -1,0 +1,66 @@
+module JuMPExtension
+# Simple example of JuMP extension used in the tests to check that JuMP works well with extensions
+# The main difference between `JuMP.Model` and `JuMPExtension.MyModel` is the fact that in `addvariable` (resp. `addconstraint`),
+# `JuMP.Model` applies the modification to its `moibackend` field while
+# `JuMPExtension.MyModel` stores the `AbstractVariable` (resp. `AbstractConstraint`) in a list.
+
+using JuMP
+
+mutable struct MyModel <: JuMP.AbstractModel
+    variables::Vector{JuMP.AbstractVariable}
+    varnames::Vector{String}
+    constraints::Vector{JuMP.AbstractConstraint}
+    connames::Vector{String}
+    objdict::Dict{Symbol, Any}
+    function MyModel()
+        new(JuMP.AbstractVariable[], String[],   # Variables
+            JuMP.AbstractConstraint[], String[], # Constraints
+            Dict{Symbol, Any}())
+    end
+end
+
+JuMP.object_dictionary(m::MyModel) = m.objdict
+
+# Variables
+struct MyVariableRef <: JuMP.AbstractVariableRef
+    model::MyModel # `model` owning the variable
+    idx::Int       # Index in `model.variables`
+end
+Base.copy(v::MyVariableRef) = v
+JuMP.variabletype(::MyModel) = MyVariableRef
+function JuMP.addvariable(m::MyModel, v::JuMP.AbstractVariable, name::String="")
+    push!(m.variables, v)
+    push!(m.varnames, name)
+    MyVariableRef(m, length(m.variables))
+end
+
+# Constraints
+struct MyConstraintRef
+    model::MyModel # `model` owning the constraint
+    idx::Int       # Index in `model.constraints`
+end
+function JuMP.addconstraint(m::MyModel, c::JuMP.AbstractConstraint, name::String="")
+    push!(m.constraints, c)
+    push!(m.connames, name)
+    MyConstraintRef(m, length(m.constraints))
+end
+function JuMP.constraintobject(cref::MyConstraintRef, F::Type, S::Type)
+    c = cref.model.constraints[cref.idx]
+    # `TypeError` should be thrown is `F` and `S` are not correct
+    # This is needed for the tests in `constraints.jl`
+    c.func::F
+    c.set::S
+    c
+end
+
+# Names
+JuMP.name(vref::MyVariableRef) = vref.model.varnames[vref.idx]
+function JuMP.setname(vref::MyVariableRef, name::String)
+    cref.model.varnames[vref.idx] = name
+end
+JuMP.name(cref::MyConstraintRef) = cref.model.connames[cref.idx]
+function JuMP.setname(cref::MyConstraintRef, name::String)
+    cref.model.connames[cref.idx] = name
+end
+
+end

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -15,10 +15,13 @@ mutable struct MyModel <: JuMP.AbstractModel
     nextconidx::Int                                 # Next constraint index is nextconidx+1
     constraints::Dict{Int, JuMP.AbstractConstraint} # Map conidx -> variable
     connames::Dict{Int, String}                     # Map varidx -> name
+    objectivesense::Symbol
+    objectivefunction::JuMP.AbstractJuMPScalar
     objdict::Dict{Symbol, Any}                      # Same that JuMP.Model's field `objdict`
     function MyModel()
         new(0, Dict{Int, JuMP.AbstractVariable}(),   Dict{Int, String}(), # Variables
             0, Dict{Int, JuMP.AbstractConstraint}(), Dict{Int, String}(), # Constraints
+            :Min, zero(JuMP.GenericAffExpr{Float64, MyVariableRef}),
             Dict{Symbol, Any}())
     end
 end
@@ -70,6 +73,12 @@ function JuMP.constraintobject(cref::MyConstraintRef, F::Type, S::Type)
     c.func::F
     c.set::S
     c
+end
+
+# Objective
+function JuMP.setobjective(m::MyModel, sense::Symbol, f::JuMP.AbstractJuMPScalar)
+    m.objectivesense = sense
+    m.objectivefunction = f
 end
 
 # Names

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -1,4 +1,8 @@
-@testset "Constraints" begin
+# The parameter names correspond to the JuMP types so that the test can serve as examples that can be copy pasted
+function constraints_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:JuMP.AbstractVariableRef})
+    AffExpr = JuMP.GenericAffExpr{Float64, VariableRef}
+    QuadExpr = JuMP.GenericQuadExpr{Float64, VariableRef}
+
     @testset "SingleVariable constraints" begin
         m = Model()
         @variable(m, x)
@@ -215,6 +219,13 @@
         @test_expression sum( 0*x[i,1] + y for i=1:3)
         @test_expression sum( 0*x[i,1] + y for i=1:3 for j in 1:3)
     end
+end
 
+@testset "Constraints for JuMP.Model" begin
+    constraints_test(Model, VariableRef)
+end
 
+include("JuMPExtension.jl")
+@testset "Constraints for JuMPExtension.MyModel" begin
+    constraints_test(JuMPExtension.MyModel, JuMPExtension.MyVariableRef)
 end

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -225,7 +225,6 @@ end
     constraints_test(Model, VariableRef)
 end
 
-include("JuMPExtension.jl")
 @testset "Constraints for JuMPExtension.MyModel" begin
     constraints_test(JuMPExtension.MyModel, JuMPExtension.MyVariableRef)
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -16,9 +16,9 @@ end
     @testset "buildconstraint on variable" begin
         m = Model()
         @variable(m, x)
-        @test JuMP.buildconstraint(error, x, MOI.GreaterThan(0.0)) isa JuMP.SingleVariableConstraint{MOI.GreaterThan{Float64}}
-        @test JuMP.buildconstraint(error, x, MOI.LessThan(0.0)) isa JuMP.SingleVariableConstraint{MOI.LessThan{Float64}}
-        @test JuMP.buildconstraint(error, x, MOI.EqualTo(0)) isa JuMP.SingleVariableConstraint{MOI.EqualTo{Int}}
+        @test JuMP.buildconstraint(error, x, MOI.GreaterThan(0.0)) isa JuMP.SingleVariableConstraint{VariableRef, MOI.GreaterThan{Float64}}
+        @test JuMP.buildconstraint(error, x, MOI.LessThan(0.0)) isa JuMP.SingleVariableConstraint{VariableRef, MOI.LessThan{Float64}}
+        @test JuMP.buildconstraint(error, x, MOI.EqualTo(0)) isa JuMP.SingleVariableConstraint{VariableRef, MOI.EqualTo{Int}}
     end
 
     @testset "Extension of @variable with buildvariable #1029" begin

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -21,7 +21,10 @@ Base.transpose(t::MySumType) = MySumType(t.a)
 *(t1::S, t2::MyType{T}) where {S, T} = MyType(t1*t2.a)
 *(t1::MyType{S}, t2::MyType{T}) where {S, T} = MyType(t1.a*t2.a)
 
-@testset "Operator" begin
+function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:JuMP.AbstractVariableRef})
+    AffExpr = JuMP.GenericAffExpr{Float64, VariableRef}
+    QuadExpr = JuMP.GenericQuadExpr{Float64, VariableRef}
+
     @testset "Promotion" begin
         m = Model()
         I = Int
@@ -643,4 +646,12 @@ Base.transpose(t::MySumType) = MySumType(t.a)
             @test z[i].a == y[i].a == a
         end
     end
+end
+
+@testset "Operators for JuMP.Model" begin
+    operators_test(Model, VariableRef)
+end
+
+@testset "Operators for JuMPExtension.MyModel" begin
+    operators_test(JuMPExtension.MyModel, JuMPExtension.MyVariableRef)
 end

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -21,16 +21,16 @@ Base.transpose(t::MySumType) = MySumType(t.a)
 *(t1::S, t2::MyType{T}) where {S, T} = MyType(t1*t2.a)
 *(t1::MyType{S}, t2::MyType{T}) where {S, T} = MyType(t1.a*t2.a)
 
-function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:JuMP.AbstractVariableRef})
-    AffExpr = JuMP.GenericAffExpr{Float64, VariableRef}
-    QuadExpr = JuMP.GenericQuadExpr{Float64, VariableRef}
+function operators_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::Type{<:JuMP.AbstractVariableRef})
+    AffExprType = JuMP.GenericAffExpr{Float64, VariableRefType}
+    QuadExprType = JuMP.GenericQuadExpr{Float64, VariableRefType}
 
     @testset "Promotion" begin
-        m = Model()
+        m = ModelType()
         I = Int
-        V = VariableRef
-        A = AffExpr
-        Q = QuadExpr
+        V = VariableRefType
+        A = AffExprType
+        Q = QuadExprType
         @test promote_type(V, I) == A
         @test promote_type(I, V) == A
         @test promote_type(A, I) == A
@@ -48,7 +48,7 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
     end
 
     @testset "Basic operator overloads" begin
-        m = Model()
+        m = ModelType()
         @variable(m, w)
         @variable(m, x)
         @variable(m, y)
@@ -238,9 +238,9 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
     end
 
     @testset "Higher-level operators" begin
-        m = Model()
+        m = ModelType()
         @testset "sum" begin
-            sum_m = Model()
+            sum_m = ModelType()
             @variable(sum_m, 0 ≤ matrix[1:3,1:3] ≤ 1, start = 1)
             @testset "sum(j::JuMPArray{Variable})" begin
                 @test_expression_with_string sum(matrix) "matrix[1,1] + matrix[2,1] + matrix[3,1] + matrix[1,2] + matrix[2,2] + matrix[3,2] + matrix[1,3] + matrix[2,3] + matrix[3,3]"
@@ -270,7 +270,7 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
         end
 
         @testset "dot" begin
-            dot_m = Model()
+            dot_m = ModelType()
             @variable(dot_m, 0 ≤ x[1:3] ≤ 1)
 
             @test_expression_with_string dot(x[1],x[1]) "x[1]²"
@@ -306,7 +306,7 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
             @test vecdot(B, JuMP.startvalue.(z)) ≈ 8
 
             @testset "JuMP issue #656" begin
-                issue656 = Model()
+                issue656 = ModelType()
                 @variable(issue656, x)
                 floats = Float64[i for i in 1:2]
                 anys   = Array{Any}(undef, 2)
@@ -316,7 +316,7 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
             end
 
             @testset "JuMP PR #943" begin
-                pull943 = Model()
+                pull943 = ModelType()
                 @variable(pull943, x[1 : 10^6]);
                 JuMP.setstartvalue.(x, 1 : 10^6)
                 @expression(pull943, testsum, sum(x[i] * i for i = 1 : 10^6))
@@ -330,7 +330,7 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
 
     @testset "Vectorized operations" begin
         @testset "Transpose" begin
-            m = Model()
+            m = ModelType()
             @variable(m, x[1:3])
             @variable(m, y[1:2,1:3])
             @variable(m, z[2:5])
@@ -348,7 +348,7 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
         end
 
         @testset "Vectorized arithmetic" begin
-            m = Model()
+            m = ModelType()
             @variable(m, x[1:3])
             A = [2 1 0
                  1 2 1
@@ -468,7 +468,7 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
         end
 
         @testset "Dot-ops" begin
-            m = Model()
+            m = ModelType()
             @variable(m, x[1:2,1:2])
             A = [1 2;
                  3 4]
@@ -489,7 +489,7 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
                                 3-x[2,1]  4-x[2,2]])
             @test JuMP.isequal_canonical(A.-x, B.-x)
             @test JuMP.isequal_canonical(A.-x, A.-y)
-            @test JuMP.isequal_canonical(x .- x, [zero(AffExpr) for _1 in 1:2, _2 in 1:2])
+            @test JuMP.isequal_canonical(x .- x, [zero(AffExprType) for _1 in 1:2, _2 in 1:2])
             @test JuMP.isequal_canonical(A.-y, B.-y)
             @test JuMP.isequal_canonical(x.-A, [-1+x[1,1]  -2+x[1,2];
                                 -3+x[2,1]  -4+x[2,2]])
@@ -524,7 +524,7 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
         end
 
         @testset "Vectorized comparisons" begin
-            m = Model()
+            m = ModelType()
             @variable(m, x[1:3])
             A = [1 2 3
                  0 4 5
@@ -532,13 +532,13 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
             B = sparse(A)
             # force vector output
             cref1 = @constraint(m, reshape(x,(1,3))*A*x .>= 1)
-            c1 = JuMP.constraintobject.(cref1, QuadExpr, MOI.GreaterThan)
+            c1 = JuMP.constraintobject.(cref1, QuadExprType, MOI.GreaterThan)
             f1 = map(c -> c.func, c1)
             @test JuMP.isequal_canonical(f1, [x[1]*x[1] + 2x[1]*x[2] + 4x[2]*x[2] + 9x[1]*x[3] + 5x[2]*x[3] + 7x[3]*x[3]])
             @test all(c -> c.set.lower == 1, c1)
 
             cref2 = @constraint(m, x'*A*x >= 1)
-            c2 = JuMP.constraintobject.(cref2, QuadExpr, MOI.GreaterThan)
+            c2 = JuMP.constraintobject.(cref2, QuadExprType, MOI.GreaterThan)
             @test JuMP.isequal_canonical(f1[1], c2.func)
 
             mat = [ 3x[1] + 12x[3] +  4x[2]
@@ -546,7 +546,7 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
                    15x[1] +  5x[2] + 21x[3]]
 
             cref3 = @constraint(m, (x'A)' + 2A*x .<= 1)
-            c3 = JuMP.constraintobject.(cref3, AffExpr, MOI.LessThan)
+            c3 = JuMP.constraintobject.(cref3, AffExprType, MOI.LessThan)
             f3 = map(c->c.func, c3)
             @test JuMP.isequal_canonical(f3, mat)
             @test all(c -> c.set.upper == 1, c3)
@@ -559,28 +559,28 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
             @test JuMP.isequal_canonical((x'A)' + 2A*x, @JuMP.Expression((x'B)' + 2B*x))
 
             cref4 = @constraint(m, -1 .<= (x'A)' + 2A*x .<= 1)
-            c4 = JuMP.constraintobject.(cref4, AffExpr, MOI.Interval)
+            c4 = JuMP.constraintobject.(cref4, AffExprType, MOI.Interval)
             f4 = map(c->c.func, c4)
             @test JuMP.isequal_canonical(f4, mat)
             @test all(c -> c.set.lower == -1, c4)
             @test all(c -> c.set.upper == 1, c4)
 
             cref5 = @constraint(m, -[1:3;] .<= (x'A)' + 2A*x .<= 1)
-            c5 = JuMP.constraintobject.(cref5, AffExpr, MOI.Interval)
+            c5 = JuMP.constraintobject.(cref5, AffExprType, MOI.Interval)
             f5 = map(c->c.func, c5)
             @test JuMP.isequal_canonical(f5, mat)
             @test map(c -> c.set.lower, c5) == -[1:3;]
             @test all(c -> c.set.upper == 1, c4)
 
             cref6 = @constraint(m, -[1:3;] .<= (x'A)' + 2A*x .<= [3:-1:1;])
-            c6 = JuMP.constraintobject.(cref6, AffExpr, MOI.Interval)
+            c6 = JuMP.constraintobject.(cref6, AffExprType, MOI.Interval)
             f6 = map(c->c.func, c6)
             @test JuMP.isequal_canonical(f6, mat)
             @test map(c -> c.set.lower, c6) == -[1:3;]
             @test map(c -> c.set.upper, c6) == [3:-1:1;]
 
             cref7 = @constraint(m, -[1:3;] .<= (x'A)' + 2A*x .<= 3)
-            c7 = JuMP.constraintobject.(cref7, AffExpr, MOI.Interval)
+            c7 = JuMP.constraintobject.(cref7, AffExprType, MOI.Interval)
             f7 = map(c->c.func, c7)
             @test JuMP.isequal_canonical(f7, mat)
             @test map(c -> c.set.lower, c7) == -[1:3;]
@@ -589,7 +589,7 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
     end
 
     @testset "Operators for non-Array AbstractArrays" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x[1:3])
 
         # This is needed to compare arrays that have nonstandard indexing
@@ -612,7 +612,7 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
     end
 
     @testset "diagm for non-Array AbstractArrays" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x[1:3])
 
         for x2 in (OffsetArray(x, -length(x)), view(x, :), sparse(x))
@@ -625,20 +625,20 @@ function operators_test(Model::Type{<:JuMP.AbstractModel}, VariableRef::Type{<:J
     end
 
     @testset "DimensionMismatch when performing vector-matrix multiplication with custom types #988" begin
-        m = Model()
+        m = ModelType()
         @variable m Q[1:3, 1:3] PSD
 
         x = [MyType(1), MyType(2), MyType(3)]
         y = Q * x
         z = x' * Q
-        ElemT = MySumType{AffExpr}
+        ElemT = MySumType{AffExprType}
         @test y isa Vector{ElemT}
         @test size(y) == (3,)
         @test z isa RowVector{ElemT, ConjArray{ElemT, 1, Vector{ElemT}}}
         @test size(z) == (1, 3)
         for i in 1:3
             # Q is symmetric
-            a = zero(AffExpr)
+            a = zero(AffExprType)
             a += Q[1,i]
             a += 2Q[2,i]
             a += 3Q[3,i]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,8 @@ macro test_macro_throws(errortype, m)
     :(@test_throws $errortype try @eval $m catch err; throw(err.error) end)
 end
 
+include("JuMPExtension.jl")
+
 include("derivatives.jl")
 include("derivatives_coloring.jl")
 


### PR DESCRIPTION
<s>There a still a few tests failing which is why there is WIP in the title.</s>
This PR adds a `JuMPExtension` module showing an example of JuMP extension (@joehuchette this is close this the new design that StructJuMP could have).
It uses the `constraints` tests to test that the JuMPExtension works.
A few fixes are scattered thoughout the code to make the extension possible.