### PR TITLE
Helpful error for variable declaration with misplaced constant

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -965,6 +965,7 @@ macro variable(args...)
         if x.args[1] == :>= || x.args[1] == :≥
             # x >= lb
             var = x.args[2]
+            var isa Number && _error("Variable declaration of the form `ub $(x.args[1]) x` is not supported. Use `$(x.args[3]) <= $var` instead.")
             @assert length(x.args) == 3
             lb = esc_nonconstant(x.args[3])
             haslb = true
@@ -972,8 +973,7 @@ macro variable(args...)
         elseif x.args[1] == :<= || x.args[1] == :≤
             # x <= ub
             var = x.args[2]
-            # NB: May also be lb <= x, which we do not support
-            #     We handle this later in the macro
+            var isa Number && _error("Variable declaration of the form `lb $(x.args[1]) x` is not supported. Use `$(x.args[3]) >= $var` instead.")
             @assert length(x.args) == 3
             ub = esc_nonconstant(x.args[3])
             hasub = true

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -965,7 +965,7 @@ macro variable(args...)
         if x.args[1] == :>= || x.args[1] == :≥
             # x >= lb
             var = x.args[2]
-            var isa Number && _error("Variable declaration of the form `ub $(x.args[1]) x` is not supported. Use `$(x.args[3]) <= $var` instead.")
+            var isa Number && _error("Variable declaration of the form `$(x.args[3]) $(x.args[1]) $var` is not supported. Use `$(x.args[3]) <= $var` instead.")
             @assert length(x.args) == 3
             lb = esc_nonconstant(x.args[3])
             haslb = true
@@ -973,7 +973,7 @@ macro variable(args...)
         elseif x.args[1] == :<= || x.args[1] == :≤
             # x <= ub
             var = x.args[2]
-            var isa Number && _error("Variable declaration of the form `lb $(x.args[1]) x` is not supported. Use `$(x.args[3]) >= $var` instead.")
+            var isa Number && _error("Variable declaration of the form `$(x.args[3]) $(x.args[1]) $var` is not supported. Use `$(x.args[3]) >= $var` instead.")
             @assert length(x.args) == 3
             ub = esc_nonconstant(x.args[3])
             hasub = true

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -128,4 +128,10 @@ end
         @test JuMP.isequal_canonical(c.func, zero(AffExpr))
         @test c.set == MOI.LessThan(-38.0)
     end
+
+    @testset "Helpful error for variable declaration with misplaced constant" begin
+        m = Model()
+        @test_macro_throws ErrorException @variable m 0 <= x
+        @test_macro_throws ErrorException @variable m 0 >= x
+    end
 end


### PR DESCRIPTION
On both v0.18.1 and master, when the user write `@variable(m, 0 <= x)`, he get the MethodError since `getname(::Int)` is not defined at this line:
https://github.com/JuliaOpt/JuMP.jl/blob/a59a431419f885a0e11c2838b50bea0e63061647/src/macros.jl#L996
which is not helpful at all.
With this PR, there is now an helpful error message.
```julia
ulia> @variable m 0 <= x
ERROR: In @variable(m,0 <= x): Variable declaration of the form lb <= x is not supported. Use x >= 0 instead.
Stacktrace:
 [1] macro expansion at ./REPL.jl:97 [inlined]
 [2] (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:73

julia> @variable m 0 >= x
ERROR: In @variable(m,0 >= x): Variable declaration of the form ub >= x is not supported. Use x <= 0 instead.
Stacktrace:
 [1] macro expansion at ./REPL.jl:97 [inlined]
 [2] (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:73
```

Note that we still cannot help the user for
```julia
lb = 0
@variable m lb <= x
```
where the user get
```
ERROR: UndefVarError: x not defined
Stacktrace:
 [1] macro expansion at ./REPL.jl:97 [inlined]
 [2] (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:73
```
but that would be difficult since from the macro's viewpoint, `lb` and `x` are just two `Symbol`s.

The `NB` comment was mentionning that the syntax was not supporting but was being dealt with later but apparently it's not the case. There may have been an error message but both on v0.18.1 and on master, we now get the `getname` MethodError. At least now there are tests for the error which should prevent such things from happening :)

Thanks to @alegat for raising the issue !