### PR TITLE
Fix operator_warn

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -465,7 +465,7 @@ end
 function operator_warn(lhs::GenericAffExpr,rhs::GenericAffExpr)
     if length(linearterms(lhs)) > 50 || length(linearterms(rhs)) > 50
         if length(linearterms(lhs)) > 1
-            m = first(linearterms(lhs))[1].m
+            m = first(linearterms(lhs))[2].m
             m.operator_counter += 1
             if m.operator_counter > 20000
                 Base.warn_once("The addition operator has been used on JuMP expressions a large number of times. This warning is safe to ignore but may indicate that model generation is slower than necessary. For performance reasons, you should not add expressions in a loop. Instead of x += y, use append!(x,y) to modify x in place. If y is a single variable, you may also use push!(x, coef, y) in place of x += coef*y.")

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -643,4 +643,14 @@ Base.transpose(t::MySumType) = MySumType(t.a)
             @test z[i].a == y[i].a == a
         end
     end
+
+    @testset "operator_warn" begin
+        m = Model()
+        @variable m x[1:51]
+        @test m.operator_counter == 0
+        # Triggers the increment of operator_counter since sum(x) has more than 50 terms
+        @test_expression(sum(x) + 2x[1])
+        # The following check verifies that this test covers the code incrementing `operator_counter`
+        @test m.operator_counter == 1
+    end
 end


### PR DESCRIPTION
A bug was introduced in `operator_warn` in https://github.com/JuliaOpt/JuMP.jl/pull/1301 which shows the importance of code coverage.
I have added a test that covers this part of the code and a check that it is actually covers in addition to the trivial bug fix.