### PR TITLE
Share code between constraint and SDconstraint

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -519,9 +519,9 @@ end
 function parseSDconstraint(_error::Function, sense::Symbol, lhs, rhs)
     # Simple comparison - move everything to the LHS
     aff = :()
-    if sense == :⪰ || sense == :(≥)
+    if sense == :⪰ || sense == :(≥) || sense == :(>=)
         aff = :($lhs - $rhs)
-    elseif sense == :⪯ || sense == :(≤)
+    elseif sense == :⪯ || sense == :(≤) || sense == :(<=)
         aff = :($rhs - $lhs)
     else
         _error("Invalid sense $sense in SDP constraint")

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -478,7 +478,7 @@ Add a group of constraints described by the expression `expr` parametrized by
 The expression `expr` can either be
 
 * of the form `func in set` constraining the function `func` to belong to the
-  set `set`, e.g. `@constraint(m, [1, x-1, y-2] in MOI.SecondOrderCone)`
+  set `set`, e.g. `@constraint(m, [1, x-1, y-2] in MOI.SecondOrderCone(3))`
   constrains the norm of `[x-1, y-2]` be less than 1;
 * of the form `a sign b`, where `sign` is one of `==`, `≥`, `>=`, `≤` and
   `<=` building the single constraint enforcing the comparison to hold for the

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -379,14 +379,16 @@ end
 """
     constraint_macro(args, macro_name::Symbol, parsefun::Function)
 
-Returns the code for the macro `@macro_name args...` of syntax
+Returns the code for the macro `@constraint_like args...` of syntax
 ```julia
-@macro_name con     # Single constraint
-@macro_name ref con # group of constraints
+@constraint_like con     # Single constraint
+@constraint_like ref con # group of constraints
 ```
-The expression `con` is parsed by `parsefun` which returns a code for building call.
-The building call is passed to `addconstraint` with the macro keyword arguments
-(except the `container` keyword argument which is used to determine the container type).
+where `@constraint_like` is either `@constraint` or `@SDconstraint`.
+The expression `con` is parsed by `parsefun` which returns a code that, when
+executed, returns an `AbstractConstraint`. This `AbstractConstraint` is passed
+to `addconstraint` with the macro keyword arguments (except the `container`
+keyword argument which is used to determine the container type).
 """
 function constraint_macro(args, macro_name::Symbol, parsefun::Function)
     _error(str) = macro_error(macro_name, args, str)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -355,7 +355,7 @@ end
 #     end
 # end
 
-# TODO replace these with buildconstraint(_error, fun, ::Interval) for more consistency, quad expres in Interval should now be supported with MOI anyway
+# TODO replace these with buildconstraint(_error, fun, ::Interval) for more consistency, quad exprs in Interval should now be supported with MOI anyway
 # three-argument buildconstraint is used for two-sided constraints.
 buildconstraint(_error::Function, v::AbstractVariableRef, lb::Real, ub::Real) = SingleVariableConstraint(v, MOI.Interval(lb, ub))
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -429,7 +429,7 @@ function constraint_macro(args, macro_name::Symbol, parsefun::Function)
     (x.head == :block) &&
         _error("Code block passed as constraint. Perhaps you meant to use @constraints instead?")
 
-    # Strategy: build up the code for non-macro addconstraint, and if needed
+    # Strategy: build up the code for addconstraint, and if needed
     # we will wrap in loops to assign to the ConstraintRefs
     refcall, idxvars, idxsets, condition = buildrefsets(c, variable)
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -377,7 +377,7 @@ end
 # TODO: update 3-argument @constraint macro to pass through names like @variable
 
 """
-    constraintlike(args, macro_name::Symbol, parsefun::Function)
+    constraint_macro(args, macro_name::Symbol, parsefun::Function)
 
 Returns the code for the macro `@macro_name args...` of syntax
 ```julia
@@ -388,7 +388,7 @@ The expression `con` is parsed by `parsefun` which returns a code for building c
 The building call is passed to `addconstraint` with the macro keyword arguments
 (except the `container` keyword argument which is used to determine the container type).
 """
-function constraintlike(args, macro_name::Symbol, parsefun::Function)
+function constraint_macro(args, macro_name::Symbol, parsefun::Function)
     _error(str) = macro_error(macro_name, args, str)
 
     args, kwargs, requestedcontainer = extract_kwargs(args)
@@ -480,7 +480,7 @@ macro constraint(args...)
     # will likely mean that bar will be some custom type, rather than e.g. a
     # Symbol, since we will likely want to dispatch on the type of the set
     # appearing in the constraint.
-    constraintlike(args, :constraint, parseconstraint)
+    constraint_macro(args, :constraint, parseconstraint)
 end
 
 function parseSDconstraint(_error::Function, sense::Symbol, lhs, rhs)
@@ -510,7 +510,7 @@ end
 Adds a semidefinite constraint to the `Model m`. The expression `x` must be a square, two-dimensional array.
 """
 macro SDconstraint(args...)
-    constraintlike(args, :SDconstraint, parseSDconstraint)
+    constraint_macro(args, :SDconstraint, parseSDconstraint)
 end
 
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -538,9 +538,19 @@ function parseSDconstraint(_error::Function, args...)
 end
 
 """
-    @SDconstraint(m, x)
+    @SDconstraint(m::Model, expr)
 
-Adds a semidefinite constraint to the `Model m`. The expression `x` must be a square, two-dimensional array.
+Add a semidefinite constraint described by the expression `expr`.
+
+    @SDconstraint(m::Model, ref[i=..., j=..., ...], expr)
+
+Add a group of semidefinite constraints described by the expression `expr`
+parametrized by `i`, `j`, ...
+
+The expression `expr` needs to be of the form `a sign b` where `sign` is `⪰`,
+`≥`, `>=`, `⪯`, `≤` or `<=` and `a` and `b` are `square` matrices. It
+constrains that `a - b` (or `b - a` if the sign is `⪯`, `≤` or `<=`) is
+positive semidefinite.
 """
 macro SDconstraint(args...)
     constraint_macro(args, :SDconstraint, parseSDconstraint)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -408,8 +408,8 @@ function constraint_macro(args, macro_name::Symbol, parsefun::Function)
 
     m = esc(m)
     # Two formats:
-    # - @constraint(m, a*x <= 5)
-    # - @constraint(m, myref[a=1:5], a*x <= 5)
+    # - @constraint_like(m, a*x <= 5)
+    # - @constraint_like(m, myref[a=1:5], a*x <= 5)
     length(extra) > 1 && _error("Too many arguments.")
     # Canonicalize the arguments
     c = length(extra) == 1 ? x        : gensym()


### PR DESCRIPTION
This PR creates a `constraintlike` function (I am open to a change in the name) that contains basically all the code for the `@constraint` macro that can be shared with `@SDconstraint` (i.e. all of it except the parse function).
With this change, the `@constraint` and `@SDconstraint` macros contains a single line calling `constraintlike`.

This therefore adds all the features of `@constraint` that were missing for `@SDconstraint` (e.g. constraint name, group of constraints, support for passing keyword arguments (hence fixing #1189)).

Closes https://github.com/JuliaOpt/JuMP.jl/issues/1189