### PR TITLE
Refactor @variable to have a common return

### DIFF
--- a/test/variable.jl
+++ b/test/variable.jl
@@ -328,4 +328,16 @@ end
     #     @test typeof(Y) == SparseMatrixCSC{Float64, Int}
     #     @test Y == sparse([1, 3], [2, 3], [1, 2])
     # end
+
+    @testset "Symmetric variable" begin
+        m = Model()
+
+        @variable m x[1:2, 1:2] Symmetric
+        @test x isa Symmetric
+        @test x[1, 2] === x[2, 1]
+
+        y = @variable m [1:2, 1:2] Symmetric
+        @test y isa Symmetric
+        @test y[1, 2] === y[2, 1]
+    end
 end


### PR DESCRIPTION
This slightly refactor the `@variable` macro so that all three branches have the same `return` statement instead of three different ones. The distinctions between their returned code can be factored out into `loopedcode` and `finalvariable`.
This makes it clearer what are the distinctions between the branches and gets us closed to having a `parsevariable` function.