### PR TITLE
Create VariableInfo with keywords

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1008,15 +1008,15 @@ macro variable(args...)
             # ub >= x >= lb
             x.args[4] == :>= || x.args[4] == :≥ || _error("Invalid variable bounds")
             var = x.args[3]
-            setlowerbound(infoexpr, esc_nonconstant(x.args[5]), _error)
-            setupperbound(infoexpr, esc_nonconstant(x.args[1]), _error)
+            setlowerbound_or_error(infoexpr, esc_nonconstant(x.args[5]), _error)
+            setupperbound_or_error(infoexpr, esc_nonconstant(x.args[1]), _error)
         elseif x.args[2] == :<= || x.args[2] == :≤
             # lb <= x <= u
             var = x.args[3]
             (x.args[4] != :<= && x.args[4] != :≤) &&
                 _error("Expected <= operator after variable name.")
-            setlowerbound(infoexpr, esc_nonconstant(x.args[1]), _error)
-            setupperbound(infoexpr, esc_nonconstant(x.args[5]), _error)
+            setlowerbound_or_error(infoexpr, esc_nonconstant(x.args[1]), _error)
+            setupperbound_or_error(infoexpr, esc_nonconstant(x.args[5]), _error)
         else
             _error("Use the form lb <= ... <= ub.")
         end
@@ -1027,18 +1027,18 @@ macro variable(args...)
             var = x.args[2]
             var isa Number && _error("Variable declaration of the form `$(x.args[3]) $(x.args[1]) $var` is not supported. Use `$(x.args[3]) <= $var` instead.")
             @assert length(x.args) == 3
-            setlowerbound(infoexpr, esc_nonconstant(x.args[3]), _error)
+            setlowerbound_or_error(infoexpr, esc_nonconstant(x.args[3]), _error)
         elseif x.args[1] == :<= || x.args[1] == :≤
             # x <= ub
             var = x.args[2]
             var isa Number && _error("Variable declaration of the form `$(x.args[3]) $(x.args[1]) $var` is not supported. Use `$(x.args[3]) >= $var` instead.")
             @assert length(x.args) == 3
-            setupperbound(infoexpr, esc_nonconstant(x.args[3]), _error)
+            setupperbound_or_error(infoexpr, esc_nonconstant(x.args[3]), _error)
         elseif x.args[1] == :(==)
             # fixed variable
             var = x.args[2]
             @assert length(x.args) == 3
-            fix(infoexpr, esc(x.args[3]), _error)
+            fix_or_error(infoexpr, esc(x.args[3]), _error)
         else
             # Its a comparsion, but not using <= ... <=
             _error("Unexpected syntax $(string(x)).")
@@ -1069,9 +1069,9 @@ macro variable(args...)
     extra = filter(x -> (x != :PSD && x != :Symmetric), extra) # filter out PSD and sym tag
     for ex in extra
         if ex == :Int
-            setinteger(infoexpr, _error)
+            setinteger_or_error(infoexpr, _error)
         elseif ex == :Bin
-            setbinary(infoexpr, _error)
+            setbinary_or_error(infoexpr, _error)
         end
     end
     extra = esc.(filter(ex -> !(ex in [:Int,:Bin]), extra))

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1008,15 +1008,15 @@ macro variable(args...)
             # ub >= x >= lb
             x.args[4] == :>= || x.args[4] == :≥ || _error("Invalid variable bounds")
             var = x.args[3]
-            setlowerbound_or_error(infoexpr, esc_nonconstant(x.args[5]), _error)
-            setupperbound_or_error(infoexpr, esc_nonconstant(x.args[1]), _error)
+            setlowerbound_or_error(_error, infoexpr, esc_nonconstant(x.args[5]))
+            setupperbound_or_error(_error, infoexpr, esc_nonconstant(x.args[1]))
         elseif x.args[2] == :<= || x.args[2] == :≤
             # lb <= x <= u
             var = x.args[3]
             (x.args[4] != :<= && x.args[4] != :≤) &&
                 _error("Expected <= operator after variable name.")
-            setlowerbound_or_error(infoexpr, esc_nonconstant(x.args[1]), _error)
-            setupperbound_or_error(infoexpr, esc_nonconstant(x.args[5]), _error)
+            setlowerbound_or_error(_error, infoexpr, esc_nonconstant(x.args[1]))
+            setupperbound_or_error(_error, infoexpr, esc_nonconstant(x.args[5]))
         else
             _error("Use the form lb <= ... <= ub.")
         end
@@ -1027,18 +1027,18 @@ macro variable(args...)
             var = x.args[2]
             var isa Number && _error("Variable declaration of the form `$(x.args[3]) $(x.args[1]) $var` is not supported. Use `$(x.args[3]) <= $var` instead.")
             @assert length(x.args) == 3
-            setlowerbound_or_error(infoexpr, esc_nonconstant(x.args[3]), _error)
+            setlowerbound_or_error(_error, infoexpr, esc_nonconstant(x.args[3]))
         elseif x.args[1] == :<= || x.args[1] == :≤
             # x <= ub
             var = x.args[2]
             var isa Number && _error("Variable declaration of the form `$(x.args[3]) $(x.args[1]) $var` is not supported. Use `$(x.args[3]) >= $var` instead.")
             @assert length(x.args) == 3
-            setupperbound_or_error(infoexpr, esc_nonconstant(x.args[3]), _error)
+            setupperbound_or_error(_error, infoexpr, esc_nonconstant(x.args[3]))
         elseif x.args[1] == :(==)
             # fixed variable
             var = x.args[2]
             @assert length(x.args) == 3
-            fix_or_error(infoexpr, esc(x.args[3]), _error)
+            fix_or_error(_error, infoexpr, esc(x.args[3]))
         else
             # Its a comparsion, but not using <= ... <=
             _error("Unexpected syntax $(string(x)).")
@@ -1069,9 +1069,9 @@ macro variable(args...)
     extra = filter(x -> (x != :PSD && x != :Symmetric), extra) # filter out PSD and sym tag
     for ex in extra
         if ex == :Int
-            setinteger_or_error(infoexpr, _error)
+            setinteger_or_error(_error, infoexpr)
         elseif ex == :Bin
-            setbinary_or_error(infoexpr, _error)
+            setbinary_or_error(_error, infoexpr)
         end
     end
     extra = esc.(filter(ex -> !(ex in [:Int,:Bin]), extra))

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1028,18 +1028,12 @@ macro variable(args...)
             var isa Number && _error("Variable declaration of the form `$(x.args[3]) $(x.args[1]) $var` is not supported. Use `$(x.args[3]) <= $var` instead.")
             @assert length(x.args) == 3
             setlowerbound(infoexpr, esc_nonconstant(x.args[3]), _error)
-            if !infoexpr.hasub
-                infoexpr.upperbound = Inf # Change NaN -> Inf which has same type
-            end
         elseif x.args[1] == :<= || x.args[1] == :≤
             # x <= ub
             var = x.args[2]
             var isa Number && _error("Variable declaration of the form `$(x.args[3]) $(x.args[1]) $var` is not supported. Use `$(x.args[3]) >= $var` instead.")
             @assert length(x.args) == 3
             setupperbound(infoexpr, esc_nonconstant(x.args[3]), _error)
-            if !infoexpr.haslb
-                infoexpr.lowerbound = -Inf # Change NaN -> -Inf which has same type
-            end
         elseif x.args[1] == :(==)
             # fixed variable
             var = x.args[2]

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1082,7 +1082,7 @@ macro variable(args...)
     end
     extra = esc.(filter(ex -> !(ex in [:Int,:Bin]), extra))
 
-    info = evalcode(infoexpr)
+    info = constructor_expr(infoexpr)
     if isa(var,Symbol)
         # Easy case - a single variable
         sdp && _error("Cannot add a semidefinite scalar variable")

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -52,6 +52,7 @@ function keywordify(kw::Expr)
     (kw.args[1], esc_nonconstant(kw.args[2]))
 end
 function VariableInfoExpr(; lowerbound=NaN, upperbound=NaN, start=NaN, binary=false, integer=false)
+    # isnan(::Expr) is not defined so we need to do !== NaN
     VariableInfoExpr(lowerbound !== NaN, lowerbound, upperbound !== NaN, upperbound, false, NaN, start !== NaN, start, binary, integer)
 end
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -69,7 +69,7 @@ mutable struct VariableInfo{S, T, U, V}
     integer::Bool
 end
 
-evalcode(info::VariableInfoExpr) = :(VariableInfo($(info.haslb), $(info.lowerbound), $(info.hasub), $(info.upperbound), $(info.hasfix), $(info.fixedvalue), $(info.hasstart), $(info.start), $(info.binary), $(info.integer)))
+constructor_expr(info::VariableInfoExpr) = :(VariableInfo($(info.haslb), $(info.lowerbound), $(info.hasub), $(info.upperbound), $(info.hasfix), $(info.fixedvalue), $(info.hasstart), $(info.start), $(info.binary), $(info.integer)))
 
 struct ScalarVariable{S, T, U, V} <: AbstractVariable
     info::VariableInfo{S, T, U, V}

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -19,26 +19,26 @@ mutable struct VariableInfoExpr
     integer::Any
 end
 
-function setlowerbound_or_error(info::VariableInfoExpr, lower, _error::Function)
+function setlowerbound_or_error(_error::Function, info::VariableInfoExpr, lower)
     info.haslb && _error("Cannot specify variable lowerbound twice")
     info.haslb = true
     info.lowerbound = lower
 end
-function setupperbound_or_error(info::VariableInfoExpr, upper, _error::Function)
+function setupperbound_or_error(_error::Function, info::VariableInfoExpr, upper)
     info.hasub && _error("Cannot specify variable lowerbound twice")
     info.hasub = true
     info.upperbound = upper
 end
-function fix_or_error(info::VariableInfoExpr, value, _error::Function)
+function fix_or_error(_error::Function, info::VariableInfoExpr, value)
     info.hasfix && _error("Cannot specify variable fixed value twice")
     info.hasfix = true
     info.fixedvalue = value
 end
-function setbinary_or_error(info::VariableInfoExpr, _error::Function)
+function setbinary_or_error(_error::Function, info::VariableInfoExpr)
     info.binary === false || _error("'Bin' and 'binary' keyword argument cannot both be specified.")
     info.binary = true
 end
-function setinteger_or_error(info::VariableInfoExpr, _error::Function)
+function setinteger_or_error(_error::Function, info::VariableInfoExpr)
     info.integer === false || _error("'Int' and 'integer' keyword argument cannot both be specified.")
     info.integer = true
 end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -19,26 +19,26 @@ mutable struct VariableInfoExpr
     integer::Any
 end
 
-function setlowerbound(info::VariableInfoExpr, lower, _error::Function)
+function setlowerbound_or_error(info::VariableInfoExpr, lower, _error::Function)
     info.haslb && _error("Cannot specify variable lowerbound twice")
     info.haslb = true
     info.lowerbound = lower
 end
-function setupperbound(info::VariableInfoExpr, upper, _error::Function)
+function setupperbound_or_error(info::VariableInfoExpr, upper, _error::Function)
     info.hasub && _error("Cannot specify variable lowerbound twice")
     info.hasub = true
     info.upperbound = upper
 end
-function fix(info::VariableInfoExpr, value, _error::Function)
+function fix_or_error(info::VariableInfoExpr, value, _error::Function)
     info.hasfix && _error("Cannot specify variable fixed value twice")
     info.hasfix = true
     info.fixedvalue = value
 end
-function setbinary(info::VariableInfoExpr, _error::Function)
+function setbinary_or_error(info::VariableInfoExpr, _error::Function)
     info.binary === false || _error("'Bin' and 'binary' keyword argument cannot both be specified.")
     info.binary = true
 end
-function setinteger(info::VariableInfoExpr, _error::Function)
+function setinteger_or_error(info::VariableInfoExpr, _error::Function)
     info.integer === false || _error("'Int' and 'integer' keyword argument cannot both be specified.")
     info.integer = true
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -56,7 +56,7 @@ end
             @test info.haslb
             @test info.lowerbound == 0
             @test !info.hasub
-            @test info.upperbound == Inf
+            @test isnan(info.upperbound)
             @test !info.hasfix
             @test isnan(info.fixedvalue)
             @test !info.binary


### PR DESCRIPTION
This PR creates a `VariableInfo` with the keyword arguments of the `@variable` macro which is then modified by the expression (e.g. `0 <= x <= 1` modifies lower and upper bounds).
This `VariableInfo` may contain expressions in its used during parsing.
The advantage of this approach is that we only have one variable `infoexpr` instead of `haslb`, `lb`, ... hence it will make easier to create `parsevariable` as we will only have to pass one variable.