### PR TITLE
improve error handling for arrays in nonlinear expressions

### DIFF
--- a/src/parsenlp.jl
+++ b/src/parsenlp.jl
@@ -162,8 +162,8 @@ function parseNLExpr_runtime(m::Model, x::NonlinearParameter, tape, parent, valu
     nothing
 end
 
-function parseNLExpr_runtime(m::Model, x::Vector, tape, parent, values)
-    error("Unexpected vector $x in nonlinear expression. Nonlinear expressions may contain only scalar expressions.")
+function parseNLExpr_runtime(m::Model, x::AbstractArray, tape, parent, values)
+    error("Unexpected array $x in nonlinear expression. Nonlinear expressions may contain only scalar expressions.")
 end
 
 function expression_complexity(ex::Expr)

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -128,6 +128,12 @@
         @test_throws ErrorException @NLexpression(m, sum(x))
     end
 
+    @testset "Error on non-scalar expressions" begin
+        m = Model()
+        x = [1,2,3]
+        @test_throws ErrorException @NLexpression(m, x + 1)
+    end
+
     # Converts the lower-triangular sparse Hessian in MOI format into a dense
     # matrix.
     function dense_hessian(hessian_sparsity, V, n)


### PR DESCRIPTION
Previously this was a method error for all but vectors.

Closes #1368 