### PR TITLE
Add SOCone and RSOCone sets

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -33,7 +33,7 @@ export
     NonlinearConstraint,
     ConstraintRef,
 # Cones
-    PSDCone,
+    SOCone, RSOCone, PSDCone,
 # Functions
     # Model related
     setobjectivesense,
@@ -414,6 +414,8 @@ include("quadexpr.jl")
 ##########################################################################
 # SOSConstraint  (special ordered set constraints)
 # include("sos.jl")
+
+include("sets.jl")
 
 ##########################################################################
 # SDConstraint

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -28,12 +28,12 @@ using .Derivatives
 
 export
 # Objects
-    Model, VariableRef, Norm, AffExpr, QuadExpr, SOCExpr,
-    # LinearConstraint, QuadConstraint, SDConstraint, SOCConstraint,
+    Model, VariableRef, Norm, AffExpr, QuadExpr,
+    # LinearConstraint, QuadConstraint, SDConstraint,
     NonlinearConstraint,
     ConstraintRef,
 # Cones
-    SOCone, RSOCone, PSDCone,
+    SecondOrderCone, RotatedSecondOrderCone, PSDCone,
 # Functions
     # Model related
     setobjectivesense,

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -1,17 +1,16 @@
-export PSDCone
-# Used in @constraint m x in PSDCone
+# Used in @constraint model x in PSDCone
 struct PSDCone end
 
 # Used by the @variable macro. It can also be used with the @constraint macro,
 # this allows to get the constraint reference, e.g.
-# @variable m x[1:2,1:2] Symmetric # x is Symmetric{VariableRef,Matrix{VariableRef}}
-# varpsd = @constraint m x in PSDCone()
+# @variable model x[1:2,1:2] Symmetric # x is Symmetric{VariableRef,Matrix{VariableRef}}
+# varpsd = @constraint model x in PSDCone()
 function buildconstraint(_error::Function, Q::Symmetric{V, Matrix{V}}, ::PSDCone) where V<:AbstractVariableRef
     n = Base.LinAlg.checksquare(Q)
     VectorOfVariablesConstraint([Q[i, j] for j in 1:n for i in 1:j], MOI.PositiveSemidefiniteConeTriangle(n))
 end
-# @variable m x[1:2,1:2] # x is Matrix{VariableRef}
-# varpsd = @constraint m x in PSDCone()
+# @variable model x[1:2,1:2] # x is Matrix{VariableRef}
+# varpsd = @constraint model x in PSDCone()
 function buildconstraint(_error::Function, Q::Matrix{<:AbstractVariableRef}, ::PSDCone)
     n = Base.LinAlg.checksquare(Q)
     VectorOfVariablesConstraint(vec(Q), MOI.PositiveSemidefiniteConeSquare(n))

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -1,0 +1,19 @@
+abstract type AbstractVectorSet end
+
+"""
+    moi_set(s::AbstractVectorSet, dim::Int)
+
+Returns the MOI set of dimension `dim` corresponding to the JuMP set `s`.
+"""
+function moi_set end
+
+# Used in `@constraint model f in s`
+function buildconstraint(_error::Function, f::AbstractVector,
+                         s::AbstractVectorSet)
+    return buildconstraint(_error, f, moi_set(s, length(f)))
+end
+
+struct SOCone <: AbstractVectorSet end
+moi_set(::SOCone, dim::Int) = MOI.SecondOrderCone(dim)
+struct RSOCone <: AbstractVectorSet end
+moi_set(::RSOCone, dim::Int) = MOI.RotatedSecondOrderCone(dim)

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -13,7 +13,7 @@ function buildconstraint(_error::Function, f::AbstractVector,
     return buildconstraint(_error, f, moi_set(s, length(f)))
 end
 
-struct SOCone <: AbstractVectorSet end
-moi_set(::SOCone, dim::Int) = MOI.SecondOrderCone(dim)
-struct RSOCone <: AbstractVectorSet end
-moi_set(::RSOCone, dim::Int) = MOI.RotatedSecondOrderCone(dim)
+struct SecondOrderCone <: AbstractVectorSet end
+moi_set(::SecondOrderCone, dim::Int) = MOI.SecondOrderCone(dim)
+struct RotatedSecondOrderCone <: AbstractVectorSet end
+moi_set(::RotatedSecondOrderCone, dim::Int) = MOI.RotatedSecondOrderCone(dim)

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -227,10 +227,10 @@
             z
         end
         @objective(m, Max, 1.0*x)
-        @constraint(m, varsoc, [x,y,z] in SOCone())
+        @constraint(m, varsoc, [x,y,z] in SecondOrderCone())
         # Equivalent to `[x+y,z,1.0] in MOI.SOCone()`
         @constraint(m, affsoc, [x+y,z,1.0] in MOI.SecondOrderCone(3))
-        @constraint(m, rotsoc, [x+1,y,z] in RSOCone())
+        @constraint(m, rotsoc, [x+1,y,z] in RotatedSecondOrderCone())
 
         modelstring = """
         variables: x, y, z

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -228,7 +228,8 @@
         end
         @objective(m, Max, 1.0*x)
         @constraint(m, varsoc, [x,y,z] in SOCone())
-        @constraint(m, affsoc, [x+y,z,1.0] in SOCone())
+        # Equivalent to `[x+y,z,1.0] in MOI.SOCone()`
+        @constraint(m, affsoc, [x+y,z,1.0] in MOI.SecondOrderCone(3))
         @constraint(m, rotsoc, [x+1,y,z] in RSOCone())
 
         modelstring = """

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -227,9 +227,9 @@
             z
         end
         @objective(m, Max, 1.0*x)
-        @constraint(m, varsoc, [x,y,z] in MOI.SecondOrderCone(3))
-        @constraint(m, affsoc, [x+y,z,1.0] in MOI.SecondOrderCone(3))
-        @constraint(m, rotsoc, [x+1,y,z] in MOI.RotatedSecondOrderCone(3))
+        @constraint(m, varsoc, [x,y,z] in SOCone())
+        @constraint(m, affsoc, [x+y,z,1.0] in SOCone())
+        @constraint(m, rotsoc, [x+1,y,z] in RSOCone())
 
         modelstring = """
         variables: x, y, z


### PR DESCRIPTION
Other vector sets can easily be added by implementing the `moi_set` function.

Closes #1094 