### PR TITLE
Factory

### DIFF
--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -38,11 +38,11 @@ Direct.
 In Automatic and Manual modes, two MOI layers are automatically applied to the
 optimizer:
 
-* `CachingOptimizer`: it maintain a cache of the model so that when the
-  the optimizer does not support an incremental change to the model, the
-  optimizer's internal model can be discarded and restored from the cache just
-  before optimization. The `CachingOptimizer` has two different modes: Automatic
-  and Manual corresponding to the two JuMP modes with the same names.
+* `CachingOptimizer`: maintains a cache of the model so that when the optimizer
+  does not support an incremental change to the model, the optimizer's internal
+  model can be discarded and restored from the cache just before optimization.
+  The `CachingOptimizer` has two different modes: Automatic and Manual
+  corresponding to the two JuMP modes with the same names.
 * `LazyBridgeOptimizer`: when a constraint added is not supported by the
   optimizer, it tries transform the constraint into an equivalent form,
   possibly adding new variables and constraints that are supported by the

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -68,7 +68,8 @@ JuMP.setoptimizer
 
 New JuMP models are created using the [`Model`](@ref) constructor:
 ```@docs
-Model
+Model()
+Model(::JuMP.Factory)
 ```
 
 ## Direct mode

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -56,16 +56,16 @@ optimizer:
 See the [MOI documentation](http://www.juliaopt.org/MathOptInterface.jl/stable/)
 for more details on these two MOI layers.
 
-To create a fresh new JuMP model, JuMP needs to create a new empty optimizer
-instance. New optimizer instances can be obtained using an
+To attach an optimizer to a JuMP model, JuMP needs to create a new empty
+optimizer instance. New optimizer instances can be obtained using an
 `OptimizerFactory` that can be created using the [`with_optimizer`](@ref)
 function:
 ```@docs
 with_optimizer
 ```
 
-The optimizer factory can be set to the JuMP model in the
-[`JuMP.optimize`](@ref) function:
+The factory can be provided either at model construction time or at
+[`JuMP.optimize`](@ref) time:
 ```@docs
 JuMP.optimize
 ```

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -2,10 +2,11 @@ Interacting with solvers
 ========================
 
 A JuMP model keeps a [MathOptInterface (MOI)](https://github.com/JuliaOpt/MathOptInterface.jl)
-backend internally that stores the optimization problem and acts as the
-optimization solver (the backend can also not support optimization, e.g. it can
-simply store the model in a file). JuMP can be viewed as a lightweight
-user-friendly layer on top of the MOI backend:
+*backend* internally that stores the optimization problem and acts as the
+optimization solver. We call it an MOI *backend* and not optimizer as it can
+also be a wrapper around an optimization file format such as MPS that writes
+the JuMP model in a file. JuMP can be viewed as a lightweight user-friendly
+layer on top of the MOI backend:
 
 * JuMP does not maintain any copy of the model outside this MOI backend.
 * JuMP variable (resp. constraint) references are simple structures containing

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -1,8 +1,7 @@
 Interacting with solvers
 ========================
 
-A JuMP model keeps a
-[MathOptInterface (MOI)](https://github.com/JuliaOpt/MathOptInterface.jl)
+A JuMP model keeps a [MathOptInterface (MOI)](https://github.com/JuliaOpt/MathOptInterface.jl)
 backend internally that stores the optimization problem and act as the
 optimization solver (the backend can also not support optimization, e.g. it can
 simply store the model in a file). JuMP can be viewed as a lightweight

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -2,11 +2,11 @@ Interacting with solvers
 ========================
 
 A JuMP model keeps a [MathOptInterface (MOI)](https://github.com/JuliaOpt/MathOptInterface.jl)
-*backend* internally that stores the optimization problem and acts as the
-optimization solver. We call it an MOI *backend* and not optimizer as it can
-also be a wrapper around an optimization file format such as MPS that writes
-the JuMP model in a file. JuMP can be viewed as a lightweight user-friendly
-layer on top of the MOI backend:
+*backend* of type `MOI.ModelLike` internally that stores the optimization
+problem and acts as the optimization solver. We call it an MOI *backend* and
+not optimizer as it can also be a wrapper around an optimization file format
+such as MPS that writes the JuMP model in a file. JuMP can be viewed as a
+lightweight user-friendly layer on top of the MOI backend:
 
 * JuMP does not maintain any copy of the model outside this MOI backend.
 * JuMP variable (resp. constraint) references are simple structures containing

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -1,6 +1,28 @@
 Interacting with solvers
 ========================
 
+
+```@docs
+with_optimizer
+```
+
+The solvers can be set with
+```@docs
+JuMP.setoptimizer
+```
+
+```@docs
+Model
+```
+
+## Direct mode
+
+For advanced users, the model can be created without using a caching nor a
+bridge optimizer using the [`JuMP.direct_model`](@ref) function:
+```@docs
+JuMP.direct_model
+```
+
 TODO: Describe the connection between JuMP and solvers. Automatic vs. Manual
 mode. CachingOptimizer. How to set/change solvers. How to set parameters (solver
 specific and generic). Status codes. Accessing the result.

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -1,10 +1,12 @@
 Interacting with solvers
 ========================
 
-A JuMP model stores a
+A JuMP model keeps a
 [MathOptInterface (MOI)](https://github.com/JuliaOpt/MathOptInterface.jl)
-backend internally that contains the optimization solver. The JuMP layer on top
-of this MOI backend is aimed to be as lightweight as possible:
+backend internally that stores the optimization problem and act as the
+optimization solver (the backend can also not support optimization, e.g. it can
+simply store the model in a file). JuMP can be viewed as a lightweight
+user-friendly layer on top of the MOI backend:
 
 * JuMP does not maintain any copy of the model outside this MOI backend.
 * JuMP variable (resp. constraint) references are simple structures containing
@@ -17,7 +19,7 @@ of this MOI backend is aimed to be as lightweight as possible:
   backend to support such modifications.
 
 While this allows JuMP API to to be a thin wrapper on top of the solver API,
-as mentionned in the last point above, this seems rather demanding on the
+as mentioned in the last point above, this seems rather demanding on the
 solver. Indeed, while some solvers support incremental building of the model and
 modifications before and after solve, other solvers only support the model being
 copied at once before solve. Moreover it seems to require all solvers to
@@ -38,9 +40,9 @@ In Automatic and Manual modes, two MOI layers are automatically applied to the
 optimizer:
 
 * `CachingOptimizer`: it maintain a cache of the model so that when the
-  the optimizer does not support a modification of the model, the optimizer's
-  internal model can be discarded and restored from the cache just before
-  optimization. The `CachingOptimizer` has two different modes: Automatic
+  the optimizer does not support an incremental change to the model, the
+  optimizer's internal model can be discarded and restored from the cache just
+  before optimization. The `CachingOptimizer` has two different modes: Automatic
   and Manual corresponding to the two JuMP modes with the same names.
 * `LazyBridgeOptimizer`: when a constraint added is not supported by the
   optimizer, it tries transform the constraint into an equivalent form,
@@ -69,7 +71,7 @@ JuMP.setoptimizer
 New JuMP models are created using the [`Model`](@ref) constructor:
 ```@docs
 Model()
-Model(::JuMP.Factory)
+Model(::JuMP.OptimizerFactory)
 ```
 
 ## Direct mode

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -44,12 +44,14 @@ optimizer:
   model can be discarded and restored from the cache just before optimization.
   The `CachingOptimizer` has two different modes: Automatic and Manual
   corresponding to the two JuMP modes with the same names.
-* `LazyBridgeOptimizer`: when a constraint added is not supported by the
-  optimizer, it tries transform the constraint into an equivalent form,
-  possibly adding new variables and constraints that are supported by the
-  optimizer. The applied transformations are selected among known recipes
-  which are called bridges. A few default bridges are defined in MOI but new
-  ones can be defined and added to the `LazyBridgeOptimizer` used by JuMP.
+* `LazyBridgeOptimizer` (this can be disabled using the `bridge_constraints`
+  keyword argument to [`Model`](@ref) constructor): when a constraint added is
+  not supported by the optimizer, it tries transform the constraint into an
+  equivalent form, possibly adding new variables and constraints that are
+  supported by the optimizer. The applied transformations are selected among
+  known recipes which are called bridges. A few default bridges are defined in
+  MOI but new ones can be defined and added to the `LazyBridgeOptimizer` used by
+  JuMP.
 
 See the [MOI documentation](http://www.juliaopt.org/MathOptInterface.jl/stable/)
 for more details on these two MOI layers.

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -1,29 +1,84 @@
 Interacting with solvers
 ========================
 
+A JuMP model stores a
+[MathOptInterface (MOI)](https://github.com/JuliaOpt/MathOptInterface.jl)
+backend internally that contains the optimization solver. The JuMP layer on top
+of this MOI backend is aimed to be as lightweight as possible:
 
+* JuMP does not maintain any copy of the model outside this MOI backend.
+* JuMP variable (resp. constraint) references are simple structures containing
+  both a reference to the JuMP model and the MOI index of the variable (resp.
+  constraint).
+* JuMP gives the constraints to the MOI backend in the form provided by the user
+  without doing any automatic reformulation.
+* variables additions, constraints additions/modifications and objective
+  modifications are directly applied to the MOI backend thus expecting the
+  backend to support such modifications.
+
+While this allows JuMP API to to be a thin wrapper on top of the solver API,
+as mentionned in the last point above, this seems rather demanding on the
+solver. Indeed, while some solvers support incremental building of the model and
+modifications before and after solve, other solvers only support the model being
+copied at once before solve. Moreover it seems to require all solvers to
+implement all possible reformulations independently which seems both very
+ambitious and might generate a lot of duplicated code.
+
+These apparent limitations are in fact addressed at the MOI level in a manner
+that is completely transparent to JuMP. While the MOI API may seem very
+demanding, it allows MOI models to be a succession of lightweight MOI layers
+that fill the gap between JuMP requirements and the solver capabilities.
+
+JuMP models can be created in three different modes: Automatic, Manual and
+Direct.
+
+## Automatic and Manual modes
+
+In Automatic and Manual modes, two MOI layers are automatically applied to the
+optimizer:
+
+* `CachingOptimizer`: it maintain a cache of the model so that when the
+  the optimizer does not support a modification of the model, the optimizer's
+  internal model can be discarded and restored from the cache just before
+  optimization. The `CachingOptimizer` has two different modes: Automatic
+  and Manual corresponding to the two JuMP modes with the same names.
+* `LazyBridgeOptimizer`: when a constraint added is not supported by the
+  optimizer, it tries transform the constraint into an equivalent form,
+  possibly adding new variables and constraints that are supported by the
+  optimizer. The applied transformations are selected among known recipes
+  which are called bridges. A few default bridges are defined in MOI but new
+  ones can be defined and added to the `LazyBridgeOptimizer` used by JuMP.
+
+See the [MOI documentation](http://www.juliaopt.org/MathOptInterface.jl/stable/)
+for more details on these two MOI layers.
+
+To create a fresh new JuMP model (or a fresh new copy of a JuMP model), JuMP
+needs to create a new empty optimizer instance. New optimizer instances can
+be obtained using a factory that can be created using the
+[`with_optimizer`](@ref) function:
 ```@docs
 with_optimizer
 ```
 
-The solvers can be set with
+The factory can be set to the JuMP model using the [`JuMP.setoptimizer`](@ref)
+function:
 ```@docs
 JuMP.setoptimizer
 ```
 
+New JuMP models are created using the [`Model`](@ref) constructor:
 ```@docs
 Model
 ```
 
 ## Direct mode
 
-For advanced users, the model can be created without using a caching nor a
-bridge optimizer using the [`JuMP.direct_model`](@ref) function:
+JuMP models can be created in Direct mode using the [`JuMP.direct_model`](@ref)
+function.
 ```@docs
 JuMP.direct_model
 ```
 
-TODO: Describe the connection between JuMP and solvers. Automatic vs. Manual
-mode. CachingOptimizer. How to set/change solvers. How to set parameters (solver
+TODO: How to set parameters (solver
 specific and generic). Status codes. Accessing the result.
 How to accurately measure the solve time.

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -58,14 +58,14 @@ for more details on these two MOI layers.
 
 To create a fresh new JuMP model, JuMP needs to create a new empty optimizer
 instance. New optimizer instances can be obtained using an
-[`OptimizerFactory`](@ref) that can be created using the
-[`with_optimizer`](@ref) function:
+`OptimizerFactory` that can be created using the [`with_optimizer`](@ref)
+function:
 ```@docs
 with_optimizer
 ```
 
-The factory can be set to the JuMP model in the [`JuMP.optimize`](@ref)
-function:
+The optimizer factory can be set to the JuMP model in the
+[`JuMP.optimize`](@ref) function:
 ```@docs
 JuMP.optimize
 ```

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -76,6 +76,8 @@ Model()
 Model(::JuMP.OptimizerFactory)
 ```
 
+TODO: how to control the caching optimizer states
+
 ## Direct mode
 
 JuMP models can be created in Direct mode using the [`JuMP.direct_model`](@ref)

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -56,18 +56,18 @@ optimizer:
 See the [MOI documentation](http://www.juliaopt.org/MathOptInterface.jl/stable/)
 for more details on these two MOI layers.
 
-To create a fresh new JuMP model (or a fresh new copy of a JuMP model), JuMP
-needs to create a new empty optimizer instance. New optimizer instances can
-be obtained using an [`OptimizerFactory`](@ref) that can be created using the
+To create a fresh new JuMP model, JuMP needs to create a new empty optimizer
+instance. New optimizer instances can be obtained using an
+[`OptimizerFactory`](@ref) that can be created using the
 [`with_optimizer`](@ref) function:
 ```@docs
 with_optimizer
 ```
 
-The factory can be set to the JuMP model using the [`JuMP.setoptimizer`](@ref)
+The factory can be set to the JuMP model in the [`JuMP.optimize`](@ref)
 function:
 ```@docs
-JuMP.setoptimizer
+JuMP.optimize
 ```
 
 New JuMP models are created using the [`Model`](@ref) constructor:

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -58,7 +58,7 @@ for more details on these two MOI layers.
 
 To create a fresh new JuMP model (or a fresh new copy of a JuMP model), JuMP
 needs to create a new empty optimizer instance. New optimizer instances can
-be obtained using a factory that can be created using the
+be obtained using an [`OptimizerFactory`](@ref) that can be created using the
 [`with_optimizer`](@ref) function:
 ```@docs
 with_optimizer

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -2,7 +2,7 @@ Interacting with solvers
 ========================
 
 A JuMP model keeps a [MathOptInterface (MOI)](https://github.com/JuliaOpt/MathOptInterface.jl)
-backend internally that stores the optimization problem and act as the
+backend internally that stores the optimization problem and acts as the
 optimization solver (the backend can also not support optimization, e.g. it can
 simply store the model in a file). JuMP can be viewed as a lightweight
 user-friendly layer on top of the MOI backend:

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -18,9 +18,9 @@ lightweight user-friendly layer on top of the MOI backend:
   modifications are directly applied to the MOI backend thus expecting the
   backend to support such modifications.
 
-While this allows JuMP API to to be a thin wrapper on top of the solver API,
-as mentioned in the last point above, this seems rather demanding on the
-solver. Indeed, while some solvers support incremental building of the model and
+While this allows JuMP to be a thin wrapper on top of the solver API, as
+mentioned in the last point above, this seems rather demanding on the solver.
+Indeed, while some solvers support incremental building of the model and
 modifications before and after solve, other solvers only support the model being
 copied at once before solve. Moreover it seems to require all solvers to
 implement all possible reformulations independently which seems both very

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -179,7 +179,7 @@ function Model(factory::Factory; kwargs...)
     model = Model(; kwargs...)
     model.factory = factory # useful for implementing Base.copy
     optimizer = create_model(factory)
-    MOIU.resetoptimizer!(model.moibackend, optimizer)
+    MOIU.resetoptimizer!(model, optimizer)
     return model
 end
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -84,6 +84,16 @@ const MOIBIN = MOICON{MOI.SingleVariable,MOI.ZeroOne}
 User-friendly closure that creates new MOI models. New `OptimizerFactory`s are
 created with [`with_optimizer`](@ref) and new models are created from the
 factory with [`create_model`](@ref).
+
+## Examples
+
+The following construct a factory and then use it to create two independent
+`IpoptOptimizer`s:
+```julia
+factory = with_optimizer(IpoptOptimizer, print_level=0)
+optimizer1 = JuMP.create_model(factory)
+optimizer2 = JuMP.create_model(factory)
+```
 """
 struct OptimizerFactory
     # The constructor can be

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -226,7 +226,7 @@ function Model(; caching_mode::MOIU.CachingOptimizerMode=MOIU.Automatic,
     else
         backend = caching_opt
     end
-    return Model(nothing, backend)
+    return Model(backend)
 end
 
 """
@@ -273,7 +273,7 @@ in mind the following implications of creating models using this *direct* mode:
 * The model created cannot be copied.
 """
 function direct_model(backend::MOI.ModelLike)
-    return Model(nothing, backend)
+    return Model(backend)
 end
 
 # In Automatic and Manual mode, `model.moibackend` is either directly the

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -145,6 +145,11 @@ mutable struct Model <: AbstractModel
 
     customnames::Vector
 
+    # Factory used to create a new optimizer, it is kept as it might be needed
+    # again if the user requests a copy of the model using `Base.copy`.
+    # In Manual and Automatic mode: Factory used to create the optimizer or
+    #                               Nothing if it has not already been set
+    # In Direct mode: Nothing
     factory::Union{Nothing, Factory}
     # In Manual and Automatic modes, LazyBridgeOptimizer{CachingOptimizer}.
     # In Direct mode, will hold an AbstractOptimizer.

--- a/src/optimizerinterface.jl
+++ b/src/optimizerinterface.jl
@@ -4,7 +4,7 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
-    setoptimizer(model::Model, factory::Factory)
+    set_optimizer(model::Model, factory::OptimizerFactory)
 
 Sets the optimizer of the model `model` as the optimizers created by the
 factory `factory`. The factory can be created by the [`with_optimizer`](@ref)
@@ -15,10 +15,10 @@ function.
 The following sets the optimizer of `model` to be
 `IpoptOptimizer(print_level=0)`:
 ```julia
-setoptimizer(model, with_optimizer(IpoptOptimizer, print_level=0))
+set_optimizer(model, with_optimizer(IpoptOptimizer, print_level=0))
 ```
 """
-function setoptimizer(model::Model, factory::Factory)
+function set_optimizer(model::Model, factory::OptimizerFactory)
     model.factory = factory
     optimizer = create_model(factory)
     MOIU.resetoptimizer!(model, optimizer)

--- a/src/optimizerinterface.jl
+++ b/src/optimizerinterface.jl
@@ -49,6 +49,12 @@ function optimize(model::Model,
     end
 
     if optimizer_factory !== nothing
+        if mode(model) == Direct
+            error("An optimizer factory cannot be provided at the `optimize` call in Direct mode")
+        end
+        if MOIU.state(caching_optimizer(model)) != MOIU.NoOptimizer
+            error("An optimizer factory cannot both be provided in the `Model` constructor and at the `optimize` call.")
+        end
         optimizer = optimizer_factory()
         MOIU.resetoptimizer!(model, optimizer)
         MOIU.attachoptimizer!(model)

--- a/src/optimizerinterface.jl
+++ b/src/optimizerinterface.jl
@@ -19,7 +19,7 @@ setoptimizer(model, with_optimizer(IpoptOptimizer, print_level=0))
 ```
 """
 function setoptimizer(model::Model, factory::Factory)
-    model.factory = factory # useful for implementing Base.copy
+    model.factory = factory
     optimizer = create_model(factory)
     MOIU.resetoptimizer!(model, optimizer)
 end

--- a/src/optimizerinterface.jl
+++ b/src/optimizerinterface.jl
@@ -32,14 +32,14 @@ end
 
 """
     function optimize(model::Model,
-                      factory::Union{Nothing, OptimizerFactory} = nothing;
+                      optimizer_factory::Union{Nothing, OptimizerFactory} = nothing;
                       ignore_optimize_hook=(model.optimizehook===nothing))
 
-Optimize the model. If `factory` is not `nothing`, it first set the optimizer
-to a new one created using the factory.
+Optimize the model. If `optimizer_factory` is not `nothing`, it first set the
+optimizer to a new one created using the optimizer factory.
 """
 function optimize(model::Model,
-                  factory::Union{Nothing, OptimizerFactory} = nothing;
+                  optimizer_factory::Union{Nothing, OptimizerFactory} = nothing;
                   ignore_optimize_hook=(model.optimizehook===nothing))
     # The NLPData is not kept in sync, so re-set it here.
     # TODO: Consider how to handle incremental solves.
@@ -48,8 +48,8 @@ function optimize(model::Model,
         empty!(model.nlpdata.nlconstr_duals)
     end
 
-    if factory !== nothing
-        optimizer = create_model(factory)
+    if optimizer_factory !== nothing
+        optimizer = optimizer_factory()
         MOIU.resetoptimizer!(model, optimizer)
         MOIU.attachoptimizer!(model)
     end

--- a/src/optimizerinterface.jl
+++ b/src/optimizerinterface.jl
@@ -50,7 +50,7 @@ function optimize(model::Model,
 
     if optimizer_factory !== nothing
         if mode(model) == Direct
-            error("An optimizer factory cannot be provided at the `optimize` call in Direct mode")
+            error("An optimizer factory cannot be provided at the `optimize` call in Direct mode.")
         end
         if MOIU.state(caching_optimizer(model)) != MOIU.NoOptimizer
             error("An optimizer factory cannot both be provided in the `Model` constructor and at the `optimize` call.")

--- a/src/optimizerinterface.jl
+++ b/src/optimizerinterface.jl
@@ -3,6 +3,27 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""
+    setoptimizer(model::Model, factory::Factory)
+
+Sets the optimizer of the model `model` as the optimizers created by the
+factory `factory`. The factory can be created by the [`with_optimizer`](@ref)
+function.
+
+## Examples
+
+The following sets the optimizer of `model` to be
+`IpoptOptimizer(print_level=0)`:
+```julia
+setoptimizer(model, with_optimizer(IpoptOptimizer, print_level=0))
+```
+"""
+function setoptimizer(model::Model, factory::Factory)
+    model.factory = factory # useful for implementing Base.copy
+    optimizer = create_model(factory)
+    MOIU.resetoptimizer!(model, optimizer)
+end
+
 # These methods directly map to CachingOptimizer methods.
 # They cannot be called in Direct mode.
 function MOIU.resetoptimizer!(model::Model, optimizer::MOI.AbstractOptimizer)

--- a/src/optimizerinterface.jl
+++ b/src/optimizerinterface.jl
@@ -19,6 +19,7 @@ set_optimizer(model, with_optimizer(IpoptOptimizer, print_level=0))
 ```
 """
 function set_optimizer(model::Model, factory::OptimizerFactory)
+    @assert mode(model) != Direct
     model.factory = factory
     optimizer = create_model(factory)
     MOIU.resetoptimizer!(model, optimizer)

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -186,10 +186,9 @@
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.caching_optimizer(m).model_cache, model, ["x","y"], ["c1", "c2", "c3"])
 
-        mockoptimizer = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}(), evalobjective=false)
-        MOIU.resetoptimizer!(m, mockoptimizer)
-        MOIU.attachoptimizer!(m)
+        JuMP.optimize(m, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}(), evalobjective=false))
 
+        mockoptimizer = JuMP.caching_optimizer(m).optimizer
         MOI.set!(mockoptimizer, MOI.TerminationStatus(), MOI.Success)
         MOI.set!(mockoptimizer, MOI.ObjectiveValue(), -1.0)
         MOI.set!(mockoptimizer, MOI.ResultCount(), 1)
@@ -200,8 +199,6 @@
         MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(c1), -1.0)
         MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(c2), 2.0)
         MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(c3), 3.0)
-
-        JuMP.optimize(m)
 
         #@test JuMP.isattached(m)
         @test JuMP.hasresultvalues(m)

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -39,7 +39,7 @@
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.caching_optimizer(m).model_cache, model, ["x","y"], ["c", "xub", "ylb"])
 
-        JuMP.setoptimizer(m, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}(), evalobjective=false))
+        JuMP.set_optimizer(m, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}(), evalobjective=false))
         MOIU.attachoptimizer!(m)
 
         mockoptimizer = JuMP.caching_optimizer(m).optimizer

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -39,10 +39,10 @@
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.caching_optimizer(m).model_cache, model, ["x","y"], ["c", "xub", "ylb"])
 
-        mockoptimizer = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}(), evalobjective=false)
-        MOIU.resetoptimizer!(m, mockoptimizer)
+        JuMP.setoptimizer(m, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}(), evalobjective=false))
         MOIU.attachoptimizer!(m)
 
+        mockoptimizer = JuMP.caching_optimizer(m).optimizer
         MOI.set!(mockoptimizer, MOI.TerminationStatus(), MOI.Success)
         MOI.set!(mockoptimizer, MOI.ObjectiveValue(), -1.0)
         MOI.set!(mockoptimizer, MOI.ResultCount(), 1)

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -39,8 +39,7 @@
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.caching_optimizer(m).model_cache, model, ["x","y"], ["c", "xub", "ylb"])
 
-        JuMP.set_optimizer(m, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}(), evalobjective=false))
-        MOIU.attachoptimizer!(m)
+        JuMP.optimize(m, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}(), evalobjective=false))
 
         mockoptimizer = JuMP.caching_optimizer(m).optimizer
         MOI.set!(mockoptimizer, MOI.TerminationStatus(), MOI.Success)
@@ -53,8 +52,6 @@
         MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(c), -1.0)
         MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.UpperBoundRef(x)), 0.0)
         MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.LowerBoundRef(y)), 1.0)
-
-        JuMP.optimize(m)
 
         #@test JuMP.isattached(m)
         @test JuMP.hasresultvalues(m)

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -39,20 +39,20 @@
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.caching_optimizer(m).model_cache, model, ["x","y"], ["c", "xub", "ylb"])
 
-        mocksolver = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}(), evalobjective=false)
-        MOIU.resetoptimizer!(m, mocksolver)
+        mockoptimizer = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}(), evalobjective=false)
+        MOIU.resetoptimizer!(m, mockoptimizer)
         MOIU.attachoptimizer!(m)
 
-        MOI.set!(mocksolver, MOI.TerminationStatus(), MOI.Success)
-        MOI.set!(mocksolver, MOI.ObjectiveValue(), -1.0)
-        MOI.set!(mocksolver, MOI.ResultCount(), 1)
-        MOI.set!(mocksolver, MOI.PrimalStatus(), MOI.FeasiblePoint)
-        MOI.set!(mocksolver, MOI.DualStatus(), MOI.FeasiblePoint)
-        MOI.set!(mocksolver, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
-        MOI.set!(mocksolver, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
-        MOI.set!(mocksolver, MOI.ConstraintDual(), JuMP.optimizerindex(c), -1.0)
-        MOI.set!(mocksolver, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.UpperBoundRef(x)), 0.0)
-        MOI.set!(mocksolver, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.LowerBoundRef(y)), 1.0)
+        MOI.set!(mockoptimizer, MOI.TerminationStatus(), MOI.Success)
+        MOI.set!(mockoptimizer, MOI.ObjectiveValue(), -1.0)
+        MOI.set!(mockoptimizer, MOI.ResultCount(), 1)
+        MOI.set!(mockoptimizer, MOI.PrimalStatus(), MOI.FeasiblePoint)
+        MOI.set!(mockoptimizer, MOI.DualStatus(), MOI.FeasiblePoint)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(c), -1.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.UpperBoundRef(x)), 0.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.LowerBoundRef(y)), 1.0)
 
         JuMP.optimize(m)
 
@@ -74,24 +74,24 @@
     end
 
     @testset "LP (Direct mode)" begin
-        mocksolver = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}(), evalobjective=false)
+        mockoptimizer = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}(), evalobjective=false)
 
-        m = Model(mode = JuMP.Direct, backend = mocksolver)
+        m = JuMP.direct_model(mockoptimizer)
         @variable(m, x <= 2.0)
         @variable(m, y >= 0.0)
         @objective(m, Min, -x)
 
         c = @constraint(m, x + y <= 1)
-        MOI.set!(mocksolver, MOI.TerminationStatus(), MOI.Success)
-        MOI.set!(mocksolver, MOI.ObjectiveValue(), -1.0)
-        MOI.set!(mocksolver, MOI.ResultCount(), 1)
-        MOI.set!(mocksolver, MOI.PrimalStatus(), MOI.FeasiblePoint)
-        MOI.set!(mocksolver, MOI.DualStatus(), MOI.FeasiblePoint)
-        MOI.set!(mocksolver, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
-        MOI.set!(mocksolver, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
-        MOI.set!(mocksolver, MOI.ConstraintDual(), JuMP.optimizerindex(c), -1.0)
-        MOI.set!(mocksolver, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.UpperBoundRef(x)), 0.0)
-        MOI.set!(mocksolver, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.LowerBoundRef(y)), 1.0)
+        MOI.set!(mockoptimizer, MOI.TerminationStatus(), MOI.Success)
+        MOI.set!(mockoptimizer, MOI.ObjectiveValue(), -1.0)
+        MOI.set!(mockoptimizer, MOI.ResultCount(), 1)
+        MOI.set!(mockoptimizer, MOI.PrimalStatus(), MOI.FeasiblePoint)
+        MOI.set!(mockoptimizer, MOI.DualStatus(), MOI.FeasiblePoint)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(c), -1.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.UpperBoundRef(x)), 0.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.LowerBoundRef(y)), 1.0)
 
         JuMP.optimize(m)
 
@@ -115,9 +115,8 @@
     # TODO: test Manual mode
 
     @testset "IP" begin
-        mocksolver = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}(), evalobjective=false)
         # Tests the solver= keyword.
-        m = Model(mode = JuMP.Automatic, optimizer = mocksolver)
+        m = Model(with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}(), evalobjective=false), caching_mode = MOIU.Automatic)
         @variable(m, x == 1.0, Int)
         @variable(m, y, Bin)
         @objective(m, Max, x)
@@ -140,12 +139,13 @@
 
         MOIU.attachoptimizer!(m)
 
-        MOI.set!(mocksolver, MOI.TerminationStatus(), MOI.Success)
-        MOI.set!(mocksolver, MOI.ObjectiveValue(), 1.0)
-        MOI.set!(mocksolver, MOI.ResultCount(), 1)
-        MOI.set!(mocksolver, MOI.PrimalStatus(), MOI.FeasiblePoint)
-        MOI.set!(mocksolver, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
-        MOI.set!(mocksolver, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
+        mockoptimizer = JuMP.caching_optimizer(m).optimizer
+        MOI.set!(mockoptimizer, MOI.TerminationStatus(), MOI.Success)
+        MOI.set!(mockoptimizer, MOI.ObjectiveValue(), 1.0)
+        MOI.set!(mockoptimizer, MOI.ResultCount(), 1)
+        MOI.set!(mockoptimizer, MOI.PrimalStatus(), MOI.FeasiblePoint)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
 
         JuMP.optimize(m)
 
@@ -186,20 +186,20 @@
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.caching_optimizer(m).model_cache, model, ["x","y"], ["c1", "c2", "c3"])
 
-        mocksolver = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}(), evalobjective=false)
-        MOIU.resetoptimizer!(m, mocksolver)
+        mockoptimizer = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}(), evalobjective=false)
+        MOIU.resetoptimizer!(m, mockoptimizer)
         MOIU.attachoptimizer!(m)
 
-        MOI.set!(mocksolver, MOI.TerminationStatus(), MOI.Success)
-        MOI.set!(mocksolver, MOI.ObjectiveValue(), -1.0)
-        MOI.set!(mocksolver, MOI.ResultCount(), 1)
-        MOI.set!(mocksolver, MOI.PrimalStatus(), MOI.FeasiblePoint)
-        MOI.set!(mocksolver, MOI.DualStatus(), MOI.FeasiblePoint)
-        MOI.set!(mocksolver, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
-        MOI.set!(mocksolver, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
-        MOI.set!(mocksolver, MOI.ConstraintDual(), JuMP.optimizerindex(c1), -1.0)
-        MOI.set!(mocksolver, MOI.ConstraintDual(), JuMP.optimizerindex(c2), 2.0)
-        MOI.set!(mocksolver, MOI.ConstraintDual(), JuMP.optimizerindex(c3), 3.0)
+        MOI.set!(mockoptimizer, MOI.TerminationStatus(), MOI.Success)
+        MOI.set!(mockoptimizer, MOI.ObjectiveValue(), -1.0)
+        MOI.set!(mockoptimizer, MOI.ResultCount(), 1)
+        MOI.set!(mockoptimizer, MOI.PrimalStatus(), MOI.FeasiblePoint)
+        MOI.set!(mockoptimizer, MOI.DualStatus(), MOI.FeasiblePoint)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(c1), -1.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(c2), 2.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(c3), 3.0)
 
         JuMP.optimize(m)
 
@@ -244,19 +244,19 @@
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.caching_optimizer(m).model_cache, model, ["x","y","z"], ["varsoc", "affsoc", "rotsoc"])
 
-        mocksolver = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}(), evalobjective=false)
-        MOIU.resetoptimizer!(m, mocksolver)
+        mockoptimizer = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}(), evalobjective=false)
+        MOIU.resetoptimizer!(m, mockoptimizer)
         MOIU.attachoptimizer!(m)
 
-        MOI.set!(mocksolver, MOI.TerminationStatus(), MOI.Success)
-        MOI.set!(mocksolver, MOI.ResultCount(), 1)
-        MOI.set!(mocksolver, MOI.PrimalStatus(), MOI.FeasiblePoint)
-        MOI.set!(mocksolver, MOI.DualStatus(), MOI.FeasiblePoint)
-        MOI.set!(mocksolver, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
-        MOI.set!(mocksolver, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
-        MOI.set!(mocksolver, MOI.VariablePrimal(), JuMP.optimizerindex(z), 0.0)
-        MOI.set!(mocksolver, MOI.ConstraintDual(), JuMP.optimizerindex(varsoc), [-1.0,-2.0,-3.0])
-        MOI.set!(mocksolver, MOI.ConstraintDual(), JuMP.optimizerindex(affsoc), [1.0,2.0,3.0])
+        MOI.set!(mockoptimizer, MOI.TerminationStatus(), MOI.Success)
+        MOI.set!(mockoptimizer, MOI.ResultCount(), 1)
+        MOI.set!(mockoptimizer, MOI.PrimalStatus(), MOI.FeasiblePoint)
+        MOI.set!(mockoptimizer, MOI.DualStatus(), MOI.FeasiblePoint)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(z), 0.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(varsoc), [-1.0,-2.0,-3.0])
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(affsoc), [1.0,2.0,3.0])
 
         JuMP.optimize(m)
 
@@ -300,19 +300,19 @@
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.caching_optimizer(m).model_cache, model, ["x11","x12","x22"], ["varpsd", "conpsd"])
 
-        mocksolver = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}(), evalobjective=false)
-        MOIU.resetoptimizer!(m, mocksolver)
+        mockoptimizer = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}(), evalobjective=false)
+        MOIU.resetoptimizer!(m, mockoptimizer)
         MOIU.attachoptimizer!(m)
 
-        MOI.set!(mocksolver, MOI.TerminationStatus(), MOI.Success)
-        MOI.set!(mocksolver, MOI.ResultCount(), 1)
-        MOI.set!(mocksolver, MOI.PrimalStatus(), MOI.FeasiblePoint)
-        MOI.set!(mocksolver, MOI.DualStatus(), MOI.FeasiblePoint)
-        MOI.set!(mocksolver, MOI.VariablePrimal(), JuMP.optimizerindex(x[1,1]), 1.0)
-        MOI.set!(mocksolver, MOI.VariablePrimal(), JuMP.optimizerindex(x[1,2]), 2.0)
-        MOI.set!(mocksolver, MOI.VariablePrimal(), JuMP.optimizerindex(x[2,2]), 4.0)
-        MOI.set!(mocksolver, MOI.ConstraintDual(), JuMP.optimizerindex(varpsd), [1.0,2.0,3.0])
-        MOI.set!(mocksolver, MOI.ConstraintDual(), JuMP.optimizerindex(conpsd), [4.0,5.0,6.0])
+        MOI.set!(mockoptimizer, MOI.TerminationStatus(), MOI.Success)
+        MOI.set!(mockoptimizer, MOI.ResultCount(), 1)
+        MOI.set!(mockoptimizer, MOI.PrimalStatus(), MOI.FeasiblePoint)
+        MOI.set!(mockoptimizer, MOI.DualStatus(), MOI.FeasiblePoint)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x[1,1]), 1.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x[1,2]), 2.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x[2,2]), 4.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(varpsd), [1.0,2.0,3.0])
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(conpsd), [4.0,5.0,6.0])
 
         JuMP.optimize(m)
 

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -90,7 +90,6 @@
         MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.UpperBoundRef(x)), 0.0)
         MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.LowerBoundRef(y)), 1.0)
 
-        @test_throws ErrorException JuMP.optimize(m, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}()))
         JuMP.optimize(m)
 
         #@test JuMP.isattached(m)
@@ -145,7 +144,6 @@
         MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
         MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
 
-        @test_throws ErrorException JuMP.optimize(m, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}()))
         JuMP.optimize(m)
 
         #@test JuMP.isattached(m)
@@ -324,5 +322,16 @@
         @test JuMP.hasresultdual(m, typeof(conpsd))
         @test JuMP.resultdual(conpsd) == [4.0,5.0,6.0]
 
+    end
+
+    @testset "Provide factory in `optimize` in Direct mode" begin
+        mockoptimizer = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}())
+        model = JuMP.direct_model(mockoptimizer)
+        @test_throws ErrorException JuMP.optimize(model, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}()))
+    end
+
+    @testset "Provide factory both in `Model` and `optimize`" begin
+        model = Model(with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}()))
+        @test_throws ErrorException JuMP.optimize(model, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}()))
     end
 end

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -90,6 +90,7 @@
         MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.UpperBoundRef(x)), 0.0)
         MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.LowerBoundRef(y)), 1.0)
 
+        @test_throws ErrorException JuMP.optimize(m, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}()))
         JuMP.optimize(m)
 
         #@test JuMP.isattached(m)
@@ -144,6 +145,7 @@
         MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
         MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
 
+        @test_throws ErrorException JuMP.optimize(m, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}()))
         JuMP.optimize(m)
 
         #@test JuMP.isattached(m)

--- a/test/model.jl
+++ b/test/model.jl
@@ -20,16 +20,14 @@ end
 @testset "Bridges" begin
     @testset "Automatic bridging" begin
         # optimizer not supporting Interval
-        optimizer = MOIU.MockOptimizer(LPModel{Float64}());
-        model = Model(optimizer=optimizer)
+        model = Model(with_optimizer(MOIU.MockOptimizer, LPModel{Float64}()))
         @variable model x
         cref = @constraint model 0 <= x + 1 <= 1
         @test cref isa JuMP.ConstraintRef{JuMP.Model,MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.Interval{Float64}}}
         JuMP.optimize(model)
     end
     @testset "Automatic bridging disabled with `bridge_constraints` keyword" begin
-        optimizer = MOIU.MockOptimizer(LPModel{Float64}());
-        model = Model(optimizer=optimizer, bridge_constraints=false)
+        model = Model(with_optimizer(MOIU.MockOptimizer, LPModel{Float64}()), bridge_constraints=false)
         @test model.moibackend isa MOIU.CachingOptimizer
         @test model.moibackend === JuMP.caching_optimizer(model)
         @variable model x
@@ -37,8 +35,8 @@ end
         @test_throws ErrorException JuMP.optimize(model)
     end
     @testset "No bridge automatically added in Direct mode" begin
-        optimizer = MOIU.MockOptimizer(LPModel{Float64}());
-        model = Model(backend=optimizer, mode=JuMP.Direct)
+        optimizer = MOIU.MockOptimizer(LPModel{Float64}())
+        model = JuMP.direct_model(optimizer)
         @variable model x
         @test_throws MethodError @constraint model 0 <= x + 1 <= 1
     end

--- a/test/nlp_solver.jl
+++ b/test/nlp_solver.jl
@@ -38,7 +38,7 @@ const MOI = MathOptInterface
         #     1 <= x1, x2, x3, x4 <= 5
         # Start at (1,5,5,1)
         # End at (1.000..., 4.743..., 3.821..., 1.379...)
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
         initval = [1,5,5,1]
         @variable(m, 1 <= x[i=1:4] <= 5, start=initval[i])
         @NLobjective(m, Min, x[1]*x[4]*(x[1]+x[2]+x[3]) + x[3])
@@ -63,7 +63,7 @@ const MOI = MathOptInterface
         #     1 <= x1, x2, x3, x4 <= 5
         # Start at (1,5,5,1)
         # End at (1.000..., 4.743..., 3.821..., 1.379...)
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
         initval = [1,5,5,1]
         @variable(m, 1 <= x[i=1:4] <= 5, start=initval[i])
         JuMP.setNLobjective(m, :Min, :($(x[1])*$(x[4])*($(x[1])+$(x[2])+$(x[3])) + $(x[3])))
@@ -89,7 +89,7 @@ const MOI = MathOptInterface
         L = [0.0, 0.0, -0.55, -0.55, 196, 196, 196, -400, -400]
         U = [Inf, Inf,  0.55,  0.55, 252, 252, 252,  800,  800]
 
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
         @variable(m, L[i] <= x[i=1:9] <= U[i], start = 0.0)
 
         @NLobjective(m, Min, 3 * x[1] + 1e-6 * x[1]^3 + 2 * x[2] + .522074e-6 * x[2]^3)
@@ -129,7 +129,7 @@ const MOI = MathOptInterface
     end
 
     @testset "HS110" begin
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
         @variable(m, -2.001 <= x[1:10] <= 9.999, start = 9)
 
         @NLobjective(m, Min,
@@ -150,7 +150,7 @@ const MOI = MathOptInterface
     @testset "HS111" begin
         c = [-6.089, -17.164, -34.054, -5.914, -24.721, -14.986, -24.100, -10.708, -26.662, -22.179]
 
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
         @variable(m, -100 <= x[1:10] <= 100, start = -2.3)
 
         @NLobjective(m, Min,
@@ -172,7 +172,7 @@ const MOI = MathOptInterface
     @testset "HS112" begin
         c = [-6.089, -17.164, -34.054, -5.914, -24.721, -14.986, -24.100, -10.708, -26.662, -22.179]
 
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
         @variable(m, x[1:10] >= 1e-6, start = 0.1)
 
         @NLobjective(m, Min, sum(x[j]*(c[j] + log(x[j]/sum(x[k] for k=1:10))) for j=1:10))
@@ -199,7 +199,7 @@ const MOI = MathOptInterface
         upper = [2000, 16000, 120, 5000, 2000, 93, 95, 12, 4, 162]
         start = [1745, 12000, 110, 3048, 1974, 89.2, 92.8, 8, 3.6, 145]
 
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
         @variable(m, lower[i] <= x[i=1:n] <= upper[i], start = start[i])
 
         @NLobjective(m, Min, 5.04*x[1] + .035*x[2] + 10*x[3] + 3.36*x[5] - .063*x[4]*x[7])
@@ -238,7 +238,7 @@ const MOI = MathOptInterface
         upper = [1.0, 1.0, 1.0, 0.1, 0.9, 0.9, 1000, 1000, 1000, 500, 150, 150, 150, Inf, Inf, Inf]
         start = [0.5  2 0.8  3 0.9  4 0.1  5 0.14  6 0.5  7 489  8 80  9 650 0.5  2 0.8  3 0.9  4 0.1  5 0.14  6 0.5  7 489  8 80  9 650]
 
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
         @variable(m, lower[i] <= x[i=1:N] <= upper[i], start = start[i])
         @NLobjective(m, Min, x[11] + x[12] + x[13])
 
@@ -273,7 +273,7 @@ const MOI = MathOptInterface
     end
 
     @testset "HS118" begin
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
 
         L = zeros(15)
         L[1] =  8.0
@@ -341,7 +341,7 @@ const MOI = MathOptInterface
     end
 
     @testset "Two-sided constraints" begin
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
         @variable(m, x)
         @NLobjective(m, Max, x)
         l = -1
@@ -364,7 +364,7 @@ const MOI = MathOptInterface
     end
 
     @testset "Two-sided constraints (no macros)" begin
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
         @variable(m, x)
         JuMP.setNLobjective(m, :Max, x)
         l = -1
@@ -387,7 +387,7 @@ const MOI = MathOptInterface
     end
 
     @testset "Duals" begin
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
         @variable(m, x >= 0)
         @variable(m, y <= 5)
         @variable(m, 2 <= z <= 4)
@@ -443,7 +443,7 @@ const MOI = MathOptInterface
     end
 
     @testset "Quadratic inequality constraints, linear objective" begin
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
         @variable(m, -2 <= x <= 2)
         @variable(m, -2 <= y <= 2)
         @objective(m, Min, x - y)
@@ -458,7 +458,7 @@ const MOI = MathOptInterface
     end
 
     @testset "Quadratic inequality constraints, NL objective" begin
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
         @variable(m, -2 <= x <= 2)
         @variable(m, -2 <= y <= 2)
         @NLobjective(m, Min, x - y)
@@ -473,7 +473,7 @@ const MOI = MathOptInterface
     end
 
     @testset "Quadratic equality constraints" begin
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
         @variable(m, 0 <= x[1:2] <= 1)
         @constraint(m, x[1]^2 + x[2]^2 == 1/2)
         @NLobjective(m, Max, x[1] - x[2])
@@ -487,7 +487,7 @@ const MOI = MathOptInterface
     end
 
     @testset "Fixed variables" begin
-        m = Model(with_optimizer(IpoptOptimize, print_level=0))
+        m = Model(with_optimizer(IpoptOptimizer, print_level=0))
         @variable(m, x == 0)
         @variable(m, y ≥ 0)
         @objective(m, Min, y)

--- a/test/nlp_solver.jl
+++ b/test/nlp_solver.jl
@@ -27,8 +27,6 @@ using Compat.Test
 using MathOptInterface
 const MOI = MathOptInterface
 
-new_optimizer() = IpoptOptimizer(print_level=0)
-
 @testset "NLP solver tests" begin
 
     @testset "HS071" begin
@@ -40,7 +38,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
         #     1 <= x1, x2, x3, x4 <= 5
         # Start at (1,5,5,1)
         # End at (1.000..., 4.743..., 3.821..., 1.379...)
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
         initval = [1,5,5,1]
         @variable(m, 1 <= x[i=1:4] <= 5, start=initval[i])
         @NLobjective(m, Min, x[1]*x[4]*(x[1]+x[2]+x[3]) + x[3])
@@ -65,7 +63,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
         #     1 <= x1, x2, x3, x4 <= 5
         # Start at (1,5,5,1)
         # End at (1.000..., 4.743..., 3.821..., 1.379...)
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
         initval = [1,5,5,1]
         @variable(m, 1 <= x[i=1:4] <= 5, start=initval[i])
         JuMP.setNLobjective(m, :Min, :($(x[1])*$(x[4])*($(x[1])+$(x[2])+$(x[3])) + $(x[3])))
@@ -91,7 +89,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
         L = [0.0, 0.0, -0.55, -0.55, 196, 196, 196, -400, -400]
         U = [Inf, Inf,  0.55,  0.55, 252, 252, 252,  800,  800]
 
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
         @variable(m, L[i] <= x[i=1:9] <= U[i], start = 0.0)
 
         @NLobjective(m, Min, 3 * x[1] + 1e-6 * x[1]^3 + 2 * x[2] + .522074e-6 * x[2]^3)
@@ -131,7 +129,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
     end
 
     @testset "HS110" begin
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
         @variable(m, -2.001 <= x[1:10] <= 9.999, start = 9)
 
         @NLobjective(m, Min,
@@ -152,7 +150,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
     @testset "HS111" begin
         c = [-6.089, -17.164, -34.054, -5.914, -24.721, -14.986, -24.100, -10.708, -26.662, -22.179]
 
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
         @variable(m, -100 <= x[1:10] <= 100, start = -2.3)
 
         @NLobjective(m, Min,
@@ -174,7 +172,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
     @testset "HS112" begin
         c = [-6.089, -17.164, -34.054, -5.914, -24.721, -14.986, -24.100, -10.708, -26.662, -22.179]
 
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
         @variable(m, x[1:10] >= 1e-6, start = 0.1)
 
         @NLobjective(m, Min, sum(x[j]*(c[j] + log(x[j]/sum(x[k] for k=1:10))) for j=1:10))
@@ -201,7 +199,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
         upper = [2000, 16000, 120, 5000, 2000, 93, 95, 12, 4, 162]
         start = [1745, 12000, 110, 3048, 1974, 89.2, 92.8, 8, 3.6, 145]
 
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
         @variable(m, lower[i] <= x[i=1:n] <= upper[i], start = start[i])
 
         @NLobjective(m, Min, 5.04*x[1] + .035*x[2] + 10*x[3] + 3.36*x[5] - .063*x[4]*x[7])
@@ -240,7 +238,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
         upper = [1.0, 1.0, 1.0, 0.1, 0.9, 0.9, 1000, 1000, 1000, 500, 150, 150, 150, Inf, Inf, Inf]
         start = [0.5  2 0.8  3 0.9  4 0.1  5 0.14  6 0.5  7 489  8 80  9 650 0.5  2 0.8  3 0.9  4 0.1  5 0.14  6 0.5  7 489  8 80  9 650]
 
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
         @variable(m, lower[i] <= x[i=1:N] <= upper[i], start = start[i])
         @NLobjective(m, Min, x[11] + x[12] + x[13])
 
@@ -275,7 +273,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
     end
 
     @testset "HS118" begin
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
 
         L = zeros(15)
         L[1] =  8.0
@@ -343,7 +341,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
     end
 
     @testset "Two-sided constraints" begin
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
         @variable(m, x)
         @NLobjective(m, Max, x)
         l = -1
@@ -366,7 +364,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
     end
 
     @testset "Two-sided constraints (no macros)" begin
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
         @variable(m, x)
         JuMP.setNLobjective(m, :Max, x)
         l = -1
@@ -389,7 +387,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
     end
 
     @testset "Duals" begin
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
         @variable(m, x >= 0)
         @variable(m, y <= 5)
         @variable(m, 2 <= z <= 4)
@@ -445,7 +443,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
     end
 
     @testset "Quadratic inequality constraints, linear objective" begin
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
         @variable(m, -2 <= x <= 2)
         @variable(m, -2 <= y <= 2)
         @objective(m, Min, x - y)
@@ -460,7 +458,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
     end
 
     @testset "Quadratic inequality constraints, NL objective" begin
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
         @variable(m, -2 <= x <= 2)
         @variable(m, -2 <= y <= 2)
         @NLobjective(m, Min, x - y)
@@ -475,7 +473,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
     end
 
     @testset "Quadratic equality constraints" begin
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
         @variable(m, 0 <= x[1:2] <= 1)
         @constraint(m, x[1]^2 + x[2]^2 == 1/2)
         @NLobjective(m, Max, x[1] - x[2])
@@ -489,7 +487,7 @@ new_optimizer() = IpoptOptimizer(print_level=0)
     end
 
     @testset "Fixed variables" begin
-        m = Model(optimizer=new_optimizer())
+        m = Model(with_optimizer(IpoptOptimize, print_level=0))
         @variable(m, x == 0)
         @variable(m, y ≥ 0)
         @objective(m, Min, y)


### PR DESCRIPTION
New constructor interface as discussed [here](https://docs.google.com/document/d/1knl5tOg4WW6xqy2TRgAcWoy9lb4fqggm-qh2XEk8q9Q/).
Factories allow to create new optimizers on demand which would allow implementing copy (https://github.com/JuliaOpt/JuMP.jl/issues/1381, https://github.com/JuliaOpt/JuMP.jl/issues/1300) without the need for any change in MOI like https://github.com/JuliaOpt/MathOptInterface.jl/pull/387.