### PR TITLE
First pass of printing for MOI constraints.

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -281,6 +281,7 @@ Base.isempty(::AbstractJuMPScalar) = false
 ##########################################################################
 # Constraint
 # Holds the index of a constraint in a Model.
+# TODO: Rename "m" field (breaks style guidelines).
 struct ConstraintRef{M<:AbstractModel,C}
     m::M
     index::C

--- a/src/print.jl
+++ b/src/print.jl
@@ -146,7 +146,7 @@ wrap_in_inline_math_mode(str) = "\$ $str \$"
 #------------------------------------------------------------------------
 ## Model
 #------------------------------------------------------------------------
-function Base.show(io::IO, model::Model) # TODO temporary
+function Base.show(io::IO, model::Model) # TODO(#1180) temporary
     print(io, "A JuMP Model")
 end
 
@@ -169,7 +169,7 @@ function var_string(::Type{IJuliaMode}, v::AbstractVariableRef)
     var_name = name(v)
     if !isempty(var_name)
         # TODO: This is wrong if variable name constains extra "]"
-        return replace(replace(var_name,"[","_{",1),"]","}")
+        return replace(replace(var_name, "[", "_{", 1), "]", "}")
     else
         return "noname"
     end
@@ -177,7 +177,7 @@ end
 
 Base.show(io::IO, a::GenericAffExpr) = print(io, aff_string(REPLMode,a))
 function Base.show(io::IO, ::MIME"text/latex", a::GenericAffExpr)
-    print(io, wrap_in_math_mode(aff_string(IJuliaMode,a)))
+    print(io, wrap_in_math_mode(aff_string(IJuliaMode, a)))
 end
 
 function aff_string(mode, a::GenericAffExpr, show_constant=true)
@@ -186,7 +186,7 @@ function aff_string(mode, a::GenericAffExpr, show_constant=true)
         return show_constant ? string_round(a.constant) : "0"
     end
 
-    term_str = Array{String}(undef,2*length(linearterms(a)))
+    term_str = Array{String}(undef, 2 * length(linearterms(a)))
     elm = 1
     # For each non-zero for this model
     for (coef, var) in linearterms(a)
@@ -194,8 +194,8 @@ function aff_string(mode, a::GenericAffExpr, show_constant=true)
 
         pre = is_one_for_printing(coef) ? "" : string_round(abs(coef)) * " "
 
-        term_str[2*elm-1] = sign_string(coef)
-        term_str[2*elm  ] = string(pre, var_string(mode, var))
+        term_str[2 * elm - 1] = sign_string(coef)
+        term_str[2 * elm] = string(pre, var_string(mode, var))
         elm += 1
     end
 
@@ -206,7 +206,7 @@ function aff_string(mode, a::GenericAffExpr, show_constant=true)
     else
         # Correction for very first term - don't want a " + "/" - "
         term_str[1] = (term_str[1] == " - ") ? "-" : ""
-        ret = join(term_str[1:2*(elm-1)])
+        ret = join(term_str[1 : 2 * (elm - 1)])
         if !is_zero_for_printing(a.constant) && show_constant
             ret = string(ret, sign_string(a.constant),
                          string_round(abs(a.constant)))
@@ -220,14 +220,14 @@ end
 #------------------------------------------------------------------------
 Base.show(io::IO, q::GenericQuadExpr) = print(io, quad_string(REPLMode,q))
 function Base.show(io::IO, ::MIME"text/latex", q::GenericQuadExpr)
-    print(io, wrap_in_math_mode(quad_string(IJuliaMode,q)))
+    print(io, wrap_in_math_mode(quad_string(IJuliaMode, q)))
 end
 
 function quad_string(mode, q::GenericQuadExpr)
-    length(quadterms(q)) == 0 && return aff_string(mode,q.aff)
+    length(quadterms(q)) == 0 && return aff_string(mode, q.aff)
 
     # Odd terms are +/i, even terms are the variables/coeffs
-    term_str = Array{String}(undef,2*length(quadterms(q)))
+    term_str = Array{String}(undef, 2 * length(quadterms(q)))
     elm = 1
     if length(term_str) > 0
         for (coef, var1, var2) in quadterms(q)
@@ -238,12 +238,12 @@ function quad_string(mode, q::GenericQuadExpr)
             x = var_string(mode,var1)
             y = var_string(mode,var2)
 
-            term_str[2*elm-1] = sign_string(coef)
-            term_str[2*elm  ] = "$pre$x"
+            term_str[2 * elm - 1] = sign_string(coef)
+            term_str[2 * elm] = "$pre$x"
             if x == y
-                term_str[2*elm] *= math_symbol(mode, :sq)
+                term_str[2 * elm] *= math_symbol(mode, :sq)
             else
-                term_str[2*elm] *= string(math_symbol(mode, :times), y)
+                term_str[2 * elm] *= string(math_symbol(mode, :times), y)
             end
             if elm == 1
                 # Correction for first term as there is no space
@@ -253,14 +253,14 @@ function quad_string(mode, q::GenericQuadExpr)
             elm += 1
         end
     end
-    ret = join(term_str[1:2*(elm-1)])
+    ret = join(term_str[1 : 2 * (elm - 1)])
 
     aff_str = aff_string(mode, q.aff)
     if aff_str == "0"
         return ret
     else
         if aff_str[1] == '-'
-            return string(ret, " - ", aff_str[2:end])
+            return string(ret, " - ", aff_str[2 : end])
         else
             return string(ret, " + ", aff_str)
         end
@@ -354,8 +354,8 @@ end
 #------------------------------------------------------------------------
 function nl_expr_string(model::Model, mode, c::NonlinearExprData)
     return string(tape_to_expr(model, 1, c.nd, adjmat(c.nd), c.const_values, [],
-                             [], model.nlpdata.user_operators, false, false,
-                             mode))
+                               [], model.nlpdata.user_operators, false, false,
+                               mode))
 end
 
 #------------------------------------------------------------------------

--- a/src/print.jl
+++ b/src/print.jl
@@ -283,8 +283,6 @@ function Base.show(io::IO, ::MIME"text/latex", ref::ConstraintRef{Model})
     print(io, constraint_string(IJuliaMode, constraint_name, constraint_object))
 end
 
-# TODO: Print SingleVariableConstraint, VectorOfVariablesConstraint, AffExprConstraint, VectorAffExprConstraint, QuadExprConstraint
-
 function function_string(print_mode, variable::AbstractVariableRef)
     return var_string(print_mode, variable)
 end

--- a/test/old/print.jl
+++ b/test/old/print.jl
@@ -441,47 +441,6 @@ end
      * 1 linear constraint
      * 1 variable
     Solver is default solver""", repl=:show)
-
-        #------------------------------------------------------------------
-
-        mod_3 = Model()
-
-        @variable(mod_3, y[1:5])
-        @NLparameter(mod_3, p == 10)
-        @NLexpression(mod_3, ex, y[2])
-        @NLconstraint(mod_3, y[1]*y[2] == 1)
-        @NLconstraint(mod_3, y[3]*y[4] == 1)
-        @NLconstraint(mod_3, y[5]*y[1] - ex == 1)
-
-        @NLobjective(mod_3, Min, y[1]*y[3] - p)
-
-        io_test(REPLMode, p, "\"Reference to nonlinear parameter #1\"")
-        io_test(REPLMode, ex, "\"Reference to nonlinear expression #1\"")
-
-        io_test(REPLMode, mod_3, """
-    Min y[1] * y[3] - parameter[1]
-    Subject to
-     y[1] * y[2] - 1.0 $eq 0
-     y[3] * y[4] - 1.0 $eq 0
-     (y[5] * y[1] - subexpression[1]) - 1.0 $eq 0
-     y[i] $fa i $inset {1,2,3,4,5}
-    subexpression[1]: y[2]
-    """, repl=:print)
-        io_test(REPLMode, mod_3, """
-    Minimization problem with:
-     * 0 linear constraints
-     * 3 nonlinear constraints
-     * 5 variables
-    Solver is default solver""", repl=:show)
-        io_test(IJuliaMode, mod_3, """
-    \\begin{alignat*}{1}\\min\\quad & y_{1} * y_{3} - parameter_{1}\\\\
-    \\text{Subject to} \\quad & y_{1} * y_{2} - 1.0 = 0\\\\
-     & y_{3} * y_{4} - 1.0 = 0\\\\
-     & (y_{5} * y_{1} - subexpression_{1}) - 1.0 = 0\\\\
-     & y_{i} \\quad\\forall i \\in \\{1,2,3,4,5\\}\\\\
-    subexpression_{1} = \\quad &y_{2}\\\\
-    \\end{alignat*}
-    """, repl=:print)
     end
 
     @testset "changing variable categories" begin

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -11,15 +11,13 @@
 # Testing for VariableRef
 #############################################################################
 using JuMP
-import JuMP.repl
 using Compat
 using Compat.Test
 
 function variables_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::Type{<:JuMP.AbstractVariableRef})
     AffExprType = JuMP.GenericAffExpr{Float64, VariableRefType}
 
-    @testset "constructors" begin
-        # Constructors
+    @testset "Constructors" begin
         mcon = ModelType()
 
         @testset "No bound" begin


### PR DESCRIPTION
Feels like I've untangled the printing rat's nest. JuMP `ConstraintRef` objects now print out the underlying constraint. There's obvious room for improvement, especially in how constraint sets print out (like, print fancy versions in IJulia). See the tests for example of what the print-out looks like. I also print the constraint name if it's non-empty.

Does not yet resolve the issue #1180 because we need to decide what model printing should look like. Based on #957 we might want to print a summary by default and have another method to get the extensive-form print-out of the model.

@IainNZ, care to review since you did most of the original printing work?