### PR TITLE
Add shape concept

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -370,7 +370,7 @@ Base.isempty(::AbstractJuMPScalar) = false
 """
     AbstractShape
 
-Abstract vectorizable shape. Given a vectorized form of an object of shape
+Abstract vectorizable shape. Given a flat vector form of an object of shape
 `shape`, the original object can be obtained by [`reshape`](@ref).
 """
 abstract type AbstractShape end
@@ -425,10 +425,10 @@ Return an object in it original shape `shape` given its vectorized form
 
 ## Examples
 
-Given a [`SymmetricMatrix`](@ref) of vectorized form `[1, 2, 3]`, the following
-code retrieve the matrix `Symmetric(Matrix[1 2; 2 3])`:
+Given a [`SymmetricMatrixShape`](@ref) of vectorized form `[1, 2, 3]`, the
+following code retrieve the matrix `Symmetric(Matrix[1 2; 2 3])`:
 ```julia
-reshape([1, 2, 3], SymmetricMatrix(2))
+reshape([1, 2, 3], SymmetricMatrixShape(2))
 ```
 """
 function reshape end
@@ -577,8 +577,7 @@ false if not.
 MOI.canget(m::Model, attr::MOI.AbstractModelAttribute) = MOI.canget(m.moibackend, attr)
 MOI.canget(m::Model, attr::MOI.AbstractVariableAttribute, ::Type{VariableRef}) = MOI.canget(m.moibackend, attr, MOIVAR)
 function MOI.canget(model::Model, attr::MOI.AbstractConstraintAttribute,
-                    ::Type{ConstraintRef{Model, T, Shape}}) where {T <: MOICON,
-                                                                   Shape}
+                    ::Type{<:ConstraintRef{Model, T, Shape}}) where {T <: MOICON}
     return MOI.canget(model.moibackend, attr, T)
 end
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -367,13 +367,103 @@ Base.next(x::AbstractJuMPScalar, state) = (x, true)
 Base.done(::AbstractJuMPScalar, state) = state
 Base.isempty(::AbstractJuMPScalar) = false
 
+"""
+    AbstractShape
+
+Abstract vectorizable shape. Given a vectorized form of an object of shape
+`shape`, the original object can be obtained by [`reshape`](@ref).
+"""
+abstract type AbstractShape end
+
+"""
+    dual_shape(shape::AbstractShape)::AbstractShape
+
+Returns the shape of the dual space of the space of objects of shape `shape`. By
+default, the `dual_shape` of a shape is itself. See the examples section below
+for an example for which this is not the case.
+
+## Examples
+
+Consider polynomial constraints for which the dual is moment constraints and
+moment constraints for which the dual is polynomial constraints. Shapes for
+polynomials can be defined as follows:
+```julia
+struct Polynomial
+    coefficients::Vector{Float64}
+    monomials::Vector{Monomial}
+end
+struct PolynomialShape <: JuMP.AbstractShape
+    monomials::Vector{Monomial}
+end
+JuMP.reshape(x::Vector, shape::PolynomialShape) = Polynomial(x, shape.monomials)
+```
+and a shape for moments can be defined as follows:
+```julia
+struct Moments
+    coefficients::Vector{Float64}
+    monomials::Vector{Monomial}
+end
+struct MomentsShape <: JuMP.AbstractShape
+    monomials::Vector{Monomial}
+end
+JuMP.reshape(x::Vector, shape::MomentsShape) = Moments(x, shape.monomials)
+```
+The `dual_shape` allows to define the shape of the dual of polynomial and moment
+constraints:
+```julia
+dual_shape(shape::PolynomialShape) = MomentsShape(shape.monomials)
+dual_shape(shape::MomentsShape) = PolynomialShape(shape.monomials)
+```
+"""
+dual_shape(shape::AbstractShape) = shape
+
+"""
+    reshape(vectorized_form::Vector, shape::AbstractShape)
+
+Return an object in it original shape `shape` given its vectorized form
+`vectorized_form`.
+
+## Examples
+
+Given a [`SymmetricMatrix`](@ref) of vectorized form `[1, 2, 3]`, the following
+code retrieve the matrix `Symmetric(Matrix[1 2; 2 3])`:
+```julia
+reshape([1, 2, 3], SymmetricMatrix(2))
+```
+"""
+function reshape end
+
+"""
+    shape(c::AbstractConstraint)::AbstractShape
+
+Return the shape of the constraint `c`.
+"""
+function shape end
+
+"""
+    ScalarShape
+
+Shape of scalar constraints.
+"""
+struct ScalarShape <: AbstractShape end
+reshape(α, ::ScalarShape) = α
+
+"""
+    VectorShape
+
+Vector for which the vectorized form corresponds exactly to the vector given.
+"""
+struct VectorShape <: AbstractShape end
+reshape(vectorized_form, ::VectorShape) = vectorized_form
+
 ##########################################################################
 # Constraint
 # Holds the index of a constraint in a Model.
 # TODO: Rename "m" field (breaks style guidelines).
-struct ConstraintRef{M<:AbstractModel,C}
+struct ConstraintRef{M <: AbstractModel, C, Shape <: AbstractShape}
     m::M
     index::C
+    shape::Shape
 end
 
 # TODO: should model be a parameter here?
@@ -400,7 +490,7 @@ function addconstraint(m::Model, c::AbstractConstraint, name::String="")
         error("Constraints of type $(typeof(f))-in-$(typeof(s)) are not supported by the solver" * bridge_message)
     end
     cindex = MOI.addconstraint!(m.moibackend, f, s)
-    cref = ConstraintRef(m, cindex)
+    cref = ConstraintRef(m, cindex, shape(c))
     if !isempty(name)
         setname(cref, name)
     end
@@ -466,7 +556,7 @@ Use `hasresultdual` to check if a result exists before asking for values.
 Replaces `getdual` for most use cases.
 """
 function resultdual(cr::ConstraintRef{Model, <:MOICON})
-    MOI.get(cr.m, MOI.ConstraintDual(), cr)
+    reshape(MOI.get(cr.m, MOI.ConstraintDual(), cr), dual_shape(cr.shape))
 end
 
 """
@@ -486,7 +576,11 @@ false if not.
 """
 MOI.canget(m::Model, attr::MOI.AbstractModelAttribute) = MOI.canget(m.moibackend, attr)
 MOI.canget(m::Model, attr::MOI.AbstractVariableAttribute, ::Type{VariableRef}) = MOI.canget(m.moibackend, attr, MOIVAR)
-MOI.canget(m::Model, attr::MOI.AbstractConstraintAttribute, ::Type{ConstraintRef{Model,T}}) where {T <: MOICON} = MOI.canget(m.moibackend, attr, T)
+function MOI.canget(model::Model, attr::MOI.AbstractConstraintAttribute,
+                    ::Type{ConstraintRef{Model, T, Shape}}) where {T <: MOICON,
+                                                                   Shape}
+    return MOI.canget(model.moibackend, attr, T)
+end
 
 """
     get(m::JuMP.Model, attr::MathOptInterface.AbstractModelAttribute)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -577,7 +577,7 @@ false if not.
 MOI.canget(m::Model, attr::MOI.AbstractModelAttribute) = MOI.canget(m.moibackend, attr)
 MOI.canget(m::Model, attr::MOI.AbstractVariableAttribute, ::Type{VariableRef}) = MOI.canget(m.moibackend, attr, MOIVAR)
 function MOI.canget(model::Model, attr::MOI.AbstractConstraintAttribute,
-                    ::Type{<:ConstraintRef{Model, T, Shape}}) where {T <: MOICON}
+                    ::Type{<:ConstraintRef{Model, T}}) where {T <: MOICON}
     return MOI.canget(model.moibackend, attr, T)
 end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1443,7 +1443,7 @@ macro NLconstraint(m, x, extra...)
         code = quote
             c = NonlinearConstraint($(processNLExpr(m, lhs)), $lb, $ub)
             push!($esc_m.nlpdata.nlconstr, c)
-            $(refcall) = ConstraintRef($esc_m, NonlinearConstraintIndex(length($esc_m.nlpdata.nlconstr)))
+            $(refcall) = ConstraintRef($esc_m, NonlinearConstraintIndex(length($esc_m.nlpdata.nlconstr)), ScalarShape())
         end
     elseif isexpr(x, :comparison)
         # ranged row
@@ -1460,7 +1460,7 @@ macro NLconstraint(m, x, extra...)
             end
             c = NonlinearConstraint($(processNLExpr(m, x.args[3])), $(esc(lb)), $(esc(ub)))
             push!($esc_m.nlpdata.nlconstr, c)
-            $(refcall) = ConstraintRef($esc_m, NonlinearConstraintIndex(length($esc_m.nlpdata.nlconstr)))
+            $(refcall) = ConstraintRef($esc_m, NonlinearConstraintIndex(length($esc_m.nlpdata.nlconstr)), ScalarShape())
         end
     else
         # Unknown

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -226,6 +226,7 @@ struct QuadExprConstraint{V <: AbstractVariableRef, S <: MOI.AbstractScalarSet} 
 end
 
 moi_function_and_set(c::QuadExprConstraint) = (MOI.ScalarQuadraticFunction(c.func), c.set)
+shape(::QuadExprConstraint) = ScalarShape()
 
 function constraintobject(ref::ConstraintRef{Model, MOICON{FuncType, SetType}}) where
         {FuncType <: MOI.ScalarQuadraticFunction, SetType <: MOI.AbstractScalarSet}

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -1,19 +1,62 @@
 # Used in @constraint model x in PSDCone
 struct PSDCone end
 
+"""
+    SymmetricMatrix
+
+Symmetric square matrix of `side_dimension` rows and columns. The vectorized
+form contains the entries of the upper-right triangular part of the matrix given
+column by column (or equivalently, the entries of the lower-left triangular part
+given row by row).
+"""
+struct SymmetricMatrix <: AbstractShape
+    side_dimension::Int
+end
+function reshape(vectorized_form::Vector{T}, shape::SymmetricMatrix) where T
+    matrix = Matrix{T}(undef, shape.side_dimension, shape.side_dimension)
+    k = 0
+    for j in 1:shape.side_dimension
+        for i in 1:j
+            k += 1
+            matrix[j, i] = matrix[i, j] = vectorized_form[k]
+        end
+    end
+    return Symmetric(matrix)
+end
+
+"""
+    SquareMatrix
+
+Square matrix of `side_dimension` rows and columns. The vectorized form contains
+the entries of the the matrix given column by column (or equivalently, the
+entries of the lower-left triangular part given row by row).
+"""
+struct SquareMatrix <: AbstractShape
+    side_dimension::Int
+end
+function reshape(vectorized_form::Vector{T}, shape::SquareMatrix) where T
+    return Base.reshape(vectorized_form,
+                        shape.side_dimension,
+                        shape.side_dimension)
+end
+
 # Used by the @variable macro. It can also be used with the @constraint macro,
 # this allows to get the constraint reference, e.g.
 # @variable model x[1:2,1:2] Symmetric # x is Symmetric{VariableRef,Matrix{VariableRef}}
 # varpsd = @constraint model x in PSDCone()
 function buildconstraint(_error::Function, Q::Symmetric{V, Matrix{V}}, ::PSDCone) where V<:AbstractVariableRef
     n = Base.LinAlg.checksquare(Q)
-    VectorOfVariablesConstraint([Q[i, j] for j in 1:n for i in 1:j], MOI.PositiveSemidefiniteConeTriangle(n))
+    VectorOfVariablesConstraint([Q[i, j] for j in 1:n for i in 1:j],
+                                MOI.PositiveSemidefiniteConeTriangle(n),
+                                SymmetricMatrix(n))
 end
 # @variable model x[1:2,1:2] # x is Matrix{VariableRef}
 # varpsd = @constraint model x in PSDCone()
 function buildconstraint(_error::Function, Q::Matrix{<:AbstractVariableRef}, ::PSDCone)
     n = Base.LinAlg.checksquare(Q)
-    VectorOfVariablesConstraint(vec(Q), MOI.PositiveSemidefiniteConeSquare(n))
+    VectorOfVariablesConstraint(vec(Q),
+                                MOI.PositiveSemidefiniteConeSquare(n),
+                                SquareMatrix(n))
 end
 
 function buildconstraint(_error::Function, x::AbstractMatrix, ::PSDCone)
@@ -24,6 +67,7 @@ function buildconstraint(_error::Function, x::AbstractMatrix, ::PSDCone)
     # https://github.com/JuliaOpt/JuMP.jl/pull/1122#issuecomment-344980944
     @assert issymmetric(x)
     aff = [x[i, j] for j in 1:n for i in 1:j]
-    s = MOI.PositiveSemidefiniteConeTriangle(n)
-    return VectorAffExprConstraint(aff, s)
+    return VectorAffExprConstraint(aff,
+                                   MOI.PositiveSemidefiniteConeTriangle(n),
+                                   SymmetricMatrix(n))
 end

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -2,17 +2,17 @@
 struct PSDCone end
 
 """
-    SymmetricMatrix
+    SymmetricMatrixShape
 
-Symmetric square matrix of `side_dimension` rows and columns. The vectorized
-form contains the entries of the upper-right triangular part of the matrix given
-column by column (or equivalently, the entries of the lower-left triangular part
-given row by row).
+Shape object for a symmetric square matrix of `side_dimension` rows and columns.
+The vectorized form contains the entries of the upper-right triangular part of
+the matrix given column by column (or equivalently, the entries of the
+lower-left triangular part given row by row).
 """
-struct SymmetricMatrix <: AbstractShape
+struct SymmetricMatrixShape <: AbstractShape
     side_dimension::Int
 end
-function reshape(vectorized_form::Vector{T}, shape::SymmetricMatrix) where T
+function reshape(vectorized_form::Vector{T}, shape::SymmetricMatrixShape) where T
     matrix = Matrix{T}(undef, shape.side_dimension, shape.side_dimension)
     k = 0
     for j in 1:shape.side_dimension
@@ -25,16 +25,17 @@ function reshape(vectorized_form::Vector{T}, shape::SymmetricMatrix) where T
 end
 
 """
-    SquareMatrix
+    SquareMatrixShape
 
-Square matrix of `side_dimension` rows and columns. The vectorized form contains
-the entries of the the matrix given column by column (or equivalently, the
-entries of the lower-left triangular part given row by row).
+Shape object for a square matrix of `side_dimension` rows and columns. The
+vectorized form contains the entries of the the matrix given column by column
+(or equivalently, the entries of the lower-left triangular part given row by
+row).
 """
-struct SquareMatrix <: AbstractShape
+struct SquareMatrixShape <: AbstractShape
     side_dimension::Int
 end
-function reshape(vectorized_form::Vector{T}, shape::SquareMatrix) where T
+function reshape(vectorized_form::Vector{T}, shape::SquareMatrixShape) where T
     return Base.reshape(vectorized_form,
                         shape.side_dimension,
                         shape.side_dimension)
@@ -48,7 +49,7 @@ function buildconstraint(_error::Function, Q::Symmetric{V, Matrix{V}}, ::PSDCone
     n = Base.LinAlg.checksquare(Q)
     VectorOfVariablesConstraint([Q[i, j] for j in 1:n for i in 1:j],
                                 MOI.PositiveSemidefiniteConeTriangle(n),
-                                SymmetricMatrix(n))
+                                SymmetricMatrixShape(n))
 end
 # @variable model x[1:2,1:2] # x is Matrix{VariableRef}
 # varpsd = @constraint model x in PSDCone()
@@ -56,7 +57,7 @@ function buildconstraint(_error::Function, Q::Matrix{<:AbstractVariableRef}, ::P
     n = Base.LinAlg.checksquare(Q)
     VectorOfVariablesConstraint(vec(Q),
                                 MOI.PositiveSemidefiniteConeSquare(n),
-                                SquareMatrix(n))
+                                SquareMatrixShape(n))
 end
 
 function buildconstraint(_error::Function, x::AbstractMatrix, ::PSDCone)
@@ -69,5 +70,5 @@ function buildconstraint(_error::Function, x::AbstractMatrix, ::PSDCone)
     aff = [x[i, j] for j in 1:n for i in 1:j]
     return VectorAffExprConstraint(aff,
                                    MOI.PositiveSemidefiniteConeTriangle(n),
-                                   SymmetricMatrix(n))
+                                   SymmetricMatrixShape(n))
 end

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -182,7 +182,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         c = JuMP.constraintobject(cref)
         @test c.func == [x, z, y, w]
         @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
-        @test c.shape isa JuMP.SquareMatrix
+        @test c.shape isa JuMP.SquareMatrixShape
 
         @SDconstraint(m, cref, [x 1; 1 -y] ⪰ [1 x; x -2])
         @test JuMP.name(cref) == "cref"

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -191,7 +191,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         @test JuMP.isequal_canonical(c.func[2], 1-x)
         @test JuMP.isequal_canonical(c.func[3], 2-y)
         @test c.set == MOI.PositiveSemidefiniteConeTriangle(2)
-        @test c.shape isa JuMP.SymmetricMatrix
+        @test c.shape isa JuMP.SymmetricMatrixShape
 
         @SDconstraint(m, iref[i=1:2], 0 ⪯ [x+i x+y; x+y -y])
         for i in 1:2
@@ -201,7 +201,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
             @test JuMP.isequal_canonical(c.func[2], x+y)
             @test JuMP.isequal_canonical(c.func[3], -y)
             @test c.set == MOI.PositiveSemidefiniteConeTriangle(2)
-            @test c.shape isa JuMP.SymmetricMatrix
+            @test c.shape isa JuMP.SymmetricMatrixShape
         end
 
         # Should throw "ERROR: function JuMP.addconstraint does not accept keyword arguments"

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -182,6 +182,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         c = JuMP.constraintobject(cref)
         @test c.func == [x, z, y, w]
         @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
+        @test c.shape isa JuMP.SquareMatrix
 
         @SDconstraint(m, cref, [x 1; 1 -y] ⪰ [1 x; x -2])
         @test JuMP.name(cref) == "cref"
@@ -190,6 +191,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         @test JuMP.isequal_canonical(c.func[2], 1-x)
         @test JuMP.isequal_canonical(c.func[3], 2-y)
         @test c.set == MOI.PositiveSemidefiniteConeTriangle(2)
+        @test c.shape isa JuMP.SymmetricMatrix
 
         @SDconstraint(m, iref[i=1:2], 0 ⪯ [x+i x+y; x+y -y])
         for i in 1:2
@@ -199,6 +201,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
             @test JuMP.isequal_canonical(c.func[2], x+y)
             @test JuMP.isequal_canonical(c.func[3], -y)
             @test c.set == MOI.PositiveSemidefiniteConeTriangle(2)
+            @test c.shape isa JuMP.SymmetricMatrix
         end
 
         # Should throw "ERROR: function JuMP.addconstraint does not accept keyword arguments"

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -318,9 +318,11 @@
 
         @test JuMP.resultvalue.(x) == [1.0 2.0; 2.0 4.0]
         @test JuMP.hasresultdual(m, typeof(varpsd))
-        @test JuMP.resultdual(varpsd) == [1.0,2.0,3.0]
+        @test JuMP.resultdual(varpsd) isa Symmetric
+        @test JuMP.resultdual(varpsd) == [1.0 2.0; 2.0 3.0]
         @test JuMP.hasresultdual(m, typeof(conpsd))
-        @test JuMP.resultdual(conpsd) == [4.0,5.0,6.0]
+        @test JuMP.resultdual(conpsd) isa Symmetric
+        @test JuMP.resultdual(conpsd) == [4.0 5.0; 5.0 6.0]
 
     end
 


### PR DESCRIPTION
Every constraint should be mapped into a `Vector` in `MOI.AbstractVectorSet` to be given to MOI and then MOI returns a vector for `ConstraintPrimal` and `ConstraintDual`. However, when the user do
```julia
@constraint some_object in some_set
```
and `some_object` is not a vector, it is rather confusing to get a vector back as `ConstraintPrimal` and `ConstraintDual`. This is currently the case when constraining a matrix to be PSD. It used to return a matrix in JuMP v0.18 so this is currently blocking for JuMP v0.19.

One solution is to keep track of the original shape in an `AbstractShape` object and reshape it in `resultdual` and `resultvalue` (which is currently missing: https://github.com/JuliaOpt/JuMP.jl/issues/1394).
This solution has been implemented in this PR.