### PR TITLE
Add with_optimizer shortcut for Module.Optimizer

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -123,6 +123,15 @@ function with_optimizer(constructor::Type, args...; kwargs...)
     return OptimizerFactory(constructor, args, kwargs)
 end
 
+"""
+    with_optimizer(mod::Module, args...; kwargs...)
+
+Shortcut for `with_optimizer(mod.Optimizer, args..., kwargs...)`.
+"""
+function with_optimizer(mod::Module, args...; kwargs...)
+    return with_optimizer(mod.Optimizer, args...; kwargs...)
+end
+
 function (optimizer_factory::OptimizerFactory)()
     return optimizer_factory.constructor(optimizer_factory.args...;
                                          optimizer_factory.kwargs...)

--- a/test/model.jl
+++ b/test/model.jl
@@ -40,3 +40,20 @@ end
         @test_throws ErrorException @constraint model 0 <= x + 1 <= 1
     end
 end
+
+module TestOptimizerModule
+struct Optimizer
+    a::Int
+    b::Int
+end
+end
+
+@testset "Factories" begin
+    factory = with_optimizer(TestOptimizerModule, 1, 2)
+    @test factory.constructor == TestOptimizerModule.Optimizer
+    @test factory.args == (1, 2)
+    optimizer = factory()
+    @test optimizer isa TestOptimizerModule.Optimizer
+    @test optimizer.a == 1
+    @test optimizer.b == 2
+end


### PR DESCRIPTION
For solvers following the guideline: https://github.com/JuliaOpt/MathOptInterface.jl/issues/425#issuecomment-409707912, this PR allows to write `with_optimizer(CSDP)` instead of `with_optimizer(CSDP.Optimizer)`