### PR TITLE
[release-0.18] more fixes for 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
-MathProgBase 0.6
-ReverseDiffSparse 0.8
-ForwardDiff 0.5
+MathProgBase 0.6 0.8
+ReverseDiffSparse 0.8 0.9
+ForwardDiff 0.5 0.8
 Calculus
-Compat 0.49
+Compat 1.0.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
-MathProgBase 0.6 0.8
-ReverseDiffSparse 0.8 0.9
-ForwardDiff 0.5 0.8
+MathProgBase 0.6
+ReverseDiffSparse 0.8
+ForwardDiff 0.5
 Calculus
 Compat 0.49

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -336,8 +336,14 @@ abstract type AbstractConstraint end
 # In JuMP, used only for Variable. Useful primarily for extensions
 abstract type AbstractJuMPScalar end
 
-Base.iterate(x::AbstractJuMPScalar) = (x, true)
-Base.iterate(x::AbstractJuMPScalar, state) = nothing
+if VERSION < v"0.7-"
+    Base.start(::AbstractJuMPScalar) = false
+    Base.next(x::AbstractJuMPScalar, state) = (x, true)
+    Base.done(::AbstractJuMPScalar, state) = state
+else
+    Base.iterate(x::AbstractJuMPScalar) = (x, true)
+    Base.iterate(x::AbstractJuMPScalar, state) = nothing
+end
 Base.isempty(::AbstractJuMPScalar) = false
 
 #############################################################################

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -7,9 +7,7 @@
 # An algebraic modeling language for Julia
 # See http://github.com/JuliaOpt/JuMP.jl
 #############################################################################
-
-__precompile__()
-
+VERSION < v"0.7.0-beta2.199" && __precompile__()
 module JuMP
 
 import Base.map
@@ -338,9 +336,8 @@ abstract type AbstractConstraint end
 # In JuMP, used only for Variable. Useful primarily for extensions
 abstract type AbstractJuMPScalar end
 
-Base.start(::AbstractJuMPScalar) = false
-Base.next(x::AbstractJuMPScalar, state) = (x, true)
-Base.done(::AbstractJuMPScalar, state) = state
+Base.iterate(x::AbstractJuMPScalar) = (x, true)
+Base.iterate(x::AbstractJuMPScalar, state) = nothing
 Base.isempty(::AbstractJuMPScalar) = false
 
 #############################################################################

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -202,8 +202,14 @@ Base.values(d::JuMPArray) = ValueIterator(d.innerArray)
 mutable struct ValueIterator{T,N}
     x::Array{T,N}
 end
-Base.iterate(it::ValueIterator) = iterate(it.x)
-Base.iterate(it::ValueIterator, k) = iterate(it.x, k)
+if VERSION < v"0.7-"
+    Base.start(it::ValueIterator)   =  start(it.x)
+    Base.next(it::ValueIterator, k) =   next(it.x, k)
+    Base.done(it::ValueIterator, k) =   done(it.x, k)
+else
+    Base.iterate(it::ValueIterator) = iterate(it.x)
+    Base.iterate(it::ValueIterator, k) = iterate(it.x, k)
+end
 Base.length(it::ValueIterator) = length(it.x)
 
 mutable struct KeyIterator{JA<:JuMPArray}

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -202,10 +202,9 @@ Base.values(d::JuMPArray) = ValueIterator(d.innerArray)
 mutable struct ValueIterator{T,N}
     x::Array{T,N}
 end
-Base.start(it::ValueIterator)   =  start(it.x)
-Base.next(it::ValueIterator, k) =   next(it.x, k)
-Base.done(it::ValueIterator, k) =   done(it.x, k)
-Base.length(it::ValueIterator)  = length(it.x)
+Base.iterate(it::ValueIterator) = iterate(it.x)
+Base.iterate(it::ValueIterator, k) = iterate(it.x, k)
+Base.length(it::ValueIterator) = length(it.x)
 
 mutable struct KeyIterator{JA<:JuMPArray}
     x::JA

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -41,18 +41,24 @@ end
 
 linearterms(aff::GenericAffExpr) = LinearTermIterator(aff)
 
-function Base.iterate(lti::LinearTermIterator)
-    if length(lti.aff.vars) ≥ 1
-        ((lti.aff.coeffs[1], lti.aff.vars[1]), 2)
-    else
-        nothing
+if VERSION < v"0.7-"
+    Base.start(lti::LinearTermIterator) = 1
+    Base.done( lti::LinearTermIterator, state::Int) = state > length(lti.aff.vars)
+    Base.next( lti::LinearTermIterator, state::Int) = ((lti.aff.coeffs[state], lti.aff.vars[state]), state+1)
+else
+    function Base.iterate(lti::LinearTermIterator)
+        if length(lti.aff.vars) ≥ 1
+            ((lti.aff.coeffs[1], lti.aff.vars[1]), 2)
+        else
+            nothing
+        end
     end
-end
-function Base.iterate(lti::LinearTermIterator, state::Int)
-    if state ≤ length(lti.aff.vars)
-        ((lti.affs.coeffs[state], lti.affs.vars[state]), state+1)
-    else
-        nothing
+    function Base.iterate(lti::LinearTermIterator, state::Int)
+        if state ≤ length(lti.aff.vars)
+            ((lti.affs.coeffs[state], lti.affs.vars[state]), state+1)
+        else
+            nothing
+        end
     end
 end
 

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -24,6 +24,8 @@ mutable struct GenericAffExpr{CoefType,VarType} <: AbstractJuMPScalar
     coeffs::Vector{CoefType}
     constant::CoefType
 end
+GenericAffExpr(a::GenericAffExpr) = GenericAffExpr(a.vars, a.coeffs, a.constant)
+
 coeftype(::GenericAffExpr{C,V}) where {C,V} = C
 
 Base.zero(::Type{GenericAffExpr{C,V}}) where {C,V} = GenericAffExpr{C,V}(V[],C[],zero(C))
@@ -39,7 +41,7 @@ end
 
 linearterms(aff::GenericAffExpr) = LinearTermIterator(aff)
 
-function Base.iterate(lti::LinearTermIterator) 
+function Base.iterate(lti::LinearTermIterator)
     if length(lti.aff.vars) ≥ 1
         ((lti.aff.coeffs[1], lti.aff.vars[1]), 2)
     else
@@ -94,10 +96,12 @@ end
 # Alias for (Float64, Variable), the specific GenericAffExpr used by JuMP
 const AffExpr = GenericAffExpr{Float64,Variable}
 AffExpr() = zero(AffExpr)
+AffExpr(v::Variable) = AffExpr([v], [1.], 0.)
+AffExpr(v::Real) = AffExpr(Variable[], Float64[], v)
+AffExpr(a::AffExpr) = AffExpr(a.vars, a.coeffs, a.constant)
 
 Base.isempty(a::AffExpr) = (length(a.vars) == 0 && a.constant == 0.)
-Base.convert(::Type{AffExpr}, v::Variable) = AffExpr([v], [1.], 0.)
-Base.convert(::Type{AffExpr}, v::Real) = AffExpr(Variable[], Float64[], v)
+Base.convert(::Type{AffExpr}, v::Union{Variable,<:Real}) = AffExpr(v)
 
 # Check all coefficients are finite, i.e. not NaN, not Inf, not -Inf
 function assert_isfinite(a::AffExpr)

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -39,9 +39,20 @@ end
 
 linearterms(aff::GenericAffExpr) = LinearTermIterator(aff)
 
-Base.start(lti::LinearTermIterator) = 1
-Base.done( lti::LinearTermIterator, state::Int) = state > length(lti.aff.vars)
-Base.next( lti::LinearTermIterator, state::Int) = ((lti.aff.coeffs[state], lti.aff.vars[state]), state+1)
+function Base.iterate(lti::LinearTermIterator) 
+    if length(lti.aff.vars) ≥ 1
+        ((lti.aff.coeffs[1], lti.aff.vars[1]), 2)
+    else
+        nothing
+    end
+end
+function Base.iterate(lti::LinearTermIterator, state::Int)
+    if state ≤ length(lti.aff.vars)
+        ((lti.affs.coeffs[state], lti.affs.vars[state]), state+1)
+    else
+        nothing
+    end
+end
 
 # More efficient ways to grow an affine expression
 # Add a single term to an affine expression

--- a/src/parseExpr_staged.jl
+++ b/src/parseExpr_staged.jl
@@ -287,7 +287,7 @@ end
 @generated function addtoexpr_reorder(ex, args...)
     n = length(args)
     @assert n ≥ 3
-    varidx = find(t -> (t == Variable || t == AffExpr), collect(args))
+    varidx = findall(t -> (t == Variable || t == AffExpr), collect(args))
     allscalar = all(t -> (t <: Number), args[setdiff(1:n, varidx)])
     idx = (allscalar && length(varidx) == 1) ? varidx[1] : n
     coef = Expr(:call, :*, [:(args[$i]) for i in setdiff(1:n,idx)]...)

--- a/src/print.jl
+++ b/src/print.jl
@@ -451,7 +451,7 @@ function cont_str(mode, j, sym::PrintSymbols)
                 dimidx += 1
             end
             if dimidx > length(DIMS)
-                throw(ErrorException("Unexpectedly ran out of indices"))
+                error("Unexpectedly ran out of indices")
             end
             idxvars[i] = DIMS[dimidx]
             dimidx += 1

--- a/src/print.jl
+++ b/src/print.jl
@@ -396,7 +396,7 @@ exprstr(n::Norm) = norm_str(REPLMode, n)
 #------------------------------------------------------------------------
 ## JuMPContainer{Variable}
 #------------------------------------------------------------------------
-Base.show(io::IO, j::Union{JuMPContainer{Variable}, Array{Variable}}) = print(io, cont_str(REPLMode,j))
+Base.show(io::IO, j::JuMPContainer{Variable}) = print(io, cont_str(REPLMode,j))
 Base.show(io::IO, ::MIME"text/latex", j::Union{JuMPContainer{Variable},Array{Variable}}) =
     print(io, cont_str(IJuliaMode,j,mathmode=false))
 # Generic string converter, called by mode-specific handlers
@@ -444,7 +444,7 @@ function cont_str(mode, j, sym::PrintSymbols)
                 dimidx += 1
             end
             if dimidx > length(DIMS)
-                error("Unexpectedly ran out of indices")
+                throw(ErrorException("Unexpectedly ran out of indices"))
             end
             idxvars[i] = DIMS[dimidx]
             dimidx += 1
@@ -627,7 +627,7 @@ function val_str(mode, dict::JuMPDict{Float64,N}) where N
 
     ndim = length(first(keys(dict.tupledict)))
 
-    key_strs = Array{String}(length(dict), ndim)
+    key_strs = Array{String}(undef, length(dict), ndim)
     for (i, key) in enumerate(sortedkeys)
         for j in 1:ndim
             key_strs[i,j] = string(key[j])

--- a/src/print.jl
+++ b/src/print.jl
@@ -420,7 +420,7 @@ function cont_str(mode, j, sym::PrintSymbols)
         if ndims(j) == 1
             return sprint((io,v) -> Base.show_vector(io, v, "[", "]"), j)
         else
-            return sprint((io,X) -> Base.showarray(io, X), j)
+            return sprint((io,X) -> Base.show(io, X), j)
         end
     end
 
@@ -436,7 +436,7 @@ function cont_str(mode, j, sym::PrintSymbols)
         end
     end
     num_dims = length(data.indexsets)
-    idxvars = Array{String}(num_dims)
+    idxvars = Array{String}(undef, num_dims)
     dimidx = 1
     for i in 1:num_dims
         if data.indexexprs[i].idxvar == nothing
@@ -569,7 +569,7 @@ function val_str(mode, j::JuMPArray{Float64,N}) where N
         # Determine longest index so we can align columns
         max_index_len = 0
         for index_str in index_strs
-            max_index_len = max(max_index_len, strwidth(index_str))
+            max_index_len = max(max_index_len, textwidth(index_str))
         end
 
         # If have recursed, we need to prepend the parent's index strings
@@ -679,7 +679,7 @@ function aff_str(mode, a::AffExpr, show_constant=true)
     end
 
     elm = 1
-    term_str = Array{String}(2*length(a.vars))
+    term_str = Array{String}(undef, 2*length(a.vars))
     # For each model
     for m in keys(moddict)
         indvec = moddict[m]
@@ -741,7 +741,7 @@ function quad_str(mode, q::GenericQuadExpr, sym)
     Qnnz = length(V)
 
     # Odd terms are +/i, even terms are the variables/coeffs
-    term_str = Array{String}(2*Qnnz)
+    term_str = Array{String}(undef, 2*Qnnz)
     if Qnnz > 0
         for ind in 1:Qnnz
             val = abs(V[ind])

--- a/src/print.jl
+++ b/src/print.jl
@@ -396,7 +396,7 @@ exprstr(n::Norm) = norm_str(REPLMode, n)
 #------------------------------------------------------------------------
 ## JuMPContainer{Variable}
 #------------------------------------------------------------------------
-Base.show(io::IO, j::JuMPContainer{Variable}) = print(io, cont_str(REPLMode,j))
+Base.show(io::IO, j::Union{JuMPContainer{Variable}, Array{Variable}}) = print(io, cont_str(REPLMode,j))
 Base.show(io::IO, ::MIME"text/latex", j::Union{JuMPContainer{Variable},Array{Variable}}) =
     print(io, cont_str(IJuliaMode,j,mathmode=false))
 # Generic string converter, called by mode-specific handlers
@@ -404,6 +404,13 @@ Base.show(io::IO, ::MIME"text/latex", j::Union{JuMPContainer{Variable},Array{Var
 # Assumes that !isempty(j)
 _getmodel(j::Array{Variable}) = first(j).m
 _getmodel(j::JuMPContainer) = getmeta(j, :model)
+
+# 0.7 compat
+const _print_array = if VERSION < v"0.7-"
+    Base.showarray
+else
+    Base.print_array
+end
 
 function cont_str(mode, j, sym::PrintSymbols)
     # Check if anything in the container
@@ -420,7 +427,7 @@ function cont_str(mode, j, sym::PrintSymbols)
         if ndims(j) == 1
             return sprint((io,v) -> Base.show_vector(io, v, "[", "]"), j)
         else
-            return sprint((io,X) -> Base.show(io, X), j)
+            return sprint((io,X) -> _print_array(io, X), j)
         end
     end
 

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -26,6 +26,8 @@ mutable struct GenericQuadExpr{CoefType,VarType} <: AbstractJuMPScalar
     qcoeffs::Vector{CoefType}
     aff::GenericAffExpr{CoefType,VarType}
 end
+GenericQuadExpr(q::GenericQuadExpr) = GenericQuadExpr(q.qvars1, q.qvars2, q.qcoeffs, q.aff)
+
 coeftype(::GenericQuadExpr{C,V}) where {C,V} = C
 
 Base.isempty(q::GenericQuadExpr) = (length(q.qvars1) == 0 && isempty(q.aff))

--- a/src/sos.jl
+++ b/src/sos.jl
@@ -27,8 +27,8 @@ Base.copy(sos::SOSConstraint, new_model::Model) =
 # variable in each expression and a vector of their coefficients
 function constructSOS(m::Model, coll::Vector{AffExpr})
     nvar = length(coll)
-    vars = Array{Variable}(nvar)
-    weight = Array{Float64}(nvar)
+    vars = Array{Variable}(undef, nvar)
+    weight = Array{Float64}(undef, nvar)
     for (i,aff) in enumerate(coll)
         if (length(aff.vars) != 1) || (aff.constant != 0)
             error("Must specify set in terms of single variables")

--- a/test/callback.jl
+++ b/test/callback.jl
@@ -10,8 +10,7 @@
 # test/callback.jl
 # Testing callbacks
 #############################################################################
-using JuMP, MathProgBase
-using Base.Test
+using MathProgBase
 
 !isdefined(:lp_solvers) && include("solvers.jl")
 

--- a/test/callback.jl
+++ b/test/callback.jl
@@ -10,6 +10,7 @@
 # test/callback.jl
 # Testing callbacks
 #############################################################################
+using JuMP, Compat.Test
 using MathProgBase
 
 !isdefined(:lp_solvers) && include("solvers.jl")

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -10,9 +10,6 @@
 # test/expr.jl
 # Testing for AffExpr and QuadExpr
 #############################################################################
-using JuMP
-using Base.Test
-
 @testset "Expressions" begin
 
     @testset "Test expression construction" begin

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -10,6 +10,8 @@
 # test/expr.jl
 # Testing for AffExpr and QuadExpr
 #############################################################################
+using JuMP, Compat.Test
+
 @testset "Expressions" begin
 
     @testset "Test expression construction" begin

--- a/test/fuzzer.jl
+++ b/test/fuzzer.jl
@@ -95,7 +95,7 @@ function test_approx_equal_exprs(ex1, ex2)
     end
     if !res
         str = "The following expression did not pass the fuzzer:\n    ex1 = QuadExpr($(ex1.qvars1),$(ex1.qvars2),$(ex1.qcoeffs),AffExpr($(ex1.aff.vars),$(ex1.aff.coeffs),$(ex1.aff.constant)))\n    ex2 = QuadExpr($(ex2.qvars1),$(ex2.qvars2),$(ex2.qcoeffs),AffExpr($(ex2.aff.vars),$(ex2.aff.coeffs),$(ex2.aff.constant)))"
-        warn(str)
+        @warn(str)
     end
     return res
 end

--- a/test/fuzzer.jl
+++ b/test/fuzzer.jl
@@ -2,6 +2,7 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+using JuMP, Compat.Test
 
 function random_aff_expr(N, vars::Vector)
     ex = Expr(:call, :+)

--- a/test/hockschittkowski/runhs.jl
+++ b/test/hockschittkowski/runhs.jl
@@ -22,7 +22,7 @@ if Pkg.installed("Ipopt") == nothing
     println("Cannot run NLP tests because Ipopt is not installed.")
     exit(1)
 end
-using Ipopt, JuMP, Test
+using Ipopt, JuMP, Compat.Test
 nlp_solver = IpoptSolver(print_level=0)
 
 HS_path = dirname(@__FILE__)

--- a/test/hockschittkowski/runhs.jl
+++ b/test/hockschittkowski/runhs.jl
@@ -22,7 +22,7 @@ if Pkg.installed("Ipopt") == nothing
     println("Cannot run NLP tests because Ipopt is not installed.")
     exit(1)
 end
-using Ipopt, JuMP, Base.Test
+using Ipopt, JuMP, Test
 nlp_solver = IpoptSolver(print_level=0)
 
 HS_path = dirname(@__FILE__)

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -5,7 +5,7 @@
 
 # hygiene.jl
 # Make sure that our macros have good hygiene
-using Test
+using Compat.Test
 
 module M
 import JuMP

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -5,7 +5,7 @@
 
 # hygiene.jl
 # Make sure that our macros have good hygiene
-using Base.Test
+using Test
 
 module M
 import JuMP

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1,6 +1,8 @@
 # test/macros.jl
 # Testing macros work correctly
 #############################################################################
+using JuMP
+using Compat.Test
 # To ensure the tests work on Windows and Linux/OSX, we need
 # to use the correct comparison operators
 const leq = JuMP.repl[:leq]

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1,9 +1,6 @@
 # test/macros.jl
 # Testing macros work correctly
 #############################################################################
-using JuMP
-using Base.Test
-
 # To ensure the tests work on Windows and Linux/OSX, we need
 # to use the correct comparison operators
 const leq = JuMP.repl[:leq]

--- a/test/model.jl
+++ b/test/model.jl
@@ -11,6 +11,7 @@
 # Testing Model printing, basic solving
 # Must be run as part of runtests.jl, as it needs a list of solvers.
 #############################################################################
+using JuMP, Compat.Test
 using OffsetArrays
 
 # If solvers not loaded, load them (i.e running just these tests)

--- a/test/model.jl
+++ b/test/model.jl
@@ -11,8 +11,6 @@
 # Testing Model printing, basic solving
 # Must be run as part of runtests.jl, as it needs a list of solvers.
 #############################################################################
-using JuMP
-using Base.Test
 using OffsetArrays
 
 # If solvers not loaded, load them (i.e running just these tests)

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -10,6 +10,7 @@
 # test/nonlinear.jl
 # Test general nonlinear
 #############################################################################
+using JuMP, Compat.Test
 # If solvers not loaded, load them (i.e running just these tests)
 !isdefined(:nlp_solvers) && include("solvers.jl")
 

--- a/test/nonlinear.jl
+++ b/test/nonlinear.jl
@@ -10,9 +10,6 @@
 # test/nonlinear.jl
 # Test general nonlinear
 #############################################################################
-using JuMP
-using Base.Test
-
 # If solvers not loaded, load them (i.e running just these tests)
 !isdefined(:nlp_solvers) && include("solvers.jl")
 

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -10,8 +10,6 @@
 # test/operator.jl
 # Testing operator overloading is correct
 #############################################################################
-using JuMP
-using Base.Test
 using OffsetArrays
 
 # To ensure the tests work on both Windows and Linux/OSX, we need

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -10,6 +10,7 @@
 # test/operator.jl
 # Testing operator overloading is correct
 #############################################################################
+using JuMP, Compat.Test
 using OffsetArrays
 
 # To ensure the tests work on both Windows and Linux/OSX, we need

--- a/test/print.jl
+++ b/test/print.jl
@@ -10,8 +10,6 @@
 # test/print.jl
 # Testing $fa pretty-printing-related functionality
 #############################################################################
-using JuMP
-using Base.Test
 import JuMP.REPLMode, JuMP.IJuliaMode
 import JuMP.repl, JuMP.ijulia
 
@@ -179,6 +177,7 @@ end
         @testset "Empty JuMPContainer printing (#124)" begin
         m = Model()
         @variable(m, empty_free[1:0])
+        # TODO! tests returning "empty_free (no indices)", why is that not desired behavior?
         io_test(REPLMode, empty_free, "Empty Array{Variable} (no indices)")
         io_test(IJuliaMode, empty_free, "Empty Array{Variable} (no indices)")
         @variable(m, empty_set[[]])
@@ -610,12 +609,12 @@ end
             io_test(REPLMode,   v, "JuMP.Variable[x,y,x]")
             io_test(IJuliaMode, v, "JuMP.Variable[x,y,x]")
         else
-            io_test(REPLMode,   v, "JuMP.Variable[x, y, x]")
-            io_test(IJuliaMode, v, "JuMP.Variable[x, y, x]")
+            io_test(REPLMode,   v, "$Variable[x, y, x]")
+            io_test(IJuliaMode, v, "$Variable[x, y, x]")
         end
 
-        io_test(REPLMode,   A, "JuMP.Variable[x y; y x]")
-        io_test(IJuliaMode, A, "JuMP.Variable[x y; y x]")
+        io_test(REPLMode,   A, "$Variable[x y; y x]")
+        io_test(IJuliaMode, A, "$Variable[x y; y x]")
     end
 
     @testset "basename keyword argument" begin

--- a/test/print.jl
+++ b/test/print.jl
@@ -10,6 +10,9 @@
 # test/print.jl
 # Testing $fa pretty-printing-related functionality
 #############################################################################
+using JuMP
+using Compat.Test
+
 import JuMP.REPLMode, JuMP.IJuliaMode
 import JuMP.repl, JuMP.ijulia
 

--- a/test/probmod.jl
+++ b/test/probmod.jl
@@ -11,9 +11,6 @@
 # Testing problem modification
 # Must be run as part of runtests.jl, as it needs a list of solvers.
 #############################################################################
-using JuMP
-using Base.Test
-
 # If solvers not loaded, load them (i.e running just these tests)
 !isdefined(:lp_solvers) && include("solvers.jl")
 

--- a/test/probmod.jl
+++ b/test/probmod.jl
@@ -11,6 +11,7 @@
 # Testing problem modification
 # Must be run as part of runtests.jl, as it needs a list of solvers.
 #############################################################################
+using JuMP, Compat.Test
 # If solvers not loaded, load them (i.e running just these tests)
 !isdefined(:lp_solvers) && include("solvers.jl")
 

--- a/test/qcqpmodel.jl
+++ b/test/qcqpmodel.jl
@@ -11,9 +11,6 @@
 # Testing quadratic models (objective and constraints)
 # Must be run as part of runtests.jl, as it needs a list of solvers.
 #############################################################################
-using JuMP
-using Base.Test
-
 # If solvers not loaded, load them (i.e running just these tests)
 !isdefined(:lp_solvers) && include("solvers.jl")
 

--- a/test/qcqpmodel.jl
+++ b/test/qcqpmodel.jl
@@ -11,6 +11,7 @@
 # Testing quadratic models (objective and constraints)
 # Must be run as part of runtests.jl, as it needs a list of solvers.
 #############################################################################
+using JuMP, Compat.Test
 # If solvers not loaded, load them (i.e running just these tests)
 !isdefined(:lp_solvers) && include("solvers.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,23 +18,23 @@ include("solvers.jl")
 
 # Static tests - most don't require a solver
 include("print.jl")
-# include("variable.jl")
-# include("expr.jl")
-# include("operator.jl")
-# include("macros.jl")
-# 
-# # Fuzzer of macros to build expressions
-# include("fuzzer.jl")
-# 
-# # Solver-dependent tests
-# include("model.jl");        length(   lp_solvers) == 0 && @warn("Model tests not run!")
-# include("probmod.jl");      length(   lp_solvers) == 0 && @warn("Prob. mod. tests not run!")
-# include("callback.jl");     length( lazy_solvers) == 0 && @warn("Callback tests not run!")
-# include("qcqpmodel.jl");    length( quad_solvers) == 0 && @warn("Quadratic tests not run!")
-# include("nonlinear.jl");    length(  nlp_solvers) == 0 && @warn("Nonlinear tests not run!")
-#                             length(minlp_solvers) == 0 && @warn("Mixed-integer Nonlinear tests not run!")
-# include("sdp.jl");          length(  sdp_solvers) == 0 && @warn("Semidefinite tests not run!")
-# include("socduals.jl");     length(conic_solvers_with_duals) == 0 && @warn("Conic solvers with duals tests not run!")
+include("variable.jl")
+include("expr.jl")
+include("operator.jl")
+include("macros.jl")
+
+# Fuzzer of macros to build expressions
+include("fuzzer.jl")
+
+# Solver-dependent tests
+include("model.jl");        length(   lp_solvers) == 0 && @warn("Model tests not run!")
+include("probmod.jl");      length(   lp_solvers) == 0 && @warn("Prob. mod. tests not run!")
+include("callback.jl");     length( lazy_solvers) == 0 && @warn("Callback tests not run!")
+include("qcqpmodel.jl");    length( quad_solvers) == 0 && @warn("Quadratic tests not run!")
+include("nonlinear.jl");    length(  nlp_solvers) == 0 && @warn("Nonlinear tests not run!")
+                            length(minlp_solvers) == 0 && @warn("Mixed-integer Nonlinear tests not run!")
+include("sdp.jl");          length(  sdp_solvers) == 0 && @warn("Semidefinite tests not run!")
+include("socduals.jl");     length(conic_solvers_with_duals) == 0 && @warn("Conic solvers with duals tests not run!")
 # Throw an error if anything failed
 #FactCheck.exitstatus()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,23 +22,23 @@ include("solvers.jl")
 
 # Static tests - most don't require a solver
 include("print.jl")
-include("variable.jl")
-include("expr.jl")
-include("operator.jl")
-include("macros.jl")
-
-# Fuzzer of macros to build expressions
-include("fuzzer.jl")
-
-# Solver-dependent tests
-include("model.jl");        length(   lp_solvers) == 0 && @warn("Model tests not run!")
-include("probmod.jl");      length(   lp_solvers) == 0 && @warn("Prob. mod. tests not run!")
-include("callback.jl");     length( lazy_solvers) == 0 && @warn("Callback tests not run!")
-include("qcqpmodel.jl");    length( quad_solvers) == 0 && @warn("Quadratic tests not run!")
-include("nonlinear.jl");    length(  nlp_solvers) == 0 && @warn("Nonlinear tests not run!")
-                            length(minlp_solvers) == 0 && @warn("Mixed-integer Nonlinear tests not run!")
-include("sdp.jl");          length(  sdp_solvers) == 0 && @warn("Semidefinite tests not run!")
-include("socduals.jl");     length(conic_solvers_with_duals) == 0 && @warn("Conic solvers with duals tests not run!")
+#include("variable.jl")
+#include("expr.jl")
+#include("operator.jl")
+#include("macros.jl")
+#
+## Fuzzer of macros to build expressions
+#include("fuzzer.jl")
+#
+## Solver-dependent tests
+#include("model.jl");        length(   lp_solvers) == 0 && @warn("Model tests not run!")
+#include("probmod.jl");      length(   lp_solvers) == 0 && @warn("Prob. mod. tests not run!")
+#include("callback.jl");     length( lazy_solvers) == 0 && @warn("Callback tests not run!")
+#include("qcqpmodel.jl");    length( quad_solvers) == 0 && @warn("Quadratic tests not run!")
+#include("nonlinear.jl");    length(  nlp_solvers) == 0 && @warn("Nonlinear tests not run!")
+#                            length(minlp_solvers) == 0 && @warn("Mixed-integer Nonlinear tests not run!")
+#include("sdp.jl");          length(  sdp_solvers) == 0 && @warn("Semidefinite tests not run!")
+#include("socduals.jl");     length(conic_solvers_with_duals) == 0 && @warn("Conic solvers with duals tests not run!")
 # Throw an error if anything failed
 #FactCheck.exitstatus()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,30 +11,30 @@
 #############################################################################
 
 using JuMP
-using Base.Test
+using Compat.Test, Compat.LinearAlgebra
 
 # Load solvers
 include("solvers.jl")
 
 # Static tests - most don't require a solver
 include("print.jl")
-include("variable.jl")
-include("expr.jl")
-include("operator.jl")
-include("macros.jl")
-
-# Fuzzer of macros to build expressions
-include("fuzzer.jl")
-
-# Solver-dependent tests
-include("model.jl");        length(   lp_solvers) == 0 && warn("Model tests not run!")
-include("probmod.jl");      length(   lp_solvers) == 0 && warn("Prob. mod. tests not run!")
-include("callback.jl");     length( lazy_solvers) == 0 && warn("Callback tests not run!")
-include("qcqpmodel.jl");    length( quad_solvers) == 0 && warn("Quadratic tests not run!")
-include("nonlinear.jl");    length(  nlp_solvers) == 0 && warn("Nonlinear tests not run!")
-                            length(minlp_solvers) == 0 && warn("Mixed-integer Nonlinear tests not run!")
-include("sdp.jl");          length(  sdp_solvers) == 0 && warn("Semidefinite tests not run!")
-include("socduals.jl");     length(conic_solvers_with_duals) == 0 && warn("Conic solvers with duals tests not run!")
+# include("variable.jl")
+# include("expr.jl")
+# include("operator.jl")
+# include("macros.jl")
+# 
+# # Fuzzer of macros to build expressions
+# include("fuzzer.jl")
+# 
+# # Solver-dependent tests
+# include("model.jl");        length(   lp_solvers) == 0 && @warn("Model tests not run!")
+# include("probmod.jl");      length(   lp_solvers) == 0 && @warn("Prob. mod. tests not run!")
+# include("callback.jl");     length( lazy_solvers) == 0 && @warn("Callback tests not run!")
+# include("qcqpmodel.jl");    length( quad_solvers) == 0 && @warn("Quadratic tests not run!")
+# include("nonlinear.jl");    length(  nlp_solvers) == 0 && @warn("Nonlinear tests not run!")
+#                             length(minlp_solvers) == 0 && @warn("Mixed-integer Nonlinear tests not run!")
+# include("sdp.jl");          length(  sdp_solvers) == 0 && @warn("Semidefinite tests not run!")
+# include("socduals.jl");     length(conic_solvers_with_duals) == 0 && @warn("Conic solvers with duals tests not run!")
 # Throw an error if anything failed
 #FactCheck.exitstatus()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,23 +22,23 @@ include("solvers.jl")
 
 # Static tests - most don't require a solver
 include("print.jl")
-#include("variable.jl")
-#include("expr.jl")
-#include("operator.jl")
-#include("macros.jl")
-#
-## Fuzzer of macros to build expressions
-#include("fuzzer.jl")
-#
-## Solver-dependent tests
-#include("model.jl");        length(   lp_solvers) == 0 && @warn("Model tests not run!")
-#include("probmod.jl");      length(   lp_solvers) == 0 && @warn("Prob. mod. tests not run!")
-#include("callback.jl");     length( lazy_solvers) == 0 && @warn("Callback tests not run!")
-#include("qcqpmodel.jl");    length( quad_solvers) == 0 && @warn("Quadratic tests not run!")
-#include("nonlinear.jl");    length(  nlp_solvers) == 0 && @warn("Nonlinear tests not run!")
-#                            length(minlp_solvers) == 0 && @warn("Mixed-integer Nonlinear tests not run!")
-#include("sdp.jl");          length(  sdp_solvers) == 0 && @warn("Semidefinite tests not run!")
-#include("socduals.jl");     length(conic_solvers_with_duals) == 0 && @warn("Conic solvers with duals tests not run!")
+include("variable.jl")
+include("expr.jl")
+include("operator.jl")
+include("macros.jl")
+
+# Fuzzer of macros to build expressions
+include("fuzzer.jl")
+
+# Solver-dependent tests
+include("model.jl");        length(   lp_solvers) == 0 && @warn("Model tests not run!")
+include("probmod.jl");      length(   lp_solvers) == 0 && @warn("Prob. mod. tests not run!")
+include("callback.jl");     length( lazy_solvers) == 0 && @warn("Callback tests not run!")
+include("qcqpmodel.jl");    length( quad_solvers) == 0 && @warn("Quadratic tests not run!")
+include("nonlinear.jl");    length(  nlp_solvers) == 0 && @warn("Nonlinear tests not run!")
+                            length(minlp_solvers) == 0 && @warn("Mixed-integer Nonlinear tests not run!")
+include("sdp.jl");          length(  sdp_solvers) == 0 && @warn("Semidefinite tests not run!")
+include("socduals.jl");     length(conic_solvers_with_duals) == 0 && @warn("Conic solvers with duals tests not run!")
 # Throw an error if anything failed
 #FactCheck.exitstatus()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,10 @@
 using JuMP
 using Compat.Test, Compat.LinearAlgebra
 
+if VERSION < v"0.7-"
+    using Compat: @warn
+end
+
 # Load solvers
 include("solvers.jl")
 

--- a/test/sdp.jl
+++ b/test/sdp.jl
@@ -1,6 +1,3 @@
-using JuMP
-using Base.Test
-
 !isdefined(:sdp_solvers) && include("solvers.jl")
 
 const TOL = 1e-4

--- a/test/sdp.jl
+++ b/test/sdp.jl
@@ -1,3 +1,5 @@
+using JuMP, Compat.Test
+
 !isdefined(:sdp_solvers) && include("solvers.jl")
 
 const TOL = 1e-4

--- a/test/socduals.jl
+++ b/test/socduals.jl
@@ -1,3 +1,5 @@
+using JuMP, Compat.Test
+
 !isdefined(:conic_solvers_with_duals) && include("solvers.jl")
 
 const TOL = 1e-4

--- a/test/socduals.jl
+++ b/test/socduals.jl
@@ -1,6 +1,3 @@
-using JuMP
-using Base.Test
-
 !isdefined(:conic_solvers_with_duals) && include("solvers.jl")
 
 const TOL = 1e-4

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -10,7 +10,7 @@
 # test/variable.jl
 # Testing for Variable
 #############################################################################
-using JuMP
+using JuMP, Compat.Test
 import JuMP.repl
 
 @testset "Variables" begin

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -12,7 +12,6 @@
 #############################################################################
 using JuMP
 import JuMP.repl
-using Base.Test
 
 @testset "Variables" begin
     @testset "constructors" begin


### PR DESCRIPTION
Hello all.  I've continued the process of getting 0.18 up and running on 0.7.  As this will be a long process, I'm hoping that we can do this with lots of small PR's like this one, not worrying much about whether we are passing tests on 0.7 until things are a little further along.  (When I updated DataFrames.jl for 0.7 I did one gigantic PR, and it was not a good way of doing it.)

The biggest changes I've made so far are probably implementing `iterate` methods and constructors (as now `convert` falls back to constructors and not vice versa).

Many of the errors are macro errors, and as the macro code is incredibly dense these will be the hardest to work on, so I've avoided fixing macros so far.

I have a question concerning the desired print behavior, so that perhaps I can make another fix before this gets merged.  Looking at the test set starting [here](https://github.com/JuliaOpt/JuMP.jl/blob/release-0.18/test/print.jl#L179) I cannot understand why `empty_set` and `empty_free` would be expected to print differently.  They are both variables being initialized with empty arrays, both of those macros create `JuMPContainer` objects with very similar type signatures exactly as I would expect them to.  The code in `print.jl` prints `empty_free` as `empty_free (no indices)` and, having poured through that code, it seems like the intended behavior, so I don't understand why that test is that way.  Note that [this line](https://github.com/JuliaOpt/JuMP.jl/blob/release-0.18/src/print.jl#L411) causes all `JuMPContainer`s to print with the name they were initialized with, as I would expect.  Perhaps this is an error in the macro parsing and `empty_free` was supposed to be an `Array{Variable}`?

Anyway, any suggestions for simply fixing this PR up a bit more before moving onto the next iteration would be appreciated.  Thanks!