### PR TITLE
Clean up operator_warn.

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -607,7 +607,7 @@ end
     operator_warn(model::Model)
 
 This function is called on the model whenever two affine expressions are added
-together wthiout using `destructive_add!`, and at least one of the two
+together without using `destructive_add!`, and at least one of the two
 expressions has more than 50 terms.
 
 For the case of `Model`, if this function is called more than 20,000 times then

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -146,6 +146,8 @@ product of two variables.
 """
 function add_to_expression! end
 
+# TODO: add deprecations for Base.push! and Base.append!
+
 function add_to_expression!(aff::GenericAffExpr{C,V}, new_coef::C, new_var::V) where {C,V}
     add_or_set!(aff.terms, new_var, new_coef)
     aff

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -146,8 +146,6 @@ product of two variables.
 """
 function add_to_expression! end
 
-# TODO: add deprecations for Base.push! and Base.append!
-
 function add_to_expression!(aff::GenericAffExpr{C,V}, new_coef::C, new_var::V) where {C,V}
     add_or_set!(aff.terms, new_var, new_coef)
     aff

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -149,7 +149,11 @@ end
 Base.:/(lhs::GenericAffExpr, rhs::AbstractVariableRef) = error("Cannot divide affine expression by a variable")
 # AffExpr--AffExpr
 function Base.:+(lhs::GenericAffExpr{C,V}, rhs::GenericAffExpr{C,V}) where {C,V<:JuMPTypes}
-    operator_warn(lhs,rhs)
+    if length(linearterms(lhs)) > 50 || length(linearterms(rhs)) > 50
+        if length(linearterms(lhs)) > 1
+            operator_warn(owner_model(first(linearterms(lhs))[2]))
+        end
+    end
     result_terms = copy(lhs.terms)
     # merge() returns a Dict(), so we need to call merge!() instead.
     # Note: merge!() doesn't appear to call sizehint!(). Is this important?


### PR DESCRIPTION
Rephrase docstring.
Update warning message to not refer to removed push!/append!.
Style guidification.
Inline the (affexpr,affexpr) method as its only called from that
one place, and there doesn't seem any intention to add more.
It just adds a level of indirection that isn't well documented.
Remove strange fallback.
Remove comment in affexpr about deprecation - it won't happen.