### PR TITLE
added 0.7 iterators

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -8,7 +8,7 @@
 # See http://github.com/JuliaOpt/JuMP.jl
 #############################################################################
 
-__precompile__()
+VERSION < v"0.7.0-beta2.199" && __precompile__()
 
 module JuMP
 
@@ -362,9 +362,14 @@ Return the model owning the scalar `s`.
 """
 function owner_model end
 
-Base.start(::AbstractJuMPScalar) = false
-Base.next(x::AbstractJuMPScalar, state) = (x, true)
-Base.done(::AbstractJuMPScalar, state) = state
+if VERSION < v"0.7-"
+    Base.start(::AbstractJuMPScalar) = false
+    Base.next(x::AbstractJuMPScalar, state) = (x, true)
+    Base.done(::AbstractJuMPScalar, state) = state
+else
+    Base.iterate(x::AbstractJuMPScalar) = (x, true)
+    Base.iterate(::AbstractJuMPScalar, state) = nothing
+end
 Base.isempty(::AbstractJuMPScalar) = false
 
 ##########################################################################

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,7 +28,7 @@ function Base.fill!(v::VectorView{T},value) where T
     end
     nothing
 end
-function Base.scale!(v::VectorView{T},value::T) where T<:Number
+function Compat.LinearAlgebra.scale!(v::VectorView{T},value::T) where T<:Number
     for i in 1:length(v)
         v[i] *= value
     end


### PR DESCRIPTION
I've added iterators using `Base.iterate` for 0.7.  Only 3 objects (`LinearTermIterator`, `QuadTermIterator` and `AbstractJuMPScalar`) require manual iterator implementations.  There are a number of different ways of going about this, I've chosen to do it by defining more methods for the existing helper function `reorder_iterator`.  Note that if this is *not* done than each of the `iterate` functions will need to de-structure output.  This method also eliminates splatting (which was probably ok here).  I'm not necessarily claiming it was the best way of doing it, but it seemed like a good approach to me.

I've also taken the liberty to make a few very simple fixes to 0.7 deprecation warnings.

I've yet to run the full tests locally, so lets see how this goes.