### PR TITLE
Allow Function and UnionAll in with_optimizer

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -83,7 +83,7 @@ struct OptimizerFactory
     # * `Function`: a function, or
     # * `DataType`: a type, or
     # * `UnionAll`: a type with missing parameters.
-    constructor::Union{Function, DataType, UnionAll}
+    constructor
     args::Tuple
     kwargs # type changes from Julia v0.6 to v0.7 so we leave it untyped for now
 end
@@ -102,8 +102,13 @@ the constructor call `IpoptOptimizer(print_level=0)`:
 with_optimizer(IpoptOptimizer, print_level=0)
 ```
 """
-function with_optimizer(constructor::Union{Function, DataType, UnionAll},
+function with_optimizer(constructor,
                         args...; kwargs...)
+    if !applicable(constructor, args...)
+        error("$constructor is does not have any method with arguments $args.",
+              "The first argument of `with_optimizer` should be callable with",
+              " the other argument of `with_optimizer`.")
+    end
     return OptimizerFactory(constructor, args, kwargs)
 end
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -89,7 +89,7 @@ struct OptimizerFactory
 end
 
 """
-    with_optimizer(constructor::Type, args...; kwargs...)
+    with_optimizer(constructor, args...; kwargs...)
 
 Return an `OptimizerFactory` that creates optimizers using the constructor
 `constructor` with positional arguments `args` and keyword arguments `kwargs`.
@@ -102,7 +102,8 @@ the constructor call `IpoptOptimizer(print_level=0)`:
 with_optimizer(IpoptOptimizer, print_level=0)
 ```
 """
-function with_optimizer(constructor::Type, args...; kwargs...)
+function with_optimizer(constructor::Union{Function, DataType, UnionAll},
+                        args...; kwargs...)
     return OptimizerFactory(constructor, args, kwargs)
 end
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -40,3 +40,28 @@ end
         @test_throws ErrorException @constraint model 0 <= x + 1 <= 1
     end
 end
+
+struct Optimizer
+    a::Int
+    b::Int
+end
+function f(a::Int; b::Int = 1)
+    return Optimizer(a, b)
+end
+
+@testset "Factories" begin
+    factory = with_optimizer(Optimizer, 1, 2)
+    @test factory.constructor == Optimizer
+    @test factory.args == (1, 2)
+    optimizer = factory()
+    @test optimizer isa Optimizer
+    @test optimizer.a == 1
+    @test optimizer.b == 2
+    factory = with_optimizer(f, 1, b = 2)
+    @test factory.constructor == f
+    @test factory.args == (1,)
+    optimizer = factory()
+    @test optimizer isa Optimizer
+    @test optimizer.a == 1
+    @test optimizer.b == 2
+end

--- a/test/model.jl
+++ b/test/model.jl
@@ -57,6 +57,7 @@ end
     @test optimizer isa Optimizer
     @test optimizer.a == 1
     @test optimizer.b == 2
+    @test_throws ErrorException factory = with_optimizer(f, 1, 2)
     factory = with_optimizer(f, 1, b = 2)
     @test factory.constructor == f
     @test factory.args == (1,)


### PR DESCRIPTION
This is needed by CSDP as CSDP.Optimizer is a function, it is not a type as the type returned is
```julia
julia> typeof(CSDP.Optimizer())
SemidefiniteOptInterface.SOItoMOIBridge{Float64,CSDP.SDOptimizer}
```
Accepting UnionAll is also needed in case the optimizer type is parametrized