### PR TITLE
[release-0.18] more updates for 1.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
 MathProgBase 0.6 0.8
-ReverseDiffSparse 0.8 0.9
-ForwardDiff 0.5 0.8
+ReverseDiffSparse 0.8
+ForwardDiff 0.7
 Calculus
 Compat 1.0.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
 MathProgBase 0.6 0.8
-ReverseDiffSparse 0.8
-ForwardDiff 0.7
+ReverseDiffSparse 0.8 0.9
+ForwardDiff 0.5 0.8
 Calculus
 Compat 1.0.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
 MathProgBase 0.6 0.8
 ReverseDiffSparse 0.8 0.9
-ForwardDiff 0.5 0.8
+ForwardDiff 0.5 0.9
 Calculus
 Compat 1.0.0

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -29,6 +29,7 @@ if VERSION < v"0.7-"
     const SparseArrays = Compat.SparseArrays
     const Printf = Compat.Printf
     const Sys = Compat.Sys
+    using Compat: rmul!
 end
 
 export

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -31,10 +31,7 @@ if VERSION < v"0.7-"
     const Sys = Compat.Sys
     using Compat: rmul!
     # because iteration of CartesianIndex is broken in 0.6
-    Base.Tuple(idx::CartesianIndex{1}) = (idx[1],)
-    Base.Tuple(idx::CartesianIndex{2}) = (idx[1], idx[2])
-    Base.Tuple(idx::CartesianIndex{3}) = (idx[1], idx[2], idx[3])
-    Base.Tuple(idx::CartesianIndex{4}) = (idx[1], idx[2], idx[3], idx[4])
+    Base.Tuple(idx::CartesianIndex{N}) where {N} = tuple((idx[i] for i ∈ 1:N)...)
 end
 
 export

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -31,7 +31,9 @@ if VERSION < v"0.7-"
     const Sys = Compat.Sys
     using Compat: rmul!
     # because iteration of CartesianIndex is broken in 0.6
-    Base.Tuple(idx::CartesianIndex{N}) where {N} = tuple((idx[i] for i ∈ 1:N)...)
+    const _ind2sub = Base.ind2sub
+else
+    _ind2sub(tpl, k) = Tuple(CartesianIndex(tpl)[k])
 end
 
 export

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -30,6 +30,11 @@ if VERSION < v"0.7-"
     const Printf = Compat.Printf
     const Sys = Compat.Sys
     using Compat: rmul!
+    # because iteration of CartesianIndex is broken in 0.6
+    Base.Tuple(idx::CartesianIndex{1}) = (idx[1],)
+    Base.Tuple(idx::CartesianIndex{2}) = (idx[1], idx[2])
+    Base.Tuple(idx::CartesianIndex{3}) = (idx[1], idx[2], idx[3])
+    Base.Tuple(idx::CartesianIndex{4}) = (idx[1], idx[2], idx[3], idx[4])
 end
 
 export

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -88,7 +88,7 @@ else
         isexpr(s,:call) && s.args[1] == :(:) && length(s.args) == 3 && s.args[2] == 1
     end
 end
-_gendict_checkgen(::Symbol) = false
+_gendict_checkgen(::Any) = false
 function gendict(instancename,T,idxsets...)
     N = length(idxsets)
     truearray = true

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -331,7 +331,7 @@ end
 
 @generated __next(x::JuMPArray{T,N,NT}, k::Integer) where {T,N,NT} =
     quote
-        subidx = Tuple(JuMP.CartesianIndices(size(x))[k])
+        subidx = _ind2sub(size(x), k)
         $(Expr(:tuple, [:(x.indexsets[$i][subidx[$i]]) for i in 1:N]...)), next(x.innerArray,k)[2]
     end
 

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -331,7 +331,7 @@ end
 
 @generated __next(x::JuMPArray{T,N,NT}, k::Integer) where {T,N,NT} =
     quote
-        subidx = Tuple(JuMP.CartesianIndex(size(x))[k])
+        subidx = Tuple(JuMP.CartesianIndices(size(x))[k])
         $(Expr(:tuple, [:(x.indexsets[$i][subidx[$i]]) for i in 1:N]...)), next(x.innerArray,k)[2]
     end
 

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -88,6 +88,7 @@ else
         isexpr(s,:call) && s.args[1] == :(:) && length(s.args) == 3 && s.args[2] == 1
     end
 end
+_gendict_checkgen(::Symbol) = false
 function gendict(instancename,T,idxsets...)
     N = length(idxsets)
     truearray = true

--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -174,7 +174,7 @@ Base.length(x::JuMPDict) = length(x.tupledict)
 Base.ndims(x::JuMPDict{T,N}) where {T,N} = N
 Base.abs(x::JuMPDict) = map(abs, x)
 # avoid dangerous behavior with "end" (#730)
-Base.endof(x::JuMPArray) = error("endof() (and \"end\" syntax) not implemented for JuMPArray objects.")
+Compat.lastindex(x::JuMPArray) = error("lastindex() (and \"end\" syntax) not implemented for JuMPArray objects.")
 Base.size(x::JuMPArray) = error(string("size (and \"end\" syntax) not implemented for JuMPArray objects.",
 "Use JuMP.size if you want to access the dimensions."))
 Base.size(x::JuMPArray,k) = error(string("size (and \"end\" syntax) not implemented for JuMPArray objects.",
@@ -188,8 +188,6 @@ size(x,k) = Base.size(x,k)
 LinearAlgebra.issymmetric(x::JuMPArray) = issymmetric(x.innerArray)
 
 Base.eltype(x::JuMPContainer{T}) where {T} = T
-
-Base.full(x::JuMPContainer) = x
 
 # keys/vals iterations for JuMPContainers
 Base.keys(d::JuMPDict)    = keys(d.tupledict)
@@ -234,11 +232,21 @@ function indexability(x::JuMPArray)
     return true
 end
 
-function Base.start(it::KeyIterator)
-    if indexability(it.x)
-        return start(it.x.innerArray)
-    else
-        return notindexable_start(it.x)
+if VERSION < v"0.7-"
+    function Base.start(it::KeyIterator)
+        if indexability(it.x)
+            return start(it.x.innerArray)
+        else
+            return notindexable_start(it.x)
+        end
+    end
+else
+    function Base.iterate(it::KeyIterator)
+        if indexability(it.x)
+            return iterate(it.x.innerArray)
+        else
+            return notindexable_start(it.x)
+        end
     end
 end
 
@@ -254,40 +262,76 @@ end
     end
 end
 
-function Base.next(it::KeyIterator, k::Tuple)
-    cartesian_key = _next(it.x, k)
-    pos = -1
-    for i in 1:it.dim
-        if !done(it.x.indexsets[i], next(it.x.indexsets[i], k[i+1])[2] )
-            pos = i
-            break
+if VERSION < v"0.7-"
+    function Base.next(it::KeyIterator, k::Tuple)
+        cartesian_key = _next(it.x, k)
+        pos = -1
+        for i in 1:it.dim
+            if !done(it.x.indexsets[i], next(it.x.indexsets[i], k[i+1])[2] )
+                pos = i
+                break
+            end
         end
-    end
-    if pos == - 1
-        it.next_k_cache[1] = 1
-        return cartesian_key, tuple(it.next_k_cache...)
-    end
-    it.next_k_cache[1] = 0
-    for i in 1:it.dim
-        if i < pos
-            it.next_k_cache[i+1] = start(it.x.indexsets[i])
-        elseif i == pos
-            it.next_k_cache[i+1] = next(it.x.indexsets[i], k[i+1])[2]
-        else
-            it.next_k_cache[i+1] = k[i+1]
+        if pos == - 1
+            it.next_k_cache[1] = 1
+            return cartesian_key, tuple(it.next_k_cache...)
         end
+        it.next_k_cache[1] = 0
+        for i in 1:it.dim
+            if i < pos
+                it.next_k_cache[i+1] = start(it.x.indexsets[i])
+            elseif i == pos
+                it.next_k_cache[i+1] = next(it.x.indexsets[i], k[i+1])[2]
+            else
+                it.next_k_cache[i+1] = k[i+1]
+            end
+        end
+        cartesian_key, tuple(it.next_k_cache...)
     end
-    cartesian_key, tuple(it.next_k_cache...)
+    Base.done(it::KeyIterator, k::Tuple) = (k[1] == 1)
+else
+    function Base.iterate(it::KeyIterator, k::Tuple)
+        k[1] == 1 && (return nothing)
+        cartesian_key = _next(it.x, k)
+        pos = -1
+        for i in 1:it.dim
+            if iterate(it.x.indexsets[i], iterate(it.x.indexsets[i], k[i+1])[2]) ≠ nothing
+                pos = i
+                break
+            end
+        end
+        if pos == - 1
+            it.next_k_cache[1] = 1
+            return cartesian_key, tuple(it.next_k_cache...)
+        end
+        it.next_k_cache[1] = 0
+        for i in 1:it.dim
+            if i < pos
+                it.next_k_cache[i+1] = iterate(it.x.indexsets[i])
+            elseif i == pos
+                it.next_k_cache[i+1] = iterate(it.x.indexsets[i], k[i+1])[2]
+            else
+                it.next_k_cache[i+1] = k[i+1]
+            end
+        end
+        cartesian_key, tuple(it.next_k_cache...)
+    end
 end
-
-Base.done(it::KeyIterator, k::Tuple) = (k[1] == 1)
 
 @generated __next(x::JuMPArray{T,N,NT}, k::Integer) where {T,N,NT} =
     quote
         subidx = ind2sub(size(x),k)
         $(Expr(:tuple, [:(x.indexsets[$i][subidx[$i]]) for i in 1:N]...)), next(x.innerArray,k)[2]
     end
-Base.next(it::KeyIterator, k) = __next(it.x,k::Integer)
-Base.done(it::KeyIterator, k) = done(it.x.innerArray, k::Integer)
+
+if VERSION < v"0.7-"
+    Base.next(it::KeyIterator, k) = __next(it.x,k::Integer)
+    Base.done(it::KeyIterator, k) = done(it.x.innerArray, k::Integer)
+else
+    function Base.iterate(it::KeyIterator, k)
+        iterate(it.x.innerArray, k::Integer) ≡ nothing && (return nothing)
+        __next(it.x, k::Integer)
+    end
+end
 
 Base.length(it::KeyIterator)  = length(it.x.innerArray)

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -938,7 +938,7 @@ function hessian_slice(d, ex, x, H, scale, nzcount, recovery_tmp_storage,::Type{
     #output_slice = view(H, (nzcount+1):(nzcount+nzthis))
     output_slice = VectorView(nzcount, nzthis, pointer(H))
     Coloring.recover_from_matmat!(output_slice, R, ex.rinfo, recovery_tmp_storage)
-    scale!(output_slice, scale)
+    rmul!(output_slice, scale)
     return nzthis
 
 end

--- a/src/norms.jl
+++ b/src/norms.jl
@@ -43,26 +43,37 @@ end
 Base.copy(x::GenericNorm{P,C,V}) where {P,C,V} = GenericNorm{P,C,V}(copy(x.terms))
 
 # Handle the norm() function by flattening arguments into a vector
-LinearAlgebra.norm(x::V,                  p::Real=2) where {V<:AbstractJuMPScalar} = vecnorm(x,p)
-LinearAlgebra.norm(x::AbstractVector{V},  p::Real=2) where {V<:AbstractJuMPScalar} = vecnorm(x,p)
-LinearAlgebra.norm(x::AbstractMatrix{V},  p::Real=2) where {V<:AbstractJuMPScalar} = vecnorm(x,p)
-LinearAlgebra.norm(x::JuMPArray{V},       p::Real=2) where {V<:AbstractJuMPScalar} = vecnorm(x,p)
-LinearAlgebra.norm(x::JuMPDict{V},        p::Real=2) where {V<:AbstractJuMPScalar} = vecnorm(x,p)
-LinearAlgebra.norm(x::GenericAffExpr{C,V},                  p::Real=2) where {C,V} = vecnorm(x,p)
-LinearAlgebra.norm(x::AbstractVector{GenericAffExpr{C,V}},  p::Real=2) where {C,V} = vecnorm(x,p)
-LinearAlgebra.norm(x::AbstractMatrix{GenericAffExpr{C,V}},  p::Real=2) where {C,V} = vecnorm(x,p)
-LinearAlgebra.norm(x::JuMPArray{GenericAffExpr{C,V}},       p::Real=2) where {C,V} = vecnorm(x,p)
-LinearAlgebra.norm(x::JuMPDict{GenericAffExpr{C,V}},        p::Real=2) where {C,V} = vecnorm(x,p)
-
+if VERSION < v"0.7-"
+    LinearAlgebra.norm(x::V,                  p::Real=2) where {V<:AbstractJuMPScalar} = vecnorm(x,p)
+    LinearAlgebra.norm(x::AbstractVector{V},  p::Real=2) where {V<:AbstractJuMPScalar} = vecnorm(x,p)
+    LinearAlgebra.norm(x::AbstractMatrix{V},  p::Real=2) where {V<:AbstractJuMPScalar} = vecnorm(x,p)
+    LinearAlgebra.norm(x::JuMPArray{V},       p::Real=2) where {V<:AbstractJuMPScalar} = vecnorm(x,p)
+    LinearAlgebra.norm(x::JuMPDict{V},        p::Real=2) where {V<:AbstractJuMPScalar} = vecnorm(x,p)
+    LinearAlgebra.norm(x::GenericAffExpr{C,V},                  p::Real=2) where {C,V} = vecnorm(x,p)
+    LinearAlgebra.norm(x::AbstractVector{GenericAffExpr{C,V}},  p::Real=2) where {C,V} = vecnorm(x,p)
+    LinearAlgebra.norm(x::AbstractMatrix{GenericAffExpr{C,V}},  p::Real=2) where {C,V} = vecnorm(x,p)
+    LinearAlgebra.norm(x::JuMPArray{GenericAffExpr{C,V}},       p::Real=2) where {C,V} = vecnorm(x,p)
+    LinearAlgebra.norm(x::JuMPDict{GenericAffExpr{C,V}},        p::Real=2) where {C,V} = vecnorm(x,p)
+    
+    LinearAlgebra.vecnorm(x::V,                   p::Real=2) where {V<:AbstractJuMPScalar} = GenericNorm(p, [GenericAffExpr{Float64,V}(x)] )
+    LinearAlgebra.vecnorm(x::AbstractArray{V},    p::Real=2) where {V<:AbstractJuMPScalar} = GenericNorm(p, _vecaff(Float64,V,x) )
+    LinearAlgebra.vecnorm(x::JuMPArray{V},        p::Real=2) where {V<:AbstractJuMPScalar} = GenericNorm(p, _vecaff(Float64,V,x.innerArray) )
+    LinearAlgebra.vecnorm(x::JuMPDict{V},         p::Real=2) where {V<:AbstractJuMPScalar} = GenericNorm(p, _vecaff(Float64,V,collect(values(x))) )
+    LinearAlgebra.vecnorm(x::GenericAffExpr{C,V},                   p::Real=2) where {C,V} = GenericNorm(p, [x])
+    LinearAlgebra.vecnorm(x::AbstractArray{GenericAffExpr{C,V}},    p::Real=2) where {C,V} = GenericNorm(p, vec(x))
+    LinearAlgebra.vecnorm(x::JuMPArray{GenericAffExpr{C,V}},        p::Real=2) where {C,V} = GenericNorm(p, vec(x.innerArray))
+    LinearAlgebra.vecnorm(x::JuMPDict{GenericAffExpr{C,V}},         p::Real=2) where {C,V} = GenericNorm(p, collect(values(x)))
+else
+    LinearAlgebra.norm(x::V,                  p::Real=2) where {V<:AbstractJuMPScalar} = GenericNorm(p, [GenericAffExpr{Float64,V}(x)] )
+    LinearAlgebra.norm(x::AbstractArray{V},   p::Real=2) where {V<:AbstractJuMPScalar} = GenericNorm(p, _vecaff(Float64,V,x) )
+    LinearAlgebra.norm(x::JuMPArray{V},       p::Real=2) where {V<:AbstractJuMPScalar} = GenericNorm(p, _vecaff(Float64,V,x.innerArray) )
+    LinearAlgebra.norm(x::JuMPDict{V},        p::Real=2) where {V<:AbstractJuMPScalar} = GenericNorm(p, _vecaff(Float64,V,collect(values(x))) )
+    LinearAlgebra.norm(x::GenericAffExpr{C,V},                  p::Real=2) where {C,V} = GenericNorm(p, [x])
+    LinearAlgebra.norm(x::AbstractArray{GenericAffExpr{C,V}},   p::Real=2) where {C,V} = GenericNorm(p, vec(x))
+    LinearAlgebra.norm(x::JuMPArray{GenericAffExpr{C,V}},       p::Real=2) where {C,V} = GenericNorm(p, vec(x.innerArray))
+    LinearAlgebra.norm(x::JuMPDict{GenericAffExpr{C,V}},        p::Real=2) where {C,V} = GenericNorm(p, collect(values(x)))
+end
 _vecaff(C,V,x) = map(GenericAffExpr{C,V},vec(x))
-LinearAlgebra.vecnorm(x::V,                   p::Real=2) where {V<:AbstractJuMPScalar} = GenericNorm(p, [GenericAffExpr{Float64,V}(x)] )
-LinearAlgebra.vecnorm(x::AbstractArray{V},    p::Real=2) where {V<:AbstractJuMPScalar} = GenericNorm(p, _vecaff(Float64,V,x) )
-LinearAlgebra.vecnorm(x::JuMPArray{V},        p::Real=2) where {V<:AbstractJuMPScalar} = GenericNorm(p, _vecaff(Float64,V,x.innerArray) )
-LinearAlgebra.vecnorm(x::JuMPDict{V},         p::Real=2) where {V<:AbstractJuMPScalar} = GenericNorm(p, _vecaff(Float64,V,collect(values(x))) )
-LinearAlgebra.vecnorm(x::GenericAffExpr{C,V},                   p::Real=2) where {C,V} = GenericNorm(p, [x])
-LinearAlgebra.vecnorm(x::AbstractArray{GenericAffExpr{C,V}},    p::Real=2) where {C,V} = GenericNorm(p, vec(x))
-LinearAlgebra.vecnorm(x::JuMPArray{GenericAffExpr{C,V}},        p::Real=2) where {C,V} = GenericNorm(p, vec(x.innerArray))
-LinearAlgebra.vecnorm(x::JuMPDict{GenericAffExpr{C,V}},         p::Real=2) where {C,V} = GenericNorm(p, collect(values(x)))
 
 # Called by the parseNorm macro for e.g. norm2{...}
 # If the arguments are tightly typed, just pass to the constructor

--- a/src/parseExpr_staged.jl
+++ b/src/parseExpr_staged.jl
@@ -34,7 +34,7 @@ function addtoexpr(ex::Number, c::Number, x::T) where T<:GenericAffExpr
         T(ex)
     else
         x = copy(x)
-        scale!(x.coeffs, c)
+        rmul!(x.coeffs, c)
         x.constant *= c
         x.constant += ex
         x
@@ -47,8 +47,8 @@ function addtoexpr(ex::Number, c::Number, x::T) where T<:GenericQuadExpr
         T(ex)
     else
         x = copy(x)
-        scale!(x.qcoeffs, c)
-        scale!(x.aff.coeffs, c)
+        rmul!(x.qcoeffs, c)
+        rmul!(x.aff.coeffs, c)
         x.aff.constant *= c
         x.aff.constant += ex
         x

--- a/src/print.jl
+++ b/src/print.jl
@@ -396,7 +396,8 @@ exprstr(n::Norm) = norm_str(REPLMode, n)
 #------------------------------------------------------------------------
 ## JuMPContainer{Variable}
 #------------------------------------------------------------------------
-Base.show(io::IO, j::Union{JuMPContainer{Variable}, Array{Variable}}) = print(io, cont_str(REPLMode,j))
+Base.show(io::IO, j::JuMPContainer{Variable}) = print(io, cont_str(REPLMode,j))
+Base.show(io::IO, j::Array{Variable}) = print(io, cont_str(REPLMode,j))
 Base.show(io::IO, ::MIME"text/latex", j::Union{JuMPContainer{Variable},Array{Variable}}) =
     print(io, cont_str(IJuliaMode,j,mathmode=false))
 # Generic string converter, called by mode-specific handlers

--- a/src/print.jl
+++ b/src/print.jl
@@ -356,7 +356,7 @@ function fill_var_names(mode, colNames, v::Array{Variable})
     name = m.varData[v].name
     for (ii,var) in enumerate(v)
         @assert var.m === m
-        ind = Tuple(CartesianIndices(sizes)[ii])
+        ind = _ind2sub(sizes, ii)
         colNames[var.col] = if mode === IJuliaMode
             string(name, "_{", join(ind, ","), "}")
         else

--- a/src/print.jl
+++ b/src/print.jl
@@ -356,7 +356,7 @@ function fill_var_names(mode, colNames, v::Array{Variable})
     name = m.varData[v].name
     for (ii,var) in enumerate(v)
         @assert var.m === m
-        ind = ind2sub(sizes, ii)
+        ind = Tuple(CartesianIndices(sizes)[ii])
         colNames[var.col] = if mode === IJuliaMode
             string(name, "_{", join(ind, ","), "}")
         else

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -132,7 +132,7 @@ function fillConicDuals(m::Model)
 
     if numRows == 0 || isfinite(m.conicconstrDuals[1]) # NaN could mean unavailable
         if m.objSense == :Min
-            scale!(m.conicconstrDuals, -1)
+            rmul!(m.conicconstrDuals, -1)
         end
         m.linconstrDuals = m.conicconstrDuals[1:numLinRows]
         m.redCosts = zeros(numCols)
@@ -1010,7 +1010,7 @@ function conicdata(m::Model)
 
     # The conic MPB interface defines conic problems as
     # always being minimization problems, so flip if needed
-    m.objSense == :Max && scale!(f, -1.0)
+    m.objSense == :Max && rmul!(f, -1.0)
 
     rescaleSDcols!(f, J, V, m)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -88,7 +88,7 @@ function Base.fill!(v::VectorView{T},value) where T
     end
     nothing
 end
-function LinearAlgebra.scale!(v::VectorView{T},value::T) where T<:Number
+function Compat.rmul!(v::VectorView{T},value::T) where T<:Number
     for i in 1:length(v)
         v[i] *= value
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,23 +22,23 @@ include("solvers.jl")
 
 # Static tests - most don't require a solver
 include("print.jl")
-include("variable.jl")
-include("expr.jl")
-include("operator.jl")
-include("macros.jl")
-
-# Fuzzer of macros to build expressions
-include("fuzzer.jl")
-
-# Solver-dependent tests
-include("model.jl");        length(   lp_solvers) == 0 && @warn("Model tests not run!")
-include("probmod.jl");      length(   lp_solvers) == 0 && @warn("Prob. mod. tests not run!")
-include("callback.jl");     length( lazy_solvers) == 0 && @warn("Callback tests not run!")
-include("qcqpmodel.jl");    length( quad_solvers) == 0 && @warn("Quadratic tests not run!")
-include("nonlinear.jl");    length(  nlp_solvers) == 0 && @warn("Nonlinear tests not run!")
-                            length(minlp_solvers) == 0 && @warn("Mixed-integer Nonlinear tests not run!")
-include("sdp.jl");          length(  sdp_solvers) == 0 && @warn("Semidefinite tests not run!")
-include("socduals.jl");     length(conic_solvers_with_duals) == 0 && @warn("Conic solvers with duals tests not run!")
+#include("variable.jl")
+#include("expr.jl")
+#include("operator.jl")
+#include("macros.jl")
+#
+## Fuzzer of macros to build expressions
+#include("fuzzer.jl")
+#
+## Solver-dependent tests
+#include("model.jl");        length(   lp_solvers) == 0 && @warn("Model tests not run!")
+#include("probmod.jl");      length(   lp_solvers) == 0 && @warn("Prob. mod. tests not run!")
+#include("callback.jl");     length( lazy_solvers) == 0 && @warn("Callback tests not run!")
+#include("qcqpmodel.jl");    length( quad_solvers) == 0 && @warn("Quadratic tests not run!")
+#include("nonlinear.jl");    length(  nlp_solvers) == 0 && @warn("Nonlinear tests not run!")
+#                            length(minlp_solvers) == 0 && @warn("Mixed-integer Nonlinear tests not run!")
+#include("sdp.jl");          length(  sdp_solvers) == 0 && @warn("Semidefinite tests not run!")
+#include("socduals.jl");     length(conic_solvers_with_duals) == 0 && @warn("Conic solvers with duals tests not run!")
 # Throw an error if anything failed
 #FactCheck.exitstatus()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,23 +22,23 @@ include("solvers.jl")
 
 # Static tests - most don't require a solver
 include("print.jl")
-#include("variable.jl")
-#include("expr.jl")
-#include("operator.jl")
-#include("macros.jl")
-#
-## Fuzzer of macros to build expressions
-#include("fuzzer.jl")
-#
-## Solver-dependent tests
-#include("model.jl");        length(   lp_solvers) == 0 && @warn("Model tests not run!")
-#include("probmod.jl");      length(   lp_solvers) == 0 && @warn("Prob. mod. tests not run!")
-#include("callback.jl");     length( lazy_solvers) == 0 && @warn("Callback tests not run!")
-#include("qcqpmodel.jl");    length( quad_solvers) == 0 && @warn("Quadratic tests not run!")
-#include("nonlinear.jl");    length(  nlp_solvers) == 0 && @warn("Nonlinear tests not run!")
-#                            length(minlp_solvers) == 0 && @warn("Mixed-integer Nonlinear tests not run!")
-#include("sdp.jl");          length(  sdp_solvers) == 0 && @warn("Semidefinite tests not run!")
-#include("socduals.jl");     length(conic_solvers_with_duals) == 0 && @warn("Conic solvers with duals tests not run!")
+include("variable.jl")
+include("expr.jl")
+include("operator.jl")
+include("macros.jl")
+
+# Fuzzer of macros to build expressions
+include("fuzzer.jl")
+
+# Solver-dependent tests
+include("model.jl");        length(   lp_solvers) == 0 && @warn("Model tests not run!")
+include("probmod.jl");      length(   lp_solvers) == 0 && @warn("Prob. mod. tests not run!")
+include("callback.jl");     length( lazy_solvers) == 0 && @warn("Callback tests not run!")
+include("qcqpmodel.jl");    length( quad_solvers) == 0 && @warn("Quadratic tests not run!")
+include("nonlinear.jl");    length(  nlp_solvers) == 0 && @warn("Nonlinear tests not run!")
+                            length(minlp_solvers) == 0 && @warn("Mixed-integer Nonlinear tests not run!")
+include("sdp.jl");          length(  sdp_solvers) == 0 && @warn("Semidefinite tests not run!")
+include("socduals.jl");     length(conic_solvers_with_duals) == 0 && @warn("Conic solvers with duals tests not run!")
 # Throw an error if anything failed
 #FactCheck.exitstatus()
 


### PR DESCRIPTION
At the moment tests are failing again on 0.6, I'm still working on this.

In the meantime, perhaps somebody can help me understand the logic behind what type of object should be returned by expressions such as `@variable(m, x[1:N])`.  I'm having a problem right now where 1.0 returns a `JuMPContainer` (seems like the proper behavior?) and 0.6 returns an `Array{Variable}`.  The function `gendict` is getting called in 1.0 to place a constructor in the returned expression for a `JuMPContainer`, but in 0.6 the function `gendict` never gets called, and I'm trying to figure out why.  Thanks!