### PR TITLE
Fix addition of matrices

### DIFF
--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -146,8 +146,8 @@ function destructive_add!(aff::GenericAffExpr{C,V}, c::GenericQuadExpr{C,V}, x::
         GenericQuadExpr{C,V}(aff)
     else
         result = c*x
-        add_to_expression!(result.aff, aff)
-        result
+        add_to_expression!(result, aff)
+        return result
     end
 end
 
@@ -156,8 +156,8 @@ function destructive_add!(aff::GenericAffExpr{C,V}, c::Number, x::GenericQuadExp
         GenericQuadExpr{C,V}(aff)
     else
         result = c*x
-        add_to_expression!(result.aff, aff)
-        result
+        add_to_expression!(result, aff)
+        return result
     end
 end
 
@@ -261,14 +261,32 @@ function destructive_add!(ex::AbstractArray{T}, c::Number, x::AbstractArray) whe
     add_to_expression!.(ex, c*x)
 end
 
+function destructive_add!(ex::AbstractArray{<:GenericAffExpr},
+                          c::AbstractArray{<:GenericQuadExpr},
+                          x::Number)
+    result = c*x
+    add_to_expression!.(result, ex)
+    return result
+end
+function destructive_add!(ex::AbstractArray{<:GenericAffExpr}, c::Number,
+                          x::AbstractArray{<:GenericQuadExpr})
+    result = c*x
+    add_to_expression!.(result, ex)
+    return result
+end
+
+
 destructive_add!(ex, c, x) = ex + c*x
 destructive_add!(ex, c, x::AbstractArray) = (ex,) .+ c*x
 destructive_add!(ex::AbstractArray, c, x) = ex .+ (c*x,)
+destructive_add!(ex::AbstractArray, c::AbstractArray, x) = ex .+ c*x
 destructive_add!(ex::AbstractArray, c, x::AbstractArray) = ex .+ c*x
 
 destructive_add_with_reorder!(ex, arg) = destructive_add!(ex, 1.0, arg)
 # Special case because "Val{false}()" is used as the default empty expression.
 destructive_add_with_reorder!(ex::Val{false}, arg) = copy(arg)
+# Calling `copy` on the matrix will not copy the entries
+destructive_add_with_reorder!(ex::Val{false}, arg::AbstractArray) = copy.(arg)
 destructive_add_with_reorder!(ex::Val{false}, args...) = (*)(args...)
 
 

--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -287,6 +287,9 @@ destructive_add_with_reorder!(ex, arg) = destructive_add!(ex, 1.0, arg)
 destructive_add_with_reorder!(ex::Val{false}, arg) = copy(arg)
 # Calling `copy` on the matrix will not copy the entries
 destructive_add_with_reorder!(ex::Val{false}, arg::AbstractArray) = copy.(arg)
+function destructive_add_with_reorder!(ex::Val{false}, arg::Symmetric)
+    Symmetric(copy.(arg))
+end
 destructive_add_with_reorder!(ex::Val{false}, args...) = (*)(args...)
 
 

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -126,6 +126,11 @@ function add_to_expression!(quad::GenericQuadExpr{C, V}, new_coef::C, new_var::V
     quad
 end
 
+function add_to_expression!(q::GenericQuadExpr{T,S}, other::GenericAffExpr{T,S}) where {T,S}
+    add_to_expression!(q.aff, other)
+    return q
+end
+
 function add_to_expression!(q::GenericQuadExpr{T,S}, other::GenericQuadExpr{T,S}) where {T,S}
     merge!(+, q.terms, other.terms)
     add_to_expression!(q.aff, other.aff)

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -371,6 +371,28 @@ function operators_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
                   0     0 2X23^2
                   0     0      0]
             v = [4, 5, 6]
+
+            @testset "Sum of matrices" begin
+                @test_expression(Xd + Yd)
+                @test_expression(Xd + 2Yd)
+                @test_expression(Xd + Yd * 2)
+                @test_expression(Yd + Xd)
+                @test_expression(Yd + 2Xd)
+                @test_expression(Yd + Xd * 2)
+                @test_expression(Yd + Zd)
+                @test_expression(Yd + 2Zd)
+                @test_expression(Yd + Zd * 2)
+                @test_expression(Zd + Yd)
+                @test_expression(Zd + 2Yd)
+                @test_expression(Zd + Yd * 2)
+                @test_expression(Zd + Xd)
+                @test_expression(Zd + 2Xd)
+                @test_expression(Zd + Xd * 2)
+                @test_expression(Xd + Zd)
+                @test_expression(Xd + 2Zd)
+                @test_expression(Xd + Zd * 2)
+            end
+
             @test JuMP.isequal_canonical(A*x, [2x[1] +  x[2]
                                2x[2] +  x[1] + x[3]
                                 x[2] + 2x[3]])


### PR DESCRIPTION
This PR adds a few tests that cover in particular the bug of https://github.com/JuliaOpt/JuMP.jl/issues/1422. There was also a more subtle bug that was caught with these tests: taking the copy of the matrix do not copy its elements. Taking a deepcopy will copy the model so we don't want to replace copy with deepcopy. The simple fix is to broadcast copy.

Related to https://github.com/JuliaOpt/JuMP.jl/issues/1422 (does not close it as it also need to be fixed on JuMP v0.18)