### PR TITLE
Fix index set parsing in JuMP macros on Julia 1.0.

### DIFF
--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -4,7 +4,11 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 function tryParseIdxSet(arg::Expr)
-    if arg.head === :(=)
+    if arg.head === :kw  # Julia 1.0 onwards.
+        @assert length(arg.args) == 2
+        return true, arg.args[1], arg.args[2]
+    # TODO(IainNZ): Remove after dropping support for pre-1.0 Julia?
+    elseif arg.head === :(=)
         @assert length(arg.args) == 2
         return true, arg.args[1], arg.args[2]
     elseif isexpr(arg, :call) && arg.args[1] === :in

--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -4,10 +4,10 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 function tryParseIdxSet(arg::Expr)
-    if arg.head === :kw  # Julia 1.0 onwards.
-        @assert length(arg.args) == 2
-        return true, arg.args[1], arg.args[2]
-    # TODO(IainNZ): Remove after dropping support for pre-1.0 Julia?
+    is_julia_v1 = @static (VERSION >= v"1.0-" ? true : false)
+    if is_julia_v1 && arg.head === :kw
+            @assert length(arg.args) == 2
+            return true, arg.args[1], arg.args[2]
     elseif arg.head === :(=)
         @assert length(arg.args) == 2
         return true, arg.args[1], arg.args[2]


### PR DESCRIPTION
This is a change introduced between Julia v0.7 and v1.0.