### PR TITLE
Move isequal_canonical definition out of test, fix TODO.

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -375,7 +375,7 @@ Base.isempty(::AbstractJuMPScalar) = false
 # Check if two arrays of AbstractJuMPScalars are equal. Useful for testing.
 function isequal_canonical(x::AbstractArray{<:JuMP.AbstractJuMPScalar},
                            y::AbstractArray{<:JuMP.AbstractJuMPScalar})
-    size(x) == size(y) && all(JuMP.isequal_canonical.(x, y))
+    return size(x) == size(y) && all(JuMP.isequal_canonical.(x, y))
 end
 
 """

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -372,6 +372,12 @@ else
 end
 Base.isempty(::AbstractJuMPScalar) = false
 
+# Check if two arrays of AbstractJuMPScalars are equal. Useful for testing.
+function isequal_canonical(x::AbstractArray{<:JuMP.AbstractJuMPScalar},
+                           y::AbstractArray{<:JuMP.AbstractJuMPScalar})
+    size(x) == size(y) && all(JuMP.isequal_canonical.(x, y))
+end
+
 """
     AbstractShape
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,12 +22,6 @@ const MOI = MathOptInterface
 const MOIT = MOI.Test
 const MOIU = MOI.Utilities
 
-# TODO: This should be defined in JuMP source with the other versions of
-# isequal_canonical.
-function JuMP.isequal_canonical(x::AbstractArray{<:JuMP.AbstractJuMPScalar}, y::AbstractArray{<:JuMP.AbstractJuMPScalar})
-    size(x) == size(y) && all(JuMP.isequal_canonical.(x, y))
-end
-
 macro test_expression(expr)
     esc(quote
             @test JuMP.isequal_canonical(@expression(m, $expr), $expr)


### PR DESCRIPTION
This is seemingly only used by test/operator.jl, but I think the TODO is
correct and moving this with other methods for AbstractJS is better.