### PR TITLE
rename user-facing functions for style compliance

### DIFF
--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -5,7 +5,7 @@ DRAFT: Describe how constraints are represented (link to MOI docs). Constraints
 are very similar to variables in (1) how names work (2) how attributes work, and
 (3) the macro syntax for constructing them. They're a bit different because
 they're parameterized by function-set type. Describe constraints vs.
-`ConstraintRefs`. Describe `JuMP.constraintobject`. How to delete constraints.
+`ConstraintRefs`. Describe `JuMP.constraint_object`. How to delete constraints.
 How to modify constraints by setting attributes and `MOI.modifyconstraint!`.
 Describe semidefinite constraints and symmetry handling. Refer to NLP docs for
 nonlinear constraints.

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -65,9 +65,9 @@ with_optimizer
 ```
 
 The factory can be provided either at model construction time or at
-[`JuMP.optimize`](@ref) time:
+[`JuMP.optimize!`](@ref) time:
 ```@docs
-JuMP.optimize
+JuMP.optimize!
 ```
 
 New JuMP models are created using the [`Model`](@ref) constructor:

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -135,33 +135,33 @@ In the above examples, `x_free` represents an unbounded optimization variable,
     `b` is the intended variable name, or vice-versa.
 
 We can query whether an optimization variable has a lower- or upper-bound via
-the `JuMP.haslowerbound` and `JuMP.hasupperbound` functions. For example:
+the `JuMP.has_lower_bound` and `JuMP.has_upper_bound` functions. For example:
 ```jldoctest variables_2
-julia> JuMP.haslowerbound(x_free)
+julia> JuMP.has_lower_bound(x_free)
 false
 
-julia> JuMP.hasupperbound(x_upper)
+julia> JuMP.has_upper_bound(x_upper)
 true
 ```
 
 If a variable has a lower or upper bound, we can query the value of it via the
-`JuMP.lowerbound` and `JuMP.upperbound` functions. For example:
+`JuMP.lower_bound` and `JuMP.upper_bound` functions. For example:
 ```jldoctest variables_2
-julia> JuMP.lowerbound(x_interval)
+julia> JuMP.lower_bound(x_interval)
 2.0
 
-julia> JuMP.upperbound(x_interval)
+julia> JuMP.upper_bound(x_interval)
 3.0
 ```
 Querying the value of a bound that does not exist will result in an error.
 
-Instead of using the `<=` and `>=` syntax, we can also use the `lowerbound` and
-`upperbound` keyword arguments. For example:
+Instead of using the `<=` and `>=` syntax, we can also use the `lower_bound` and
+`upper_bound` keyword arguments. For example:
 ```jldoctest; setup=:(model=Model())
-julia> @variable(model, x, lowerbound=1, upperbound=2)
+julia> @variable(model, x, lower_bound=1, upper_bound=2)
 x
 
-julia> JuMP.lowerbound(x)
+julia> JuMP.lower_bound(x)
 1.0
 ```
 
@@ -210,7 +210,7 @@ julia> @variable(model, x[i=1:2, j=1:2] >= 2i + j)
  x[1,1]  x[1,2]
  x[2,1]  x[2,2]
 
-julia> JuMP.lowerbound.(x)
+julia> JuMP.lower_bound.(x)
 2×2 Array{Float64,2}:
  3.0  4.0
  5.0  6.0
@@ -262,7 +262,7 @@ And data, a 2×2 Array{JuMP.VariableRef,2}:
  x[2,1]  x[2,3]
  x[3,1]  x[3,3]
 
-julia> JuMP.lowerbound.(x)
+julia> JuMP.lower_bound.(x)
 2-dimensional JuMPArray{Float64,2,...} with index sets:
     Dimension 1, 2:3
     Dimension 2, 1:2:3
@@ -345,10 +345,10 @@ created in JuMP by passing `Bin` as an optional positional argument:
 julia> @variable(model, x, Bin)
 x
 ```
-We can check if an optimization variable is binary by calling `JuMP.isbinary` on
+We can check if an optimization variable is binary by calling `JuMP.is_binary` on
 the JuMP variable:
 ```jldoctest variables_binary
-julia> JuMP.isbinary(x)
+julia> JuMP.is_binary(x)
 true
 ```
 Binary optimization variables can also be created by setting the `binary`
@@ -373,10 +373,10 @@ keyword to `true`.
 julia> @variable(model, x, integer=true)
 x
 ```
-We can check if an optimization variable is integer by calling `JuMP.isinteger`
+We can check if an optimization variable is integer by calling `JuMP.is_integer`
 on the JuMP variable:
 ```jldoctest variables_integer
-julia> JuMP.isinteger(x)
+julia> JuMP.is_integer(x)
 true
 ```
 
@@ -433,14 +433,14 @@ If necessary, you can store `x` in `model` as follows:
 julia> model[:x] = x
 ```
 The `<=` and `>=` short-hand cannot be used to set bounds on anonymous JuMP
-variables. Instead, you should use the `lowerbound` and `upperbound` keywords.
+variables. Instead, you should use the `lower_bound` and `upper_bound` keywords.
 
 Passing the `Bin` and `Int` variable types are also invalid. Instead, you should
 use the `binary` and `integer` keywords.
 
 Thus, the anonymous variant of `@variable(model, x[i=1:2] >= i, Int)` is:
 ```jldoctest; setup=:(model=Model())
-julia> x = @variable(model, [i=1:2], basename="x", lowerbound=i, integer=true)
+julia> x = @variable(model, [i=1:2], basename="x", lower_bound=i, integer=true)
 2-element Array{JuMP.VariableRef,1}:
  x[1]
  x[2]

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -9,7 +9,7 @@ mutable struct NonlinearExprData
     const_values::Vector{Float64}
 end
 
-function setobjective(m::Model, sense::Symbol, ex::NonlinearExprData)
+function set_objective(m::Model, sense::Symbol, ex::NonlinearExprData)
     initNLP(m)
     if sense == :Min
         moisense = MOI.MinSense
@@ -117,7 +117,7 @@ function initNLP(m::Model)
     end
 end
 
-function resultdual(c::ConstraintRef{Model,NonlinearConstraintIndex})
+function result_dual(c::ConstraintRef{Model,NonlinearConstraintIndex})
     initNLP(c.m)
     nldata::NLPData = c.m.nlp_data
     if !MOI.canget(c.m, MOI.NLPBlockDual())
@@ -1076,7 +1076,7 @@ function register(m::Model, s::Symbol, dimension::Integer, f::Function, ∇f::Fu
 end
 
 # Ex: setNLobjective(m, :Min, :($x + $y^2))
-setNLobjective(m::Model, sense::Symbol, x) = setobjective(m, sense, NonlinearExprData(m, x))
+setNLobjective(m::Model, sense::Symbol, x) = set_objective(m, sense, NonlinearExprData(m, x))
 
 # Ex: addNLconstraint(m, :($x + $y^2 <= 1))
 function addNLconstraint(m::Model, ex::Expr)

--- a/src/optimizerinterface.jl
+++ b/src/optimizerinterface.jl
@@ -27,16 +27,16 @@ end
 
 
 """
-    function optimize(model::Model,
-                      optimizer_factory::Union{Nothing, OptimizerFactory} = nothing;
-                      ignore_optimize_hook=(model.optimize_hook===nothing))
+    function optimize!(model::Model,
+                       optimizer_factory::Union{Nothing, OptimizerFactory}=nothing;
+                       ignore_optimize_hook=(model.optimize_hook === nothing))
 
 Optimize the model. If `optimizer_factory` is not `nothing`, it first set the
 optimizer to a new one created using the optimizer factory.
 """
-function optimize(model::Model,
-                  optimizer_factory::Union{Nothing, OptimizerFactory} = nothing;
-                  ignore_optimize_hook=(model.optimize_hook===nothing))
+function optimize!(model::Model,
+                   optimizer_factory::Union{Nothing, OptimizerFactory}=nothing;
+                   ignore_optimize_hook=(model.optimize_hook === nothing))
     # The nlp_data is not kept in sync, so re-set it here.
     # TODO: Consider how to handle incremental solves.
     if model.nlp_data !== nothing

--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -3,7 +3,7 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-function tryParseIdxSet(arg::Expr)
+function try_parse_idx_set(arg::Expr)
     is_julia_v1 = @static (VERSION >= v"1.0-" ? true : false)
     if is_julia_v1 && arg.head === :kw
             @assert length(arg.args) == 2
@@ -18,8 +18,8 @@ function tryParseIdxSet(arg::Expr)
     end
 end
 
-function parseIdxSet(arg::Expr)
-    parse_done, idxvar, idxset = tryParseIdxSet(arg)
+function parse_idx_set(arg::Expr)
+    parse_done, idxvar, idxset = try_parse_idx_set(arg)
     if parse_done
         return idxvar, idxset
     end
@@ -104,8 +104,8 @@ end
 
 function destructive_add!(aff::GenericAffExpr{C,V},c::Number,x::GenericAffExpr{C,V}) where {C,V}
     if !iszero(c)
-        sizehint!(aff, length(linearterms(aff)) + length(linearterms(x)))
-        for (coef, var) in linearterms(x)
+        sizehint!(aff, length(linear_terms(aff)) + length(linear_terms(x)))
+        for (coef, var) in linear_terms(x)
             add_to_expression!(aff, c*coef, var)
         end
         aff.constant += c*x.constant
@@ -198,7 +198,7 @@ function destructive_add!(quad::GenericQuadExpr{C,V},c::GenericAffExpr{C,V},x::N
 end
 
 function destructive_add!(quad::GenericQuadExpr{C,V},c::GenericAffExpr{C,V},x::V) where {C,V}
-    for (coef, var) in linearterms(c)
+    for (coef, var) in linear_terms(c)
         add_to_expression!(quad, coef, var, x)
     end
     if !iszero(c.constant)
@@ -208,7 +208,7 @@ function destructive_add!(quad::GenericQuadExpr{C,V},c::GenericAffExpr{C,V},x::V
 end
 
 function destructive_add!(quad::GenericQuadExpr{C,V},c::V,x::GenericAffExpr{C,V}) where {C,V}
-    for (coef, var) in linearterms(x)
+    for (coef, var) in linear_terms(x)
         add_to_expression!(quad, coef, c, var)
     end
     if !iszero(x.constant)
@@ -336,14 +336,14 @@ function parsegen(ex,atleaf)
                     Expr(:if,esc(ex.args[2].args[1]),
                           parsegen(ex.args[1],atleaf)))
         for idxset in ex.args[2].args[2:end]
-            idxvar, s = parseIdxSet(idxset)
+            idxvar, s = parse_idx_set(idxset)
             push!(idxvars,idxvar)
         end
     else
         loop = Expr(:for,esc(itrsets(ex.args[2:end])),
                          parsegen(ex.args[1],atleaf))
         for idxset in ex.args[2:end]
-            idxvar, s = parseIdxSet(idxset)
+            idxvar, s = parse_idx_set(idxset)
             push!(idxvars,idxvar)
         end
     end

--- a/src/print.jl
+++ b/src/print.jl
@@ -182,14 +182,14 @@ end
 
 function aff_string(mode, a::GenericAffExpr, show_constant=true)
     # If the expression is empty, return the constant (or 0)
-    if length(linearterms(a)) == 0
+    if length(linear_terms(a)) == 0
         return show_constant ? string_round(a.constant) : "0"
     end
 
-    term_str = Array{String}(undef, 2 * length(linearterms(a)))
+    term_str = Array{String}(undef, 2 * length(linear_terms(a)))
     elm = 1
     # For each non-zero for this model
-    for (coef, var) in linearterms(a)
+    for (coef, var) in linear_terms(a)
         is_zero_for_printing(coef) && continue  # e.g. x - x
 
         pre = is_one_for_printing(coef) ? "" : string_round(abs(coef)) * " "
@@ -273,14 +273,10 @@ end
 #------------------------------------------------------------------------
 
 function Base.show(io::IO, ref::ConstraintRef{Model})
-    constraint_object = constraintobject(ref)
-    constraint_name = name(ref)
-    print(io, constraint_string(REPLMode, constraint_name, constraint_object))
+    print(io, constraint_string(REPLMode, name(ref), constraint_object(ref)))
 end
 function Base.show(io::IO, ::MIME"text/latex", ref::ConstraintRef{Model})
-    constraint_object = constraintobject(ref)
-    constraint_name = name(ref)
-    print(io, constraint_string(IJuliaMode, constraint_name, constraint_object))
+    print(io, constraint_string(IJuliaMode, name(ref), constraint_object(ref)))
 end
 
 function function_string(print_mode, variable::AbstractVariableRef)

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -77,12 +77,12 @@ function map_coefficients(f::Function, q::GenericQuadExpr)
 end
 
 """
-    linearterms(aff::GenericQuadExpr{C, V})
+    linear_terms(aff::GenericQuadExpr{C, V})
 
 Provides an iterator over tuples `(coefficient::C, variable::V)` in the
 linear part of the quadratic expression.
 """
-linearterms(quad::GenericQuadExpr) = LinearTermIterator(quad.aff)
+linear_terms(quad::GenericQuadExpr) = LinearTermIterator(quad.aff)
 
 struct QuadTermIterator{GQE<:GenericQuadExpr}
     quad::GQE
@@ -203,7 +203,7 @@ function QuadExpr(m::Model, f::MOI.ScalarQuadraticFunction)
     return quad
 end
 
-function setobjective(m::Model, sense::Symbol, a::QuadExpr)
+function set_objective(m::Model, sense::Symbol, a::QuadExpr)
     if sense == :Min
         moisense = MOI.MinSense
     else
@@ -216,12 +216,12 @@ function setobjective(m::Model, sense::Symbol, a::QuadExpr)
 end
 
 """
-    objectivefunction(m::Model, ::Type{QuadExpr})
+    objective_function(m::Model, ::Type{QuadExpr})
 
 Return a `QuadExpr` object representing the objective function.
 Error if the objective is not quadratic.
 """
-function objectivefunction(m::Model, ::Type{QuadExpr})
+function objective_function(m::Model, ::Type{QuadExpr})
     f = MOI.get(m.moi_backend, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())::MOI.ScalarQuadraticFunction
     return QuadExpr(m, f)
 end
@@ -233,7 +233,7 @@ function Base.copy(q::GenericQuadExpr, new_model::Model)
                 copy(q.qcoeffs), copy(q.aff, new_model))
 end
 
-# TODO: resultvalue for QuadExpr
+# TODO: result_value for QuadExpr
 
 ##########################################################################
 # TODO: GenericQuadExprConstraint
@@ -246,7 +246,7 @@ end
 moi_function_and_set(c::QuadExprConstraint) = (MOI.ScalarQuadraticFunction(c.func), c.set)
 shape(::QuadExprConstraint) = ScalarShape()
 
-function constraintobject(ref::ConstraintRef{Model, MOICON{FuncType, SetType}}) where
+function constraint_object(ref::ConstraintRef{Model, MOICON{FuncType, SetType}}) where
         {FuncType <: MOI.ScalarQuadraticFunction, SetType <: MOI.AbstractScalarSet}
     model = ref.m
     f = MOI.get(model, MOI.ConstraintFunction(), ref)::FuncType

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -7,69 +7,73 @@ abstract type AbstractVariable end
 
 # Any fields can usually be either a number or an expression
 mutable struct VariableInfoExpr
-    haslb::Bool
-    lowerbound::Any
-    hasub::Bool
-    upperbound::Any
-    hasfix::Bool
-    fixedvalue::Any
-    hasstart::Bool
+    has_lb::Bool
+    lower_bound::Any
+    has_ub::Bool
+    upper_bound::Any
+    has_fix::Bool
+    fixed_value::Any
+    has_start::Bool
     start::Any
     binary::Any
     integer::Any
 end
 
-function setlowerbound_or_error(_error::Function, info::VariableInfoExpr, lower)
-    info.haslb && _error("Cannot specify variable lowerbound twice")
-    info.haslb = true
-    info.lowerbound = lower
+function set_lower_bound_or_error(_error::Function, info::VariableInfoExpr, lower)
+    info.has_lb && _error("Cannot specify variable lower_bound twice")
+    info.has_lb = true
+    info.lower_bound = lower
 end
-function setupperbound_or_error(_error::Function, info::VariableInfoExpr, upper)
-    info.hasub && _error("Cannot specify variable lowerbound twice")
-    info.hasub = true
-    info.upperbound = upper
+function set_upper_bound_or_error(_error::Function, info::VariableInfoExpr, upper)
+    info.has_ub && _error("Cannot specify variable upper_bound twice")
+    info.has_ub = true
+    info.upper_bound = upper
 end
 function fix_or_error(_error::Function, info::VariableInfoExpr, value)
-    info.hasfix && _error("Cannot specify variable fixed value twice")
-    info.hasfix = true
-    info.fixedvalue = value
+    info.has_fix && _error("Cannot specify variable fixed value twice")
+    info.has_fix = true
+    info.fixed_value = value
 end
-function setbinary_or_error(_error::Function, info::VariableInfoExpr)
+function set_binary_or_error(_error::Function, info::VariableInfoExpr)
     info.binary === false || _error("'Bin' and 'binary' keyword argument cannot both be specified.")
     info.binary = true
 end
-function setinteger_or_error(_error::Function, info::VariableInfoExpr)
+function set_integer_or_error(_error::Function, info::VariableInfoExpr)
     info.integer === false || _error("'Int' and 'integer' keyword argument cannot both be specified.")
     info.integer = true
 end
 
-function isinfokeyword(kw::Expr)
-    kw.args[1] in [:lowerbound, :upperbound, :start, :binary, :integer]
+function is_info_keyword(kw::Expr)
+    kw.args[1] in [:lower_bound, :upper_bound, :start, :binary, :integer]
 end
 # :(start = 0)     -> (:start, 0)
 # :(start = i + 1) -> (:start, :($(Expr(:escape, :(i + 1)))))
 function keywordify(kw::Expr)
     (kw.args[1], esc_nonconstant(kw.args[2]))
 end
-function VariableInfoExpr(; lowerbound=NaN, upperbound=NaN, start=NaN, binary=false, integer=false)
+function VariableInfoExpr(; lower_bound=NaN, upper_bound=NaN, start=NaN, binary=false, integer=false)
     # isnan(::Expr) is not defined so we need to do !== NaN
-    VariableInfoExpr(lowerbound !== NaN, lowerbound, upperbound !== NaN, upperbound, false, NaN, start !== NaN, start, binary, integer)
+    VariableInfoExpr(lower_bound !== NaN, lower_bound, upper_bound !== NaN, upper_bound, false, NaN, start !== NaN, start, binary, integer)
 end
 
 mutable struct VariableInfo{S, T, U, V}
-    haslb::Bool
-    lowerbound::S
-    hasub::Bool
-    upperbound::T
-    hasfix::Bool
-    fixedvalue::U
-    hasstart::Bool
+    has_lb::Bool
+    lower_bound::S
+    has_ub::Bool
+    upper_bound::T
+    has_fix::Bool
+    fixed_value::U
+    has_start::Bool
     start::V
     binary::Bool
     integer::Bool
 end
 
-constructor_expr(info::VariableInfoExpr) = :(VariableInfo($(info.haslb), $(info.lowerbound), $(info.hasub), $(info.upperbound), $(info.hasfix), $(info.fixedvalue), $(info.hasstart), $(info.start), $(info.binary), $(info.integer)))
+function constructor_expr(info::VariableInfoExpr)
+    return :(VariableInfo($(info.has_lb), $(info.lower_bound), $(info.has_ub),
+             $(info.upper_bound), $(info.has_fix), $(info.fixed_value),
+             $(info.has_start), $(info.start), $(info.binary), $(info.integer)))
+end
 
 struct ScalarVariable{S, T, U, V} <: AbstractVariable
     info::VariableInfo{S, T, U, V}
@@ -78,11 +82,13 @@ end
 """
     AbstractVariableRef
 
-Variable returned by [`addvariable`](@ref). Affine (resp. quadratic) operations with variables of type `V<:AbstractVariableRef` and coefficients of type `T` create a `GenericAffExpr{T,V}` (resp. `GenericQuadExpr{T,V}`).
+Variable returned by [`add_variable`](@ref). Affine (resp. quadratic) operations
+with variables of type `V<:AbstractVariableRef` and coefficients of type `T`
+    create a `GenericAffExpr{T,V}` (resp. `GenericQuadExpr{T,V}`).
 """
 abstract type AbstractVariableRef <: AbstractJuMPScalar end
 
-variablereftype(v::AbstractVariableRef) = typeof(v)
+variable_ref_type(v::AbstractVariableRef) = typeof(v)
 
 """
     VariableRef <: AbstractVariableRef
@@ -174,11 +180,11 @@ Get a variable's name.
 name(v::VariableRef) = MOI.get(v.m, MOI.VariableName(), v)
 
 """
-    setname(v::VariableRef,s::AbstractString)
+    set_name(v::VariableRef,s::AbstractString)
 
 Set a variable's name.
 """
-setname(v::VariableRef, s::String) = MOI.set!(v.m, MOI.VariableName(), v, s)
+set_name(v::VariableRef, s::String) = MOI.set!(v.m, MOI.VariableName(), v, s)
 
 MOI.SingleVariable(v::VariableRef) = MOI.SingleVariable(index(v))
 
@@ -187,7 +193,7 @@ MOI.VectorOfVariables(vars::Vector{VariableRef}) = MOI.VectorOfVariables(index.(
 
 VariableRef(m::Model, f::MOI.SingleVariable) = VariableRef(m, f.variable)
 
-function setobjective(m::Model, sense::Symbol, x::VariableRef)
+function set_objective(m::Model, sense::Symbol, x::VariableRef)
     # TODO: This code is repeated here, for GenericAffExpr, and for GenericQuadExpr.
     if sense == :Min
         moisense = MOI.MinSense
@@ -196,16 +202,17 @@ function setobjective(m::Model, sense::Symbol, x::VariableRef)
         moisense = MOI.MaxSense
     end
     MOI.set!(m.moi_backend, MOI.ObjectiveSense(), moisense)
-    MOI.set!(m.moi_backend, MOI.ObjectiveFunction{MOI.SingleVariable}(), MOI.SingleVariable(x))
+    MOI.set!(m.moi_backend, MOI.ObjectiveFunction{MOI.SingleVariable}(),
+             MOI.SingleVariable(x))
 end
 
 """
-    objectivefunction(m::Model, ::Type{VariableRef})
+    objective_function(m::Model, ::Type{VariableRef})
 
 Return a `VariableRef` object representing the objective function.
 Error if the objective is not a `SingleVariable`.
 """
-function objectivefunction(m::Model, ::Type{VariableRef})
+function objective_function(m::Model, ::Type{VariableRef})
     f = MOI.get(m.moi_backend, MOI.ObjectiveFunction{MOI.SingleVariable}())::MOI.SingleVariable
     return VariableRef(m, f)
 end
@@ -232,7 +239,7 @@ end
 moi_function_and_set(c::VectorOfVariablesConstraint) = (MOI.VectorOfVariables(c.func), c.set)
 shape(c::VectorOfVariablesConstraint) = c.shape
 
-function constraintobject(ref::ConstraintRef{Model, MOICON{FuncType, SetType}}) where
+function constraint_object(ref::ConstraintRef{Model, MOICON{FuncType, SetType}}) where
         {FuncType <: MOI.SingleVariable, SetType <: MOI.AbstractScalarSet}
     model = ref.m
     f = MOI.get(model, MOI.ConstraintFunction(), ref)::FuncType
@@ -240,7 +247,7 @@ function constraintobject(ref::ConstraintRef{Model, MOICON{FuncType, SetType}}) 
     return SingleVariableConstraint(VariableRef(model, f), s)
 end
 
-function constraintobject(ref::ConstraintRef{Model, MOICON{FuncType, SetType}}) where
+function constraint_object(ref::ConstraintRef{Model, MOICON{FuncType, SetType}}) where
         {FuncType <: MOI.VectorOfVariables, SetType <: MOI.AbstractVectorSet}
     model = ref.m
     f = MOI.get(model, MOI.ConstraintFunction(), ref)::FuncType
@@ -254,127 +261,127 @@ end
 
 # lower bounds
 
-haslowerbound(v::VariableRef) = haskey(v.m.variable_to_lower_bound,index(v))
+has_lower_bound(v::VariableRef) = haskey(v.m.variable_to_lower_bound,index(v))
 
-function lowerboundindex(v::VariableRef)
-    @assert haslowerbound(v) # TODO error message
+function lower_bound_index(v::VariableRef)
+    @assert has_lower_bound(v) # TODO error message
     return v.m.variable_to_lower_bound[index(v)]
 end
-function setlowerboundindex(v::VariableRef, cindex::MOILB)
+function set_lower_bound_index(v::VariableRef, cindex::MOILB)
     v.m.variable_to_lower_bound[index(v)] = cindex
 end
 
 """
-    setlowerbound(v::VariableRef,lower::Number)
+    set_lower_bound(v::VariableRef,lower::Number)
 
 Set the lower bound of a variable. If one does not exist, create a new lower bound constraint.
 """
-function setlowerbound(v::VariableRef,lower::Number)
+function set_lower_bound(v::VariableRef,lower::Number)
     newset = MOI.GreaterThan(convert(Float64,lower))
     # do we have a lower bound already?
-    if haslowerbound(v)
-        cindex = lowerboundindex(v)
+    if has_lower_bound(v)
+        cindex = lower_bound_index(v)
         MOI.set!(v.m.moi_backend, MOI.ConstraintSet(), cindex, newset)
     else
-        @assert !isfixed(v)
+        @assert !is_fixed(v)
         cindex = MOI.addconstraint!(v.m.moi_backend, MOI.SingleVariable(index(v)), newset)
-        setlowerboundindex(v, cindex)
+        set_lower_bound_index(v, cindex)
     end
     nothing
 end
 
 function LowerBoundRef(v::VariableRef)
-    return ConstraintRef{Model, MOILB, ScalarShape}(v.m, lowerboundindex(v),
+    return ConstraintRef{Model, MOILB, ScalarShape}(v.m, lower_bound_index(v),
                                                     ScalarShape())
 end
 
 """
-    deletelowerbound(v::VariableRef)
+    delete_lower_bound(v::VariableRef)
 
 Delete the lower bound constraint of a variable.
 """
-function deletelowerbound(v::VariableRef)
+function delete_lower_bound(v::VariableRef)
     MOI.delete!(v.m, LowerBoundRef(v))
     delete!(v.m.variable_to_lower_bound, index(v))
     nothing
 end
 
 """
-    lowerbound(v::VariableRef)
+    lower_bound(v::VariableRef)
 
 Return the lower bound of a variable. Error if one does not exist.
 """
-function lowerbound(v::VariableRef)
+function lower_bound(v::VariableRef)
     cset = MOI.get(v.m, MOI.ConstraintSet(), LowerBoundRef(v))::MOI.GreaterThan
     return cset.lower
 end
 
 # upper bounds
 
-hasupperbound(v::VariableRef) = haskey(v.m.variable_to_upper_bound,index(v))
+has_upper_bound(v::VariableRef) = haskey(v.m.variable_to_upper_bound,index(v))
 
-function upperboundindex(v::VariableRef)
-    @assert hasupperbound(v) # TODO error message
+function upper_bound_index(v::VariableRef)
+    @assert has_upper_bound(v) # TODO error message
     return v.m.variable_to_upper_bound[index(v)]
 end
-function setupperboundindex(v::VariableRef, cindex::MOIUB)
+function set_upper_bound_index(v::VariableRef, cindex::MOIUB)
     v.m.variable_to_upper_bound[index(v)] = cindex
 end
 
 """
-    setupperbound(v::VariableRef,upper::Number)
+    set_upper_bound(v::VariableRef,upper::Number)
 
 Set the upper bound of a variable. If one does not exist, create an upper bound constraint.
 """
-function setupperbound(v::VariableRef,upper::Number)
+function set_upper_bound(v::VariableRef,upper::Number)
     newset = MOI.LessThan(convert(Float64,upper))
     # do we have an upper bound already?
-    if hasupperbound(v)
-        cindex = upperboundindex(v)
+    if has_upper_bound(v)
+        cindex = upper_bound_index(v)
         MOI.set!(v.m.moi_backend, MOI.ConstraintSet(), cindex, newset)
     else
-        @assert !isfixed(v)
+        @assert !is_fixed(v)
         cindex = MOI.addconstraint!(v.m.moi_backend, MOI.SingleVariable(index(v)), newset)
-        setupperboundindex(v, cindex)
+        set_upper_bound_index(v, cindex)
     end
     nothing
 end
 
 function UpperBoundRef(v::VariableRef)
-    return ConstraintRef{Model, MOIUB, ScalarShape}(v.m, upperboundindex(v),
+    return ConstraintRef{Model, MOIUB, ScalarShape}(v.m, upper_bound_index(v),
                                                     ScalarShape())
 end
 
 """
-    deleteupperbound(v::VariableRef)
+    delete_upper_bound(v::VariableRef)
 
 Delete the upper bound constraint of a variable.
 """
-function deleteupperbound(v::VariableRef)
+function delete_upper_bound(v::VariableRef)
     MOI.delete!(v.m, UpperBoundRef(v))
     delete!(v.m.variable_to_upper_bound, index(v))
     nothing
 end
 
 """
-    upperbound(v::VariableRef)
+    upper_bound(v::VariableRef)
 
 Return the upper bound of a variable. Error if one does not exist.
 """
-function upperbound(v::VariableRef)
+function upper_bound(v::VariableRef)
     cset = MOI.get(v.m, MOI.ConstraintSet(), UpperBoundRef(v))::MOI.LessThan
     return cset.upper
 end
 
 # fixed value
 
-isfixed(v::VariableRef) = haskey(v.m.variable_to_fix,index(v))
+is_fixed(v::VariableRef) = haskey(v.m.variable_to_fix,index(v))
 
-function fixindex(v::VariableRef)
-    @assert isfixed(v) # TODO error message
+function fix_index(v::VariableRef)
+    @assert is_fixed(v) # TODO error message
     return v.m.variable_to_fix[index(v)]
 end
-function setfixindex(v::VariableRef, cindex::MOIFIX)
+function set_fix_index(v::VariableRef, cindex::MOIFIX)
     v.m.variable_to_fix[index(v)] = cindex
 end
 
@@ -386,13 +393,13 @@ Fix a variable to a value. Update the fixing constraint if one exists, otherwise
 function fix(v::VariableRef,upper::Number)
     newset = MOI.EqualTo(convert(Float64,upper))
     # are we already fixed?
-    if isfixed(v)
-        cindex = fixindex(v)
+    if is_fixed(v)
+        cindex = fix_index(v)
         MOI.set!(v.m.moi_backend, MOI.ConstraintSet(), cindex, newset)
     else
-        @assert !hasupperbound(v) && !haslowerbound(v) # Do we want to remove these instead of throwing an error?
+        @assert !has_upper_bound(v) && !has_lower_bound(v) # Do we want to remove these instead of throwing an error?
         cindex = MOI.addconstraint!(v.m.moi_backend, MOI.SingleVariable(index(v)), newset)
-        setfixindex(v, cindex)
+        set_fix_index(v, cindex)
     end
     nothing
 end
@@ -409,134 +416,134 @@ function unfix(v::VariableRef)
 end
 
 """
-    fixvalue(v::VariableRef)
+    fix_value(v::VariableRef)
 
 Return the value to which a variable is fixed. Error if one does not exist.
 """
-function fixvalue(v::VariableRef)
+function fix_value(v::VariableRef)
     cset = MOI.get(v.m, MOI.ConstraintSet(), FixRef(v))::MOI.EqualTo
     return cset.value
 end
 
 function FixRef(v::VariableRef)
-    return ConstraintRef{Model, MOIFIX, ScalarShape}(v.m, fixindex(v),
+    return ConstraintRef{Model, MOIFIX, ScalarShape}(v.m, fix_index(v),
                                                      ScalarShape())
 end
 
 # integer and binary constraints
 
-isinteger(v::VariableRef) = haskey(v.m.variable_to_integrality,index(v))
+is_integer(v::VariableRef) = haskey(v.m.variable_to_integrality,index(v))
 
-function integerindex(v::VariableRef)
-    @assert isinteger(v) # TODO error message
+function integer_index(v::VariableRef)
+    @assert is_integer(v) # TODO error message
     return v.m.variable_to_integrality[index(v)]
 end
-function setintegerindex(v::VariableRef, cindex::MOIINT)
+function set_integer_index(v::VariableRef, cindex::MOIINT)
     v.m.variable_to_integrality[index(v)] = cindex
 end
 
 """
-    setinteger(v::VariableRef)
+    set_integer(v::VariableRef)
 
 Add an integrality constraint on the variable `v`.
 """
-function setinteger(v::VariableRef)
-    isinteger(v) && return
-    @assert !isbinary(v) # TODO error message
+function set_integer(v::VariableRef)
+    is_integer(v) && return
+    @assert !is_binary(v) # TODO error message
     cindex = MOI.addconstraint!(v.m.moi_backend, MOI.SingleVariable(index(v)), MOI.Integer())
-    setintegerindex(v, cindex)
+    set_integer_index(v, cindex)
     nothing
 end
 
-function unsetinteger(v::VariableRef)
+function unset_integer(v::VariableRef)
     MOI.delete!(v.m, IntegerRef(v))
     delete!(v.m.variable_to_integrality, index(v))
 end
 
 function IntegerRef(v::VariableRef)
-    return ConstraintRef{Model, MOIINT, ScalarShape}(v.m, integerindex(v),
+    return ConstraintRef{Model, MOIINT, ScalarShape}(v.m, integer_index(v),
                                                      ScalarShape())
 end
 
-isbinary(v::VariableRef) = haskey(v.m.variable_to_zero_one,index(v))
+is_binary(v::VariableRef) = haskey(v.m.variable_to_zero_one,index(v))
 
-function binaryindex(v::VariableRef)
-    @assert isbinary(v) # TODO error message
+function binary_index(v::VariableRef)
+    @assert is_binary(v) # TODO error message
     return v.m.variable_to_zero_one[index(v)]
 end
-function setbinaryindex(v::VariableRef, cindex::MOIBIN)
+function set_binary_index(v::VariableRef, cindex::MOIBIN)
     v.m.variable_to_zero_one[index(v)] = cindex
 end
 
 """
-    setbinary(v::VariableRef)
+    set_binary(v::VariableRef)
 
 Add a constraint on the variable `v` that it must take values in the set ``\\{0,1\\}``.
 """
-function setbinary(v::VariableRef)
-    isbinary(v) && return
-    @assert !isinteger(v) # TODO error message
+function set_binary(v::VariableRef)
+    is_binary(v) && return
+    @assert !is_integer(v) # TODO error message
     cindex = MOI.addconstraint!(v.m.moi_backend, MOI.SingleVariable(index(v)), MOI.ZeroOne())
-    setbinaryindex(v, cindex)
+    set_binary_index(v, cindex)
     nothing
 end
 
-function unsetbinary(v::VariableRef)
+function unset_binary(v::VariableRef)
     MOI.delete!(v.m, BinaryRef(v))
     delete!(v.m.variable_to_zero_one, index(v))
 end
 
 function BinaryRef(v::VariableRef)
-    return ConstraintRef{Model, MOIBIN, ScalarShape}(v.m, binaryindex(v),
+    return ConstraintRef{Model, MOIBIN, ScalarShape}(v.m, binary_index(v),
                                                      ScalarShape())
 end
 
 
-startvalue(v::VariableRef) = MOI.get(v.m, MOI.VariablePrimalStart(), v)
-setstartvalue(v::VariableRef, val::Number) = MOI.set!(v.m, MOI.VariablePrimalStart(), v, val)
+start_value(v::VariableRef) = MOI.get(v.m, MOI.VariablePrimalStart(), v)
+set_start_value(v::VariableRef, val::Number) = MOI.set!(v.m, MOI.VariablePrimalStart(), v, val)
 
 """
-    resultvalue(v::VariableRef)
+    result_value(v::VariableRef)
 
 Get the value of this variable in the result returned by a solver.
-Use `hasresultvalues` to check if a result exists before asking for values.
+Use `has_result_values` to check if a result exists before asking for values.
 Replaces `getvalue` for most use cases.
 """
-resultvalue(v::VariableRef) = MOI.get(v.m, MOI.VariablePrimal(), v)
-hasresultvalues(m::Model) = MOI.canget(m, MOI.VariablePrimal(), VariableRef)
+result_value(v::VariableRef) = MOI.get(v.m, MOI.VariablePrimal(), v)
+has_result_values(m::Model) = MOI.canget(m, MOI.VariablePrimal(), VariableRef)
 
-@Base.deprecate setvalue(v::VariableRef, val::Number) setstartvalue(v, val)
+@Base.deprecate setvalue(v::VariableRef, val::Number) set_start_value(v, val)
 
 """
-    addvariable(m::Model, v::AbstractVariable, name::String="")
+    add_variable(m::Model, v::AbstractVariable, name::String="")
 
 Add a variable `v` to `Model m` and sets its name.
 """
-function addvariable end
+function add_variable end
 
-function addvariable(m::Model, v::ScalarVariable, name::String="")
+function add_variable(m::Model, v::ScalarVariable, name::String="")
     info = v.info
     vref = VariableRef(m)
-    if info.haslb
-        setlowerbound(vref, info.lowerbound)
+    if info.has_lb
+        set_lower_bound(vref, info.lower_bound)
     end
-    if info.hasub
-        setupperbound(vref, info.upperbound)
+    if info.has_ub
+        set_upper_bound(vref, info.upper_bound)
     end
-    if info.hasfix
-        fix(vref, info.fixedvalue)
+    if info.has_fix
+        fix(vref, info.fixed_value)
     end
     if info.binary
-        setbinary(vref)
+        set_binary(vref)
     end
     if info.integer
-        setinteger(vref)
+        set_integer(vref)
     end
-    if info.hasstart
-        setstartvalue(vref, info.start)
+    if info.has_start
+        set_start_value(vref, info.start)
     end
     if !isempty(name)
-        setname(vref, name)
+        set_name(vref, name)
     end
     return vref
 end

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -16,7 +16,7 @@ mutable struct MyModel <: JuMP.AbstractModel
     constraints::Dict{Int, JuMP.AbstractConstraint} # Map conidx -> variable
     connames::Dict{Int, String}                     # Map varidx -> name
     objectivesense::Symbol
-    objectivefunction::JuMP.AbstractJuMPScalar
+    objective_function::JuMP.AbstractJuMPScalar
     obj_dict::Dict{Symbol, Any}                     # Same that JuMP.Model's field `obj_dict`
     function MyModel()
         new(0, Dict{Int, JuMP.AbstractVariable}(),   Dict{Int, String}(), # Variables
@@ -44,11 +44,11 @@ end
 JuMP.owner_model(v::MyVariableRef) = v.model
 JuMP.isequal_canonical(v::MyVariableRef, w::MyVariableRef) = v == w
 JuMP.variabletype(::MyModel) = MyVariableRef
-function JuMP.addvariable(m::MyModel, v::JuMP.AbstractVariable, name::String="")
+function JuMP.add_variable(m::MyModel, v::JuMP.AbstractVariable, name::String="")
     m.nextvaridx += 1
     vref = MyVariableRef(m, m.nextvaridx)
     m.variables[vref.idx] = v
-    JuMP.setname(vref, name)
+    JuMP.set_name(vref, name)
     vref
 end
 function MOI.delete!(m::MyModel, vref::MyVariableRef)
@@ -58,47 +58,47 @@ end
 MOI.isvalid(m::MyModel, vref::MyVariableRef) = vref.idx in keys(m.variables)
 JuMP.num_variables(m::MyModel) = length(m.variables)
 
-JuMP.haslowerbound(vref::MyVariableRef) = vref.model.variables[vref.idx].info.haslb
-function JuMP.lowerbound(vref::MyVariableRef)
-    @assert !JuMP.isfixed(vref)
-    vref.model.variables[vref.idx].info.lowerbound
+JuMP.has_lower_bound(vref::MyVariableRef) = vref.model.variables[vref.idx].info.has_lb
+function JuMP.lower_bound(vref::MyVariableRef)
+    @assert !JuMP.is_fixed(vref)
+    vref.model.variables[vref.idx].info.lower_bound
 end
-function JuMP.setlowerbound(vref::MyVariableRef, lower)
-    vref.model.variables[vref.idx].info.haslb = true
-    vref.model.variables[vref.idx].info.lowerbound = lower
+function JuMP.set_lower_bound(vref::MyVariableRef, lower)
+    vref.model.variables[vref.idx].info.has_lb = true
+    vref.model.variables[vref.idx].info.lower_bound = lower
 end
-JuMP.hasupperbound(vref::MyVariableRef) = vref.model.variables[vref.idx].info.hasub
-function JuMP.upperbound(vref::MyVariableRef)
-    @assert !JuMP.isfixed(vref)
-    vref.model.variables[vref.idx].info.upperbound
+JuMP.has_upper_bound(vref::MyVariableRef) = vref.model.variables[vref.idx].info.has_ub
+function JuMP.upper_bound(vref::MyVariableRef)
+    @assert !JuMP.is_fixed(vref)
+    vref.model.variables[vref.idx].info.upper_bound
 end
-function JuMP.setupperbound(vref::MyVariableRef, upper)
-    vref.model.variables[vref.idx].info.hasub = true
-    vref.model.variables[vref.idx].info.upperbound = upper
+function JuMP.set_upper_bound(vref::MyVariableRef, upper)
+    vref.model.variables[vref.idx].info.has_ub = true
+    vref.model.variables[vref.idx].info.upper_bound = upper
 end
-JuMP.isfixed(vref::MyVariableRef) = vref.model.variables[vref.idx].info.hasfix
-JuMP.fixvalue(vref::MyVariableRef) = vref.model.variables[vref.idx].info.fixedvalue
+JuMP.is_fixed(vref::MyVariableRef) = vref.model.variables[vref.idx].info.has_fix
+JuMP.fix_value(vref::MyVariableRef) = vref.model.variables[vref.idx].info.fixed_value
 function JuMP.fix(vref::MyVariableRef, value)
-    vref.model.variables[vref.idx].info.fixedvalue = value
+    vref.model.variables[vref.idx].info.fixed_value = value
 end
-JuMP.startvalue(vref::MyVariableRef) = vref.model.variables[vref.idx].info.start
-function JuMP.setstartvalue(vref::MyVariableRef, start)
+JuMP.start_value(vref::MyVariableRef) = vref.model.variables[vref.idx].info.start
+function JuMP.set_start_value(vref::MyVariableRef, start)
     vref.model.variables[vref.idx].info.start = start
 end
-JuMP.isbinary(vref::MyVariableRef) = vref.model.variables[vref.idx].info.binary
-function JuMP.setbinary(vref::MyVariableRef)
-    @assert !JuMP.isinteger(vref)
+JuMP.is_binary(vref::MyVariableRef) = vref.model.variables[vref.idx].info.binary
+function JuMP.set_binary(vref::MyVariableRef)
+    @assert !JuMP.is_integer(vref)
     vref.model.variables[vref.idx].info.binary = true
 end
-function JuMP.unsetbinary(vref::MyVariableRef)
+function JuMP.unset_binary(vref::MyVariableRef)
     vref.model.variables[vref.idx].info.binary = false
 end
-JuMP.isinteger(vref::MyVariableRef) = vref.model.variables[vref.idx].info.integer
-function JuMP.setinteger(vref::MyVariableRef)
-    @assert !JuMP.isbinary(vref)
+JuMP.is_integer(vref::MyVariableRef) = vref.model.variables[vref.idx].info.integer
+function JuMP.set_integer(vref::MyVariableRef)
+    @assert !JuMP.is_binary(vref)
     vref.model.variables[vref.idx].info.integer = true
 end
-function JuMP.unsetinteger(vref::MyVariableRef)
+function JuMP.unset_integer(vref::MyVariableRef)
     vref.model.variables[vref.idx].info.integer = false
 end
 
@@ -107,15 +107,15 @@ struct MyConstraintRef
     model::MyModel # `model` owning the constraint
     idx::Int       # Index in `model.constraints`
 end
-JuMP.constrainttype(::MyModel) = MyConstraintRef
+JuMP.constraint_type(::MyModel) = MyConstraintRef
 if VERSION >= v"0.7-"
     Base.broadcastable(cref::MyConstraintRef) = Ref(cref)
 end
-function JuMP.addconstraint(m::MyModel, c::JuMP.AbstractConstraint, name::String="")
+function JuMP.add_constraint(m::MyModel, c::JuMP.AbstractConstraint, name::String="")
     m.nextconidx += 1
     cref = MyConstraintRef(m, m.nextconidx)
     m.constraints[cref.idx] = c
-    JuMP.setname(cref, name)
+    JuMP.set_name(cref, name)
     cref
 end
 function MOI.delete!(m::MyModel, cref::MyConstraintRef)
@@ -123,29 +123,29 @@ function MOI.delete!(m::MyModel, cref::MyConstraintRef)
     delete!(m.connames, cref.idx)
 end
 MOI.isvalid(m::MyModel, cref::MyConstraintRef) = cref.idx in keys(m.constraints)
-function JuMP.constraintobject(cref::MyConstraintRef)
+function JuMP.constraint_object(cref::MyConstraintRef)
     return cref.model.constraints[cref.idx]
 end
 
 # Objective
-function JuMP.setobjective(m::MyModel, sense::Symbol, f::JuMP.AbstractJuMPScalar)
+function JuMP.set_objective(m::MyModel, sense::Symbol, f::JuMP.AbstractJuMPScalar)
     m.objectivesense = sense
-    m.objectivefunction = f
+    m.objective_function = f
 end
-JuMP.objectivesense(m::MyModel) = m.objectivesense
-function JuMP.objectivefunction(m::MyModel, FT::Type)
+JuMP.objective_sense(m::MyModel) = m.objectivesense
+function JuMP.objective_function(m::MyModel, FT::Type)
     # ErrorException should be thrown, this is needed in `objective.jl`
-    m.objectivefunction isa FT || error("The objective function is not of type $FT")
-    m.objectivefunction
+    m.objective_function isa FT || error("The objective function is not of type $FT")
+    m.objective_function
 end
 
 # Names
 JuMP.name(vref::MyVariableRef) = vref.model.varnames[vref.idx]
-function JuMP.setname(vref::MyVariableRef, name::String)
+function JuMP.set_name(vref::MyVariableRef, name::String)
     vref.model.varnames[vref.idx] = name
 end
 JuMP.name(cref::MyConstraintRef) = cref.model.connames[cref.idx]
-function JuMP.setname(cref::MyConstraintRef, name::String)
+function JuMP.set_name(cref::MyConstraintRef, name::String)
     cref.model.connames[cref.idx] = name
 end
 

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -7,14 +7,14 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         # the LHS is first subtracted to form x - 10.0 <= 0.
         @constraint(m, cref, x in MOI.LessThan(10.0))
         @test JuMP.name(cref) == "cref"
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test c.func == x
         @test c.set == MOI.LessThan(10.0)
 
         @variable(m, y[1:2])
         @constraint(m, cref2[i=1:2], y[i] in MOI.LessThan(float(i)))
         @test JuMP.name(cref2[1]) == "cref2[1]"
-        c = JuMP.constraintobject(cref2[1])
+        c = JuMP.constraint_object(cref2[1])
         @test c.func == y[1]
         @test c.set == MOI.LessThan(1.0)
     end
@@ -24,12 +24,12 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         @variable(m, x[1:2])
 
         cref = @constraint(m, x in MOI.Zeros(2))
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test c.func == x
         @test c.set == MOI.Zeros(2)
 
         cref = @constraint(m, [x[2],x[1]] in MOI.Zeros(2))
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test c.func == [x[2],x[1]]
         @test c.set == MOI.Zeros(2)
     end
@@ -40,27 +40,27 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
 
         cref = @constraint(m, 2x <= 10)
         @test JuMP.name(cref) == ""
-        JuMP.setname(cref, "c")
+        JuMP.set_name(cref, "c")
         @test JuMP.name(cref) == "c"
 
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func, 2x)
         @test c.set == MOI.LessThan(10.0)
 
         cref = @constraint(m, 3x + 1 ≥ 10)
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func, 3x)
         @test c.set == MOI.GreaterThan(9.0)
 
         cref = @constraint(m, 1 == -x)
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func, 1.0x)
         @test c.set == MOI.EqualTo(-1.0)
 
         @test_throws ErrorException @constraint(m, [x, 2x] == [1-x, 3])
         @test_macro_throws ErrorException @constraint(m, [x == 1-x, 2x == 3])
         cref = @constraint(m, [x, 2x] .== [1-x, 3])
-        c = JuMP.constraintobject.(cref)
+        c = JuMP.constraint_object.(cref)
         @test JuMP.isequal_canonical(c[1].func, 2.0x)
         @test c[1].set == MOI.EqualTo(1.0)
         @test JuMP.isequal_canonical(c[2].func, 2.0x)
@@ -79,7 +79,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         @constraint(m, cref, 1.0 <= x + y + 1.0 <= 2.0)
         @test JuMP.name(cref) == "cref"
 
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func, x + y)
         @test c.set == MOI.Interval(0.0, 1.0)
     end
@@ -94,10 +94,10 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         cref = @constraint(m, A*x .== b)
         @test size(cref) == (2,)
 
-        c1 = JuMP.constraintobject(cref[1])
+        c1 = JuMP.constraint_object(cref[1])
         @test JuMP.isequal_canonical(c1.func, x[1] + 2x[2])
         @test c1.set == MOI.EqualTo(4.0)
-        c2 = JuMP.constraintobject(cref[2])
+        c2 = JuMP.constraint_object(cref[2])
         @test JuMP.isequal_canonical(c2.func, 3x[1] + 4x[2])
         @test c2.set == MOI.EqualTo(5.0)
     end
@@ -112,7 +112,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         @test size(cref) == (2,2)
         for i in 1:2
             for j in 1:2
-                c = JuMP.constraintobject(cref[i,j])
+                c = JuMP.constraint_object(cref[i,j])
                 @test JuMP.isequal_canonical(c.func, x[i,j] + 0)
                 @test c.set == MOI.LessThan(UB[i,j] - 1)
             end
@@ -130,7 +130,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         @test size(cref) == (2,)
 
         for i in 1:2
-            c = JuMP.constraintobject(cref[i])
+            c = JuMP.constraint_object(cref[i])
             @test JuMP.isequal_canonical(c.func, x[i] + y[i])
             @test c.set == MOI.Interval(l[i]-1, u[i]-1)
         end
@@ -155,18 +155,18 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         @variable(m, y)
 
         cref = @constraint(m, x^2 + x <= 1)
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func, x^2 + x)
         @test c.set == MOI.LessThan(1.0)
 
         cref = @constraint(m, y*x - 1.0 == 0.0)
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func, x*y)
         @test c.set == MOI.EqualTo(1.0)
 
         # TODO: VectorQuadraticFunctions
         # cref = @constraint(m, [x^2 - 1] in MOI.SecondOrderCone(1))
-        # c = JuMP.constraintobject(cref)
+        # c = JuMP.constraint_object(cref)
         # @test JuMP.isequal_canonical(c.func, -1 + x^2)
         # @test c.set == MOI.SecondOrderCone(1)
     end
@@ -179,14 +179,14 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         @variable(m, w)
 
         cref = @constraint(m, [x y; z w] in PSDCone())
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test c.func == [x, z, y, w]
         @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
         @test c.shape isa JuMP.SquareMatrixShape
 
         @SDconstraint(m, cref, [x 1; 1 -y] ⪰ [1 x; x -2])
         @test JuMP.name(cref) == "cref"
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func[1], x-1)
         @test JuMP.isequal_canonical(c.func[2], 1-x)
         @test JuMP.isequal_canonical(c.func[3], 2-y)
@@ -196,7 +196,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         @SDconstraint(m, iref[i=1:2], 0 ⪯ [x+i x+y; x+y -y])
         for i in 1:2
             @test JuMP.name(iref[i]) == "iref[$i]"
-            c = JuMP.constraintobject(iref[i])
+            c = JuMP.constraint_object(iref[i])
             @test JuMP.isequal_canonical(c.func[1], x+i)
             @test JuMP.isequal_canonical(c.func[2], x+y)
             @test JuMP.isequal_canonical(c.func[3], -y)
@@ -204,8 +204,8 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
             @test c.shape isa JuMP.SymmetricMatrixShape
         end
 
-        # Should throw "ERROR: function JuMP.addconstraint does not accept keyword arguments"
-        # This tests that the keyword arguments are passed to addconstraint
+        # Should throw "ERROR: function JuMP.add_constraint does not accept keyword arguments"
+        # This tests that the keyword arguments are passed to add_constraint
         @test_macro_throws ErrorException @SDconstraint(m, [x 1; 1 -y] ⪰ [1 x; x -2], unknown_kw=1)
         # Invalid sense == in SDP constraint
         @test_macro_throws ErrorException @SDconstraint(m, [x 1; 1 -y] == [1 x; x -2])

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -54,14 +54,14 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
                                      JuMP.GenericAffExpr(2.0, :a => 2.0))
     end
 
-    @testset "linearterms(::AffExpr)" begin
+    @testset "linear_terms(::AffExpr)" begin
         m = Model()
         @variable(m, x[1:10])
 
         aff = 1*x[1] + 2*x[2]
         k = 0
-        @test length(linearterms(aff)) == 2
-        for (coeff, var) in linearterms(aff)
+        @test length(linear_terms(aff)) == 2
+        for (coeff, var) in linear_terms(aff)
             if k == 0
                 @test coeff == 1
                 @test var === x[1]
@@ -74,11 +74,11 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
         @test k == 2
     end
 
-    @testset "linearterms(::AffExpr) for empty expression" begin
+    @testset "linear_terms(::AffExpr) for empty expression" begin
         k = 0
         aff = zero(AffExprType)
-        @test length(linearterms(aff)) == 0
-        for (coeff, var) in linearterms(aff)
+        @test length(linear_terms(aff)) == 0
+        for (coeff, var) in linear_terms(aff)
             k += 1
         end
         @test k == 0

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -23,9 +23,9 @@
 
         c = @constraint(m, x + y <= 1)
 
-        JuMP.setname(JuMP.UpperBoundRef(x), "xub")
-        JuMP.setname(JuMP.LowerBoundRef(y), "ylb")
-        JuMP.setname(c, "c")
+        JuMP.set_name(JuMP.UpperBoundRef(x), "xub")
+        JuMP.set_name(JuMP.LowerBoundRef(y), "ylb")
+        JuMP.set_name(c, "c")
 
         modelstring = """
         variables: x, y
@@ -39,7 +39,7 @@
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.caching_optimizer(m).model_cache, model, ["x","y"], ["c", "xub", "ylb"])
 
-        JuMP.optimize(m, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}(), evalobjective=false))
+        JuMP.optimize!(m, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}(), evalobjective=false))
 
         mockoptimizer = JuMP.caching_optimizer(m).optimizer
         MOI.set!(mockoptimizer, MOI.TerminationStatus(), MOI.Success)
@@ -47,27 +47,27 @@
         MOI.set!(mockoptimizer, MOI.ResultCount(), 1)
         MOI.set!(mockoptimizer, MOI.PrimalStatus(), MOI.FeasiblePoint)
         MOI.set!(mockoptimizer, MOI.DualStatus(), MOI.FeasiblePoint)
-        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
-        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
-        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(c), -1.0)
-        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.UpperBoundRef(x)), 0.0)
-        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.LowerBoundRef(y)), 1.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizer_index(x), 1.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizer_index(y), 0.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizer_index(c), -1.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizer_index(JuMP.UpperBoundRef(x)), 0.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizer_index(JuMP.LowerBoundRef(y)), 1.0)
 
         #@test JuMP.isattached(m)
-        @test JuMP.hasresultvalues(m)
+        @test JuMP.has_result_values(m)
 
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.resultvalue(x) == 1.0
-        @test JuMP.resultvalue(y) == 0.0
-        @test JuMP.resultvalue(x + y) == 1.0
-        @test JuMP.objectivevalue(m) == -1.0
+        @test JuMP.result_value(x) == 1.0
+        @test JuMP.result_value(y) == 0.0
+        @test JuMP.result_value(x + y) == 1.0
+        @test JuMP.objective_value(m) == -1.0
 
-        @test JuMP.dualstatus(m) == MOI.FeasiblePoint
-        @test JuMP.resultdual(c) == -1
-        @test JuMP.resultdual(JuMP.UpperBoundRef(x)) == 0.0
-        @test JuMP.resultdual(JuMP.LowerBoundRef(y)) == 1.0
+        @test JuMP.dual_status(m) == MOI.FeasiblePoint
+        @test JuMP.result_dual(c) == -1
+        @test JuMP.result_dual(JuMP.UpperBoundRef(x)) == 0.0
+        @test JuMP.result_dual(JuMP.LowerBoundRef(y)) == 1.0
     end
 
     @testset "LP (Direct mode)" begin
@@ -84,29 +84,29 @@
         MOI.set!(mockoptimizer, MOI.ResultCount(), 1)
         MOI.set!(mockoptimizer, MOI.PrimalStatus(), MOI.FeasiblePoint)
         MOI.set!(mockoptimizer, MOI.DualStatus(), MOI.FeasiblePoint)
-        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
-        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
-        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(c), -1.0)
-        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.UpperBoundRef(x)), 0.0)
-        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(JuMP.LowerBoundRef(y)), 1.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizer_index(x), 1.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizer_index(y), 0.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizer_index(c), -1.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizer_index(JuMP.UpperBoundRef(x)), 0.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizer_index(JuMP.LowerBoundRef(y)), 1.0)
 
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
         #@test JuMP.isattached(m)
-        @test JuMP.hasresultvalues(m)
+        @test JuMP.has_result_values(m)
 
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.resultvalue(x) == 1.0
-        @test JuMP.resultvalue(y) == 0.0
-        @test JuMP.resultvalue(x + y) == 1.0
-        @test JuMP.objectivevalue(m) == -1.0
+        @test JuMP.result_value(x) == 1.0
+        @test JuMP.result_value(y) == 0.0
+        @test JuMP.result_value(x + y) == 1.0
+        @test JuMP.objective_value(m) == -1.0
 
-        @test JuMP.dualstatus(m) == MOI.FeasiblePoint
-        @test JuMP.resultdual(c) == -1
-        @test JuMP.resultdual(JuMP.UpperBoundRef(x)) == 0.0
-        @test JuMP.resultdual(JuMP.LowerBoundRef(y)) == 1.0
+        @test JuMP.dual_status(m) == MOI.FeasiblePoint
+        @test JuMP.result_dual(c) == -1
+        @test JuMP.result_dual(JuMP.UpperBoundRef(x)) == 0.0
+        @test JuMP.result_dual(JuMP.LowerBoundRef(y)) == 1.0
     end
 
     # TODO: test Manual mode
@@ -118,9 +118,9 @@
         @variable(m, y, Bin)
         @objective(m, Max, x)
 
-        JuMP.setname(JuMP.FixRef(x), "xfix")
-        JuMP.setname(JuMP.IntegerRef(x), "xint")
-        JuMP.setname(JuMP.BinaryRef(y), "ybin")
+        JuMP.set_name(JuMP.FixRef(x), "xfix")
+        JuMP.set_name(JuMP.IntegerRef(x), "xint")
+        JuMP.set_name(JuMP.BinaryRef(y), "ybin")
 
         modelstring = """
         variables: x, y
@@ -141,24 +141,24 @@
         MOI.set!(mockoptimizer, MOI.ObjectiveValue(), 1.0)
         MOI.set!(mockoptimizer, MOI.ResultCount(), 1)
         MOI.set!(mockoptimizer, MOI.PrimalStatus(), MOI.FeasiblePoint)
-        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
-        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizer_index(x), 1.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizer_index(y), 0.0)
 
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
         #@test JuMP.isattached(m)
-        @test JuMP.hasresultvalues(m)
+        @test JuMP.has_result_values(m)
 
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.resultvalue(x) == 1.0
-        @test JuMP.resultvalue(y) == 0.0
-        @test JuMP.objectivevalue(m) == 1.0
+        @test JuMP.result_value(x) == 1.0
+        @test JuMP.result_value(y) == 0.0
+        @test JuMP.objective_value(m) == 1.0
 
-        @test !JuMP.hasresultdual(m, typeof(JuMP.FixRef(x)))
-        @test !JuMP.hasresultdual(m, typeof(JuMP.IntegerRef(x)))
-        @test !JuMP.hasresultdual(m, typeof(JuMP.BinaryRef(y)))
+        @test !JuMP.has_result_dual(m, typeof(JuMP.FixRef(x)))
+        @test !JuMP.has_result_dual(m, typeof(JuMP.IntegerRef(x)))
+        @test !JuMP.has_result_dual(m, typeof(JuMP.BinaryRef(y)))
     end
 
     @testset "QCQP" begin
@@ -183,7 +183,7 @@
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.caching_optimizer(m).model_cache, model, ["x","y"], ["c1", "c2", "c3"])
 
-        JuMP.optimize(m, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}(), evalobjective=false))
+        JuMP.optimize!(m, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}(), evalobjective=false))
 
         mockoptimizer = JuMP.caching_optimizer(m).optimizer
         MOI.set!(mockoptimizer, MOI.TerminationStatus(), MOI.Success)
@@ -191,26 +191,26 @@
         MOI.set!(mockoptimizer, MOI.ResultCount(), 1)
         MOI.set!(mockoptimizer, MOI.PrimalStatus(), MOI.FeasiblePoint)
         MOI.set!(mockoptimizer, MOI.DualStatus(), MOI.FeasiblePoint)
-        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
-        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
-        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(c1), -1.0)
-        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(c2), 2.0)
-        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(c3), 3.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizer_index(x), 1.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizer_index(y), 0.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizer_index(c1), -1.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizer_index(c2), 2.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizer_index(c3), 3.0)
 
         #@test JuMP.isattached(m)
-        @test JuMP.hasresultvalues(m)
+        @test JuMP.has_result_values(m)
 
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.resultvalue(x) == 1.0
-        @test JuMP.resultvalue(y) == 0.0
-        @test JuMP.objectivevalue(m) == -1.0
+        @test JuMP.result_value(x) == 1.0
+        @test JuMP.result_value(y) == 0.0
+        @test JuMP.objective_value(m) == -1.0
 
-        @test JuMP.dualstatus(m) == MOI.FeasiblePoint
-        @test JuMP.resultdual(c1) == -1.0
-        @test JuMP.resultdual(c2) == 2.0
-        @test JuMP.resultdual(c3) == 3.0
+        @test JuMP.dual_status(m) == MOI.FeasiblePoint
+        @test JuMP.result_dual(c1) == -1.0
+        @test JuMP.result_dual(c2) == 2.0
+        @test JuMP.result_dual(c3) == 3.0
     end
 
     @testset "SOC" begin
@@ -246,46 +246,46 @@
         MOI.set!(mockoptimizer, MOI.ResultCount(), 1)
         MOI.set!(mockoptimizer, MOI.PrimalStatus(), MOI.FeasiblePoint)
         MOI.set!(mockoptimizer, MOI.DualStatus(), MOI.FeasiblePoint)
-        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x), 1.0)
-        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(y), 0.0)
-        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(z), 0.0)
-        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(varsoc), [-1.0,-2.0,-3.0])
-        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(affsoc), [1.0,2.0,3.0])
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizer_index(x), 1.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizer_index(y), 0.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizer_index(z), 0.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizer_index(varsoc), [-1.0,-2.0,-3.0])
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizer_index(affsoc), [1.0,2.0,3.0])
 
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
         #@test JuMP.isattached(m)
-        @test JuMP.hasresultvalues(m)
+        @test JuMP.has_result_values(m)
 
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.resultvalue(x) == 1.0
-        @test JuMP.resultvalue(y) == 0.0
-        @test JuMP.resultvalue(z) == 0.0
+        @test JuMP.result_value(x) == 1.0
+        @test JuMP.result_value(y) == 0.0
+        @test JuMP.result_value(z) == 0.0
 
-        @test JuMP.hasresultdual(m, typeof(varsoc))
-        @test JuMP.resultdual(varsoc) == [-1.0, -2.0, -3.0]
+        @test JuMP.has_result_dual(m, typeof(varsoc))
+        @test JuMP.result_dual(varsoc) == [-1.0, -2.0, -3.0]
 
-        @test JuMP.hasresultdual(m, typeof(affsoc))
-        @test JuMP.resultdual(affsoc) == [1.0, 2.0, 3.0]
+        @test JuMP.has_result_dual(m, typeof(affsoc))
+        @test JuMP.result_dual(affsoc) == [1.0, 2.0, 3.0]
     end
 
     @testset "SDP" begin
         m = Model()
         @variable(m, x[1:2,1:2], Symmetric)
-        setname(x[1,1], "x11")
-        setname(x[1,2], "x12")
-        setname(x[2,2], "x22")
+        set_name(x[1,1], "x11")
+        set_name(x[1,2], "x12")
+        set_name(x[2,2], "x22")
         @static if VERSION < v"0.7-"
             @objective(m, Max, trace(x))
         else
             @objective(m, Max, tr(x))
         end
         varpsd = @constraint(m, x in PSDCone())
-        setname(varpsd, "varpsd")
+        set_name(varpsd, "varpsd")
         conpsd = @SDconstraint(m, x ⪰ [1.0 0.0; 0.0 1.0])
-        setname(conpsd, "conpsd")
+        set_name(conpsd, "conpsd")
 
         modelstring = """
         variables: x11, x12, x22
@@ -306,38 +306,38 @@
         MOI.set!(mockoptimizer, MOI.ResultCount(), 1)
         MOI.set!(mockoptimizer, MOI.PrimalStatus(), MOI.FeasiblePoint)
         MOI.set!(mockoptimizer, MOI.DualStatus(), MOI.FeasiblePoint)
-        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x[1,1]), 1.0)
-        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x[1,2]), 2.0)
-        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizerindex(x[2,2]), 4.0)
-        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(varpsd), [1.0,2.0,3.0])
-        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizerindex(conpsd), [4.0,5.0,6.0])
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizer_index(x[1,1]), 1.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizer_index(x[1,2]), 2.0)
+        MOI.set!(mockoptimizer, MOI.VariablePrimal(), JuMP.optimizer_index(x[2,2]), 4.0)
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizer_index(varpsd), [1.0,2.0,3.0])
+        MOI.set!(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizer_index(conpsd), [4.0,5.0,6.0])
 
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
         #@test JuMP.isattached(m)
-        @test JuMP.hasresultvalues(m)
+        @test JuMP.has_result_values(m)
 
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.resultvalue.(x) == [1.0 2.0; 2.0 4.0]
-        @test JuMP.hasresultdual(m, typeof(varpsd))
-        @test JuMP.resultdual(varpsd) isa Symmetric
-        @test JuMP.resultdual(varpsd) == [1.0 2.0; 2.0 3.0]
-        @test JuMP.hasresultdual(m, typeof(conpsd))
-        @test JuMP.resultdual(conpsd) isa Symmetric
-        @test JuMP.resultdual(conpsd) == [4.0 5.0; 5.0 6.0]
+        @test JuMP.result_value.(x) == [1.0 2.0; 2.0 4.0]
+        @test JuMP.has_result_dual(m, typeof(varpsd))
+        @test JuMP.result_dual(varpsd) isa Symmetric
+        @test JuMP.result_dual(varpsd) == [1.0 2.0; 2.0 3.0]
+        @test JuMP.has_result_dual(m, typeof(conpsd))
+        @test JuMP.result_dual(conpsd) isa Symmetric
+        @test JuMP.result_dual(conpsd) == [4.0 5.0; 5.0 6.0]
 
     end
 
     @testset "Provide factory in `optimize` in Direct mode" begin
         mockoptimizer = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}())
         model = JuMP.direct_model(mockoptimizer)
-        @test_throws ErrorException JuMP.optimize(model, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}()))
+        @test_throws ErrorException JuMP.optimize!(model, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}()))
     end
 
     @testset "Provide factory both in `Model` and `optimize`" begin
         model = Model(with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}()))
-        @test_throws ErrorException JuMP.optimize(model, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}()))
+        @test_throws ErrorException JuMP.optimize!(model, with_optimizer(MOIU.MockOptimizer, JuMP.JuMPMOIModel{Float64}()))
     end
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -9,7 +9,7 @@ end
     local MyVariable = Tuple{JuMP.VariableInfo, Int}
     JuMP.variabletype(m::Model, ::Type{MyVariable}) = MyVariable
     names = Dict{MyVariable, String}()
-    function JuMP.addvariable(m::Model, v::MyVariable, name::String="")
+    function JuMP.add_variable(m::Model, v::MyVariable, name::String="")
         names[v] = name
         v
     end
@@ -21,15 +21,15 @@ end
     @test isa(x, MyVariable)
     info = x[1]
     test_kw = x[2]
-    @test info.haslb
-    @test info.lowerbound == 1
-    @test info.hasub
-    @test info.upperbound == 2
-    @test !info.hasfix
-    @test isnan(info.fixedvalue)
+    @test info.has_lb
+    @test info.lower_bound == 1
+    @test info.has_ub
+    @test info.upper_bound == 2
+    @test !info.has_fix
+    @test isnan(info.fixed_value)
     @test info.binary
     @test !info.integer
-    @test info.hasstart
+    @test info.has_start
     @test info.start == 3
     @test names[x] == "x"
     @test test_kw == 1
@@ -39,33 +39,33 @@ end
     for i in 1:3
         info = y[i][1]
         test_kw = y[i][2]
-        @test info.haslb
-        @test info.lowerbound == 0
-        @test !info.hasub
-        @test isnan(info.upperbound)
-        @test !info.hasfix
-        @test isnan(info.fixedvalue)
+        @test info.has_lb
+        @test info.lower_bound == 0
+        @test !info.has_ub
+        @test isnan(info.upper_bound)
+        @test !info.has_fix
+        @test isnan(info.fixed_value)
         @test !info.binary
         @test !info.integer
-        @test !info.hasstart
+        @test !info.has_start
         @test isnan(info.start)
         @test names[y[i]] == "y[$i]"
         @test test_kw == 2
     end
 
-    z = @variable(m, variabletype=MyVariable, upperbound=3, test_kw=5)
+    z = @variable(m, variabletype=MyVariable, upper_bound=3, test_kw=5)
     info = z[1]
     test_kw = z[2]
     @test isa(z, MyVariable)
-    @test !info.haslb
-    @test isnan(info.lowerbound)
-    @test info.hasub
-    @test info.upperbound == 3
-    @test !info.hasfix
-    @test isnan(info.fixedvalue)
+    @test !info.has_lb
+    @test isnan(info.lower_bound)
+    @test info.has_ub
+    @test info.upper_bound == 3
+    @test !info.has_fix
+    @test isnan(info.fixed_value)
     @test !info.binary
     @test !info.integer
-    @test !info.hasstart
+    @test !info.has_start
     @test isnan(info.start)
     @test names[z] == ""
     @test test_kw == 5
@@ -89,42 +89,42 @@ function macros_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::Typ
         t = 10.0
 
         cref = @constraint(m, 3x - y == 3.3(w + 2z) + 5)
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func, 3*x - y - 3.3*w - 6.6*z)
         @test c.set == MOI.EqualTo(5.0)
 
         cref = @constraint(m, 3x - y == (w + 2z)*3.3 + 5)
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func, 3*x - y - 3.3*w - 6.6*z)
         @test c.set == MOI.EqualTo(5.0)
 
         cref = @constraint(m, (x+y)/2 == 1)
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func, 0.5*x + 0.5*y)
         @test c.set == MOI.EqualTo(1.0)
 
         cref = @constraint(m, -1 <= x-y <= t)
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func, x - y)
         @test c.set == MOI.Interval(-1.0, t)
 
         cref = @constraint(m, -1 <= x+1 <= 1)
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func, 1x)
         @test c.set == MOI.Interval(-2.0, 0.0)
 
         cref = @constraint(m, -1 <= x <= 1)
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test c.func == x
         @test c.set == MOI.Interval(-1.0, 1.0)
 
         cref = @constraint(m, -1 <= x <= sum(0.5 for i = 1:2))
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test c.func == x
         @test c.set == MOI.Interval(-1.0, 1.0)
 
         cref = @constraint(m, 1 >= x >= 0)
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test c.func == x
         @test c.set == MOI.Interval(0.0, 1.0)
 
@@ -136,7 +136,7 @@ function macros_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::Typ
         @test JuMP.isequal_canonical(@expression(m, quad, (w+3)*(2x+1)+10), 2*w*x + 6*x + w + 13)
 
         cref = @constraint(m, 3 + 5*7 <= 0)
-        c = JuMP.constraintobject(cref)
+        c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func, zero(AffExpr))
         @test c.set == MOI.LessThan(-38.0)
     end

--- a/test/model.jl
+++ b/test/model.jl
@@ -7,7 +7,7 @@
     end
     JuMP.set_optimize_hook(m, hook)
     @test !called
-    optimize(m)
+    optimize!(m)
     @test called
 end
 @testset "UniversalFallback" begin
@@ -24,7 +24,7 @@ end
         @variable model x
         cref = @constraint model 0 <= x + 1 <= 1
         @test cref isa JuMP.ConstraintRef{JuMP.Model,MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.Interval{Float64}}}
-        JuMP.optimize(model)
+        JuMP.optimize!(model)
     end
     @testset "Automatic bridging disabled with `bridge_constraints` keyword" begin
         model = Model(with_optimizer(MOIU.MockOptimizer, LPModel{Float64}()), bridge_constraints=false)

--- a/test/nlp_solver.jl
+++ b/test/nlp_solver.jl
@@ -45,13 +45,13 @@ const MOI = MathOptInterface
         @NLconstraint(m, x[1]*x[2]*x[3]*x[4] >= 25)
         @NLconstraint(m, sum(x[i]^2 for i=1:4) == 40)
 
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
-        @test JuMP.hasresultvalues(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        @test JuMP.has_result_values(m)
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.resultvalue.(x) ≈ [1.000000, 4.742999, 3.821150, 1.379408] atol=1e-3
+        @test JuMP.result_value.(x) ≈ [1.000000, 4.742999, 3.821150, 1.379408] atol=1e-3
     end
 
     @testset "HS071 (no macros)" begin
@@ -71,13 +71,13 @@ const MOI = MathOptInterface
         JuMP.addNLconstraint(m, :($(x[1])^2+$(x[2])^2+$(x[3])^2+$(x[4])^2 == 40))
         @test_throws ErrorException JuMP.addNLconstraint(m, :(x[1]^2+x[2]^2+x[3]^2+x[4]^2 == 40))
 
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
-        @test JuMP.hasresultvalues(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        @test JuMP.has_result_values(m)
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.resultvalue.(x) ≈ [1.000000, 4.742999, 3.821150, 1.379408] atol=1e-3
+        @test JuMP.result_value.(x) ≈ [1.000000, 4.742999, 3.821150, 1.379408] atol=1e-3
     end
 
     @testset "HS109" begin
@@ -119,13 +119,13 @@ const MOI = MathOptInterface
             x[5] * x[7] * cos(x[4] - .25) + x[6] * x[7] * cos(x[4] - x[3] - .25) -
             2 * c * x[7]^2 + 22.938 * a + .7533e-3 * a * x[7] ^2 == 0)
 
-        JuMP.optimize(m)
+        JuMP.optimize!m)
 
-        @test JuMP.hasresultvalues(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        @test JuMP.has_result_values(m)
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.objectivevalue(m) ≈ 5326.851310161077 atol=1e-5
+        @test JuMP.objective_value(m) ≈ 5326.851310161077 atol=1e-5
     end
 
     @testset "HS110" begin
@@ -137,14 +137,14 @@ const MOI = MathOptInterface
             prod( x[i] for i=1:10) ^ 0.2
         )
 
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
-        @test JuMP.hasresultvalues(m)
+        @test JuMP.has_result_values(m)
         # Ipopt returns AlmostSuccess and NearlyFeasiblePoint on this instance.
-        # @test JuMP.terminationstatus(m) == MOI.Success
-        # @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        # @test JuMP.termination_status(m) == MOI.Success
+        # @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.objectivevalue(m) ≈ -45.77846971 atol=1e-5
+        @test JuMP.objective_value(m) ≈ -45.77846971 atol=1e-5
     end
 
     @testset "HS111" begin
@@ -160,13 +160,13 @@ const MOI = MathOptInterface
         @NLconstraint(m, exp(x[4]) + 2*exp(x[5]) +   exp(x[6]) +   exp(x[7])              == 1)
         @NLconstraint(m, exp(x[3]) +   exp(x[7]) +   exp(x[8]) + 2*exp(x[9]) + exp(x[10]) == 1)
 
-        JuMP.optimize(m)
+        JuMP.optimize!m)
 
-        @test JuMP.hasresultvalues(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        @test JuMP.has_result_values(m)
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.objectivevalue(m) ≈ -47.76109026 atol=1e-5
+        @test JuMP.objective_value(m) ≈ -47.76109026 atol=1e-5
     end
 
     @testset "HS112" begin
@@ -181,13 +181,13 @@ const MOI = MathOptInterface
         @NLconstraint(m, x[4] + 2*x[5] + x[6] + x[7] == 1)
         @NLconstraint(m, x[3] + x[7] + x[8] + 2*x[9] + x[10] == 1)
 
-        JuMP.optimize(m)
+        JuMP.optimize!m)
 
-        @test JuMP.hasresultvalues(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        @test JuMP.has_result_values(m)
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.objectivevalue(m) ≈ -47.76109026 atol=1e-5
+        @test JuMP.objective_value(m) ≈ -47.76109026 atol=1e-5
     end
 
     @testset "HS114" begin
@@ -216,13 +216,13 @@ const MOI = MathOptInterface
         @NLconstraint(m, 98000*x[3]/(x[4]*x[9] + 1000*x[3]) - x[6] == 0)
         @NLconstraint(m, (x[2] + x[5])/x[1] - x[8] == 0)
 
-        JuMP.optimize(m)
+        JuMP.optimize!m)
 
-        @test JuMP.hasresultvalues(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        @test JuMP.has_result_values(m)
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.objectivevalue(m) ≈ -1768.80696 atol=1e-3
+        @test JuMP.objective_value(m) ≈ -1768.80696 atol=1e-3
     end
 
     @testset "HS116" begin
@@ -262,14 +262,14 @@ const MOI = MathOptInterface
             x[11] + x[12] + x[13] <= 250
         end
 
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
-        @test JuMP.hasresultvalues(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        @test JuMP.has_result_values(m)
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
         # This test occasionally fails, for unknown reasons.
-        @test JuMP.objectivevalue(m) ≈ 97.588409 atol=1e-3
+        @test JuMP.objective_value(m) ≈ 97.588409 atol=1e-3
     end
 
     @testset "HS118" begin
@@ -296,7 +296,7 @@ const MOI = MathOptInterface
         @variable(m, L[i] <= x[i=1:15] <= U[i])
 
         # Initial solution (could also use 'start' keyword in @variable)
-        JuMP.setstartvalue.(x, start)
+        JuMP.set_start_value.(x, start)
 
         @NLobjective(m, Min,
             sum(2.3     * x[3*k+1]   +
@@ -330,14 +330,14 @@ const MOI = MathOptInterface
         @constraint(m, x[10] + x[11] + x[12] >= 85)
         @constraint(m, x[13] + x[14] + x[15] >= 100)
 
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
-        @test JuMP.hasresultvalues(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+        @test JuMP.has_result_values(m)
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.resultvalue.(x[1:4]) ≈ [8.0, 49.0, 3.0, 1.0] atol=1e-4
-        @test JuMP.objectivevalue(m) ≈ 664.82045 atol=1e-5
+        @test JuMP.result_value.(x[1:4]) ≈ [8.0, 49.0, 3.0, 1.0] atol=1e-4
+        @test JuMP.objective_value(m) ≈ 664.82045 atol=1e-5
     end
 
     @testset "Two-sided constraints" begin
@@ -347,20 +347,20 @@ const MOI = MathOptInterface
         l = -1
         u = 1
         @NLconstraint(m, l <= x <= u)
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
-        @test JuMP.hasresultvalues(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
-        @test JuMP.objectivevalue(m) ≈ u atol=1e-6
+        @test JuMP.has_result_values(m)
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
+        @test JuMP.objective_value(m) ≈ u atol=1e-6
 
         @NLobjective(m, Min, x)
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
-        @test JuMP.hasresultvalues(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
-        @test JuMP.objectivevalue(m) ≈ l atol=1e-6
+        @test JuMP.has_result_values(m)
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
+        @test JuMP.objective_value(m) ≈ l atol=1e-6
     end
 
     @testset "Two-sided constraints (no macros)" begin
@@ -370,20 +370,20 @@ const MOI = MathOptInterface
         l = -1
         u = 1
         JuMP.addNLconstraint(m, :($l <= $x <= $u))
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
-        @test JuMP.hasresultvalues(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
-        @test JuMP.objectivevalue(m) ≈ u atol=1e-6
+        @test JuMP.has_result_values(m)
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
+        @test JuMP.objective_value(m) ≈ u atol=1e-6
 
         JuMP.setNLobjective(m, :Min, x)
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
-        @test JuMP.hasresultvalues(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
-        @test JuMP.objectivevalue(m) ≈ l atol=1e-6
+        @test JuMP.has_result_values(m)
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
+        @test JuMP.objective_value(m) ≈ l atol=1e-6
     end
 
     @testset "Duals" begin
@@ -398,48 +398,48 @@ const MOI = MathOptInterface
         @NLconstraint(m, cons3, 7.0*y <= z + r[6]/1.9)
 
         function test_result()
-            @test JuMP.hasresultvalues(m)
-            @test JuMP.terminationstatus(m) == MOI.Success
-            @test JuMP.primalstatus(m) == MOI.FeasiblePoint
+            @test JuMP.has_result_values(m)
+            @test JuMP.termination_status(m) == MOI.Success
+            @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
 
-            @test JuMP.resultvalue(x) ≈ 0.9774436 atol=1e-6
-            @test JuMP.resultvalue(y) ≈ 1.0225563 atol=1e-6
-            @test JuMP.resultvalue(z) ≈ 4.0 atol=1e-6
-            @test JuMP.resultvalue(r[3]) ≈ 0.5112781 atol=1e-6
-            @test JuMP.resultvalue(r[4]) ≈ 0.0 atol=1e-6
-            @test JuMP.resultvalue(r[5]) ≈ 0.0 atol=1e-6
-            @test JuMP.resultvalue(r[6]) ≈ 6.0 atol=1e-6
-            @test JuMP.dualstatus(m) == MOI.FeasiblePoint
+            @test JuMP.result_value(x) ≈ 0.9774436 atol=1e-6
+            @test JuMP.result_value(y) ≈ 1.0225563 atol=1e-6
+            @test JuMP.result_value(z) ≈ 4.0 atol=1e-6
+            @test JuMP.result_value(r[3]) ≈ 0.5112781 atol=1e-6
+            @test JuMP.result_value(r[4]) ≈ 0.0 atol=1e-6
+            @test JuMP.result_value(r[5]) ≈ 0.0 atol=1e-6
+            @test JuMP.result_value(r[6]) ≈ 6.0 atol=1e-6
+            @test JuMP.dual_status(m) == MOI.FeasiblePoint
             # Reduced costs
-            @test JuMP.resultdual(JuMP.LowerBoundRef(x)) ≈ 0.0 atol=1e-6
-            @test JuMP.resultdual(JuMP.UpperBoundRef(y)) ≈ 0.0 atol=1e-6
-            @test JuMP.resultdual(JuMP.UpperBoundRef(z)) ≈ -1.0714286 atol=1e-6
-            @test JuMP.resultdual(JuMP.LowerBoundRef(r[3])) ≈ 0.0 atol=1e-6
-            @test JuMP.resultdual(JuMP.UpperBoundRef(r[3])) ≈ 0.0 atol=1e-6
-            @test JuMP.resultdual(JuMP.LowerBoundRef(r[4])) ≈ 1.0 atol=1e-6
-            @test JuMP.resultdual(JuMP.UpperBoundRef(r[4])) ≈ 0.0 atol=1e-6
-            @test JuMP.resultdual(JuMP.LowerBoundRef(r[5])) ≈ 1.0 atol=1e-6
-            @test JuMP.resultdual(JuMP.UpperBoundRef(r[5])) ≈ 0.0 atol=1e-6
-            @test JuMP.resultdual(JuMP.UpperBoundRef(r[6])) ≈ -0.03759398 atol=1e-6
-            @test JuMP.resultdual(JuMP.LowerBoundRef(r[6])) ≈ 0.0 atol=1e-6
+            @test JuMP.result_dual(JuMP.LowerBoundRef(x)) ≈ 0.0 atol=1e-6
+            @test JuMP.result_dual(JuMP.UpperBoundRef(y)) ≈ 0.0 atol=1e-6
+            @test JuMP.result_dual(JuMP.UpperBoundRef(z)) ≈ -1.0714286 atol=1e-6
+            @test JuMP.result_dual(JuMP.LowerBoundRef(r[3])) ≈ 0.0 atol=1e-6
+            @test JuMP.result_dual(JuMP.UpperBoundRef(r[3])) ≈ 0.0 atol=1e-6
+            @test JuMP.result_dual(JuMP.LowerBoundRef(r[4])) ≈ 1.0 atol=1e-6
+            @test JuMP.result_dual(JuMP.UpperBoundRef(r[4])) ≈ 0.0 atol=1e-6
+            @test JuMP.result_dual(JuMP.LowerBoundRef(r[5])) ≈ 1.0 atol=1e-6
+            @test JuMP.result_dual(JuMP.UpperBoundRef(r[5])) ≈ 0.0 atol=1e-6
+            @test JuMP.result_dual(JuMP.UpperBoundRef(r[6])) ≈ -0.03759398 atol=1e-6
+            @test JuMP.result_dual(JuMP.LowerBoundRef(r[6])) ≈ 0.0 atol=1e-6
 
             # Constraint duals
-            @test JuMP.resultdual(cons1) ≈ 0.333333 atol=1e-6
-            @test JuMP.resultdual(cons2) ≈ -1.0 atol=1e-6
-            @test JuMP.resultdual(cons3) ≈ -0.0714286 atol=1e-6
+            @test JuMP.result_dual(cons1) ≈ 0.333333 atol=1e-6
+            @test JuMP.result_dual(cons2) ≈ -1.0 atol=1e-6
+            @test JuMP.result_dual(cons3) ≈ -0.0714286 atol=1e-6
         end
 
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
         test_result()
-        @test JuMP.objectivevalue(m) ≈ -5.8446115 atol=1e-6
+        @test JuMP.objective_value(m) ≈ -5.8446115 atol=1e-6
 
         # Same objective with sense/sign flipped.
         @NLobjective(m, Max, ((x + y)/2.0 + 3.0)/3.0 + z + r[3])
 
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
         test_result()
-        @test JuMP.objectivevalue(m) ≈ 5.8446115 atol=1e-6
+        @test JuMP.objective_value(m) ≈ 5.8446115 atol=1e-6
     end
 
     @testset "Quadratic inequality constraints, linear objective" begin
@@ -448,13 +448,13 @@ const MOI = MathOptInterface
         @variable(m, -2 <= y <= 2)
         @objective(m, Min, x - y)
         @constraint(m, x + x^2 + x*y + y^2 <= 1)
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
-        @test JuMP.hasresultvalues(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
-        @test JuMP.objectivevalue(m) ≈ -1-4/sqrt(3) atol=1e-6
-        @test JuMP.resultvalue(x) + JuMP.resultvalue(y) ≈ -1/3 atol=1e-3
+        @test JuMP.has_result_values(m)
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
+        @test JuMP.objective_value(m) ≈ -1-4/sqrt(3) atol=1e-6
+        @test JuMP.result_value(x) + JuMP.result_value(y) ≈ -1/3 atol=1e-3
     end
 
     @testset "Quadratic inequality constraints, NL objective" begin
@@ -463,13 +463,13 @@ const MOI = MathOptInterface
         @variable(m, -2 <= y <= 2)
         @NLobjective(m, Min, x - y)
         @constraint(m, x + x^2 + x*y + y^2 <= 1)
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
-        @test JuMP.hasresultvalues(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
-        @test JuMP.objectivevalue(m) ≈ -1-4/sqrt(3) atol=1e-6
-        @test JuMP.resultvalue(x) + JuMP.resultvalue(y) ≈ -1/3 atol=1e-3
+        @test JuMP.has_result_values(m)
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
+        @test JuMP.objective_value(m) ≈ -1-4/sqrt(3) atol=1e-6
+        @test JuMP.result_value(x) + JuMP.result_value(y) ≈ -1/3 atol=1e-3
     end
 
     @testset "Quadratic equality constraints" begin
@@ -477,13 +477,13 @@ const MOI = MathOptInterface
         @variable(m, 0 <= x[1:2] <= 1)
         @constraint(m, x[1]^2 + x[2]^2 == 1/2)
         @NLobjective(m, Max, x[1] - x[2])
-        JuMP.optimize(m)
+        JuMP.optimize!(m)
 
-        @test JuMP.hasresultvalues(m)
-        @test JuMP.terminationstatus(m) == MOI.Success
-        @test JuMP.primalstatus(m) == MOI.FeasiblePoint
-        @test JuMP.objectivevalue(m) ≈ sqrt(1/2) atol=1e-6
-        @test JuMP.resultvalue.(x) ≈ [sqrt(1/2), 0] atol=1e-6
+        @test JuMP.has_result_values(m)
+        @test JuMP.termination_status(m) == MOI.Success
+        @test JuMP.primal_status(m) == MOI.FeasiblePoint
+        @test JuMP.objective_value(m) ≈ sqrt(1/2) atol=1e-6
+        @test JuMP.result_value.(x) ≈ [sqrt(1/2), 0] atol=1e-6
     end
 
     @testset "Fixed variables" begin
@@ -494,8 +494,8 @@ const MOI = MathOptInterface
         @NLconstraint(m, y ≥ x^2)
         for α in 1:4
             JuMP.fix(x, α)
-            JuMP.optimize(m)
-            @test JuMP.resultvalue(y) ≈ α^2 atol=1e-6
+            JuMP.optimize!(m)
+            @test JuMP.result_value(y) ≈ α^2 atol=1e-6
         end
     end
 end

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -7,12 +7,12 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
         @variable(m, x)
 
         @objective(m, Min, x)
-        @test JuMP.objectivesense(m) == :Min
-        @test JuMP.objectivefunction(m, VariableRefType) == x
+        @test JuMP.objective_sense(m) == :Min
+        @test JuMP.objective_function(m, VariableRefType) == x
 
         @objective(m, Max, x)
-        @test JuMP.objectivesense(m) == :Max
-        @test JuMP.objectivefunction(m, VariableRefType) == x
+        @test JuMP.objective_sense(m) == :Max
+        @test JuMP.objective_function(m, VariableRefType) == x
     end
 
     @testset "Linear objectives" begin
@@ -20,12 +20,12 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
         @variable(m, x)
 
         @objective(m, Min, 2x)
-        @test JuMP.objectivesense(m) == :Min
-        @test JuMP.isequal_canonical(JuMP.objectivefunction(m, AffExprType), 2x)
+        @test JuMP.objective_sense(m) == :Min
+        @test JuMP.isequal_canonical(JuMP.objective_function(m, AffExprType), 2x)
 
         @objective(m, Max, x + 3x + 1)
-        @test JuMP.objectivesense(m) == :Max
-        @test JuMP.isequal_canonical(JuMP.objectivefunction(m, AffExprType), 4x + 1)
+        @test JuMP.objective_sense(m) == :Max
+        @test JuMP.isequal_canonical(JuMP.objective_function(m, AffExprType), 4x + 1)
     end
 
     @testset "Quadratic objectives" begin
@@ -33,9 +33,9 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
         @variable(m, x)
 
         @objective(m, Min, x^2 + 2x)
-        @test JuMP.objectivesense(m) == :Min
-        @test JuMP.isequal_canonical(JuMP.objectivefunction(m, QuadExprType), x^2 + 2x)
-        @test_throws ErrorException JuMP.objectivefunction(m, AffExprType)
+        @test JuMP.objective_sense(m) == :Min
+        @test JuMP.isequal_canonical(JuMP.objective_function(m, QuadExprType), x^2 + 2x)
+        @test_throws ErrorException JuMP.objective_function(m, AffExprType)
     end
 end
 

--- a/test/print.jl
+++ b/test/print.jl
@@ -89,12 +89,12 @@ Base.isless(u::UnitNumber, v::UnitNumber) = isless(u.α, v.α)
         io_test(REPLMode,   x, "x")
         io_test(IJuliaMode, x, "x")
 
-        JuMP.setname(x, "x2")
+        JuMP.set_name(x, "x2")
         @test    JuMP.name(x) == "x2"
         io_test(REPLMode,   x, "x2")
         io_test(IJuliaMode, x, "x2")
 
-        JuMP.setname(x, "")
+        JuMP.set_name(x, "")
         @test    JuMP.name(x) == ""
         io_test(REPLMode,   x, "noname")
         io_test(IJuliaMode, x, "noname")

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -22,9 +22,9 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
 
         @testset "No bound" begin
             @variable(mcon, nobounds)
-            @test !JuMP.haslowerbound(nobounds)
-            @test !JuMP.hasupperbound(nobounds)
-            @test !JuMP.isfixed(nobounds)
+            @test !JuMP.has_lower_bound(nobounds)
+            @test !JuMP.has_upper_bound(nobounds)
+            @test !JuMP.is_fixed(nobounds)
             @test JuMP.name(nobounds) == "nobounds"
 
             @test zero(nobounds) isa AffExprType
@@ -33,12 +33,12 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
 
         @testset "Lower bound" begin
             @variable(mcon, lbonly >= 0, Bin)
-            @test JuMP.haslowerbound(lbonly)
-            @test JuMP.lowerbound(lbonly) == 0.0
-            @test !JuMP.hasupperbound(lbonly)
-            @test !JuMP.isfixed(lbonly)
-            @test JuMP.isbinary(lbonly)
-            @test !JuMP.isinteger(lbonly)
+            @test JuMP.has_lower_bound(lbonly)
+            @test JuMP.lower_bound(lbonly) == 0.0
+            @test !JuMP.has_upper_bound(lbonly)
+            @test !JuMP.is_fixed(lbonly)
+            @test JuMP.is_binary(lbonly)
+            @test !JuMP.is_integer(lbonly)
             @test isequal(mcon[:lbonly],lbonly)
             # Name already used
             @test_throws ErrorException @variable(mcon, lbonly)
@@ -46,44 +46,44 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
 
         @testset "Lower bound with constant on lhs" begin
             @variable(mcon, 0 <= lblhs, Bin)
-            @test JuMP.haslowerbound(lblhs)
-            @test JuMP.lowerbound(lblhs) == 0.0
-            @test !JuMP.hasupperbound(lblhs)
-            @test !JuMP.isfixed(lblhs)
-            @test JuMP.isbinary(lblhs)
-            @test !JuMP.isinteger(lblhs)
+            @test JuMP.has_lower_bound(lblhs)
+            @test JuMP.lower_bound(lblhs) == 0.0
+            @test !JuMP.has_upper_bound(lblhs)
+            @test !JuMP.is_fixed(lblhs)
+            @test JuMP.is_binary(lblhs)
+            @test !JuMP.is_integer(lblhs)
             @test isequal(mcon[:lblhs],lblhs)
         end
 
         @testset "Upper bound" begin
             @variable(mcon, ubonly <= 1, Int)
-            @test !JuMP.haslowerbound(ubonly)
-            @test JuMP.hasupperbound(ubonly)
-            @test JuMP.upperbound(ubonly) == 1.0
-            @test !JuMP.isfixed(ubonly)
-            @test !JuMP.isbinary(ubonly)
-            @test JuMP.isinteger(ubonly)
+            @test !JuMP.has_lower_bound(ubonly)
+            @test JuMP.has_upper_bound(ubonly)
+            @test JuMP.upper_bound(ubonly) == 1.0
+            @test !JuMP.is_fixed(ubonly)
+            @test !JuMP.is_binary(ubonly)
+            @test JuMP.is_integer(ubonly)
             @test isequal(mcon[:ubonly],ubonly)
         end
 
         @testset "Upper bound" begin
             @variable(mcon, 1 >= ublhs, Int)
-            @test !JuMP.haslowerbound(ublhs)
-            @test JuMP.hasupperbound(ublhs)
-            @test JuMP.upperbound(ublhs) == 1.0
-            @test !JuMP.isfixed(ublhs)
-            @test !JuMP.isbinary(ublhs)
-            @test JuMP.isinteger(ublhs)
+            @test !JuMP.has_lower_bound(ublhs)
+            @test JuMP.has_upper_bound(ublhs)
+            @test JuMP.upper_bound(ublhs) == 1.0
+            @test !JuMP.is_fixed(ublhs)
+            @test !JuMP.is_binary(ublhs)
+            @test JuMP.is_integer(ublhs)
             @test isequal(mcon[:ublhs],ublhs)
         end
 
         @testset "Interval" begin
             function has_bounds(var, lb, ub)
-                @test JuMP.haslowerbound(var)
-                @test JuMP.lowerbound(var) == lb
-                @test JuMP.hasupperbound(var)
-                @test JuMP.upperbound(var) == ub
-                @test !JuMP.isfixed(var)
+                @test JuMP.has_lower_bound(var)
+                @test JuMP.lower_bound(var) == lb
+                @test JuMP.has_upper_bound(var)
+                @test JuMP.upper_bound(var) == ub
+                @test !JuMP.is_fixed(var)
             end
 
             @variable(mcon, 0 <= bothb1 <= 1)
@@ -100,25 +100,25 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
 
         @testset "Fix" begin
             @variable(mcon, fixed == 1.0)
-            @test !JuMP.haslowerbound(fixed)
-            @test !JuMP.hasupperbound(fixed)
-            @test JuMP.isfixed(fixed)
-            @test JuMP.fixvalue(fixed) == 1.0
+            @test !JuMP.has_lower_bound(fixed)
+            @test !JuMP.has_upper_bound(fixed)
+            @test JuMP.is_fixed(fixed)
+            @test JuMP.fix_value(fixed) == 1.0
         end
 
         @testset "Custom index sets" begin
             @variable(mcon, onerangeub[-7:1] <= 10, Int)
             @variable(mcon, manyrangelb[0:1,10:20,1:1] >= 2)
-            @test JuMP.haslowerbound(manyrangelb[0,15,1])
-            @test JuMP.lowerbound(manyrangelb[0,15,1]) == 2
-            @test !JuMP.hasupperbound(manyrangelb[0,15,1])
+            @test JuMP.has_lower_bound(manyrangelb[0,15,1])
+            @test JuMP.lower_bound(manyrangelb[0,15,1]) == 2
+            @test !JuMP.has_upper_bound(manyrangelb[0,15,1])
 
             s = ["Green","Blue"]
             @variable(mcon, x[i=-10:10,s] <= 5.5, Int, start=i+1)
-            @test JuMP.upperbound(x[-4,"Green"]) == 5.5
+            @test JuMP.upper_bound(x[-4,"Green"]) == 5.5
             @test JuMP.name(x[-10,"Green"]) == "x[-10,Green]"
             # TODO: broken because of https://github.com/JuliaOpt/MathOptInterface.jl/issues/302
-            #@test JuMP.startvalue(x[-3,"Blue"]) == -2
+            #@test JuMP.start_value(x[-3,"Blue"]) == -2
             @test isequal(mcon[:onerangeub][-7],onerangeub[-7])
             @test_throws KeyError mcon[:foo]
         end
@@ -143,54 +143,54 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
     @testset "get and set bounds" begin
         m = ModelType()
         @variable(m, 0 <= x <= 2)
-        @test JuMP.lowerbound(x) == 0
-        @test JuMP.upperbound(x) == 2
-        setlowerbound(x, 1)
-        @test JuMP.lowerbound(x) == 1
-        setupperbound(x, 3)
-        @test JuMP.upperbound(x) == 3
+        @test JuMP.lower_bound(x) == 0
+        @test JuMP.upper_bound(x) == 2
+        set_lower_bound(x, 1)
+        @test JuMP.lower_bound(x) == 1
+        set_upper_bound(x, 3)
+        @test JuMP.upper_bound(x) == 3
         @variable(m, q, Bin)
-        @test !JuMP.haslowerbound(q)
-        @test !JuMP.hasupperbound(q)
+        @test !JuMP.has_lower_bound(q)
+        @test !JuMP.has_upper_bound(q)
 
         @variable(m, 0 <= y <= 1, Bin)
-        @test JuMP.lowerbound(y) == 0
-        @test JuMP.upperbound(y) == 1
+        @test JuMP.lower_bound(y) == 0
+        @test JuMP.upper_bound(y) == 1
 
         @variable(m, fixedvar == 2)
-        @test JuMP.fixvalue(fixedvar) == 2.0
+        @test JuMP.fix_value(fixedvar) == 2.0
         JuMP.fix(fixedvar, 5)
-        @test JuMP.fixvalue(fixedvar) == 5
-        @test_throws AssertionError JuMP.lowerbound(fixedvar)
-        @test_throws AssertionError JuMP.upperbound(fixedvar)
+        @test JuMP.fix_value(fixedvar) == 5
+        @test_throws AssertionError JuMP.lower_bound(fixedvar)
+        @test_throws AssertionError JuMP.upper_bound(fixedvar)
     end
 
     @testset "get and set start" begin
         m = ModelType()
         @variable(m, x[1:3])
         x0 = collect(1:3)
-        JuMP.setstartvalue.(x, x0)
-        @test JuMP.startvalue.(x) == x0
-        @test JuMP.startvalue.([x[1],x[2],x[3]]) == x0
+        JuMP.set_start_value.(x, x0)
+        @test JuMP.start_value.(x) == x0
+        @test JuMP.start_value.([x[1],x[2],x[3]]) == x0
 
         @variable(m, y[1:3,1:2])
-        @test_throws DimensionMismatch JuMP.setstartvalue.(y, collect(1:6))
+        @test_throws DimensionMismatch JuMP.set_start_value.(y, collect(1:6))
     end
 
     @testset "get and set integer/binary" begin
         m = ModelType()
         @variable(m, x[1:3])
 
-        JuMP.setinteger(x[2])
-        @test JuMP.isinteger(x[2])
-        JuMP.unsetinteger(x[2])
-        @test !JuMP.isinteger(x[2])
+        JuMP.set_integer(x[2])
+        @test JuMP.is_integer(x[2])
+        JuMP.unset_integer(x[2])
+        @test !JuMP.is_integer(x[2])
 
-        JuMP.setbinary(x[1])
-        @test JuMP.isbinary(x[1])
-        @test_throws AssertionError JuMP.setinteger(x[1])
-        JuMP.unsetbinary(x[1])
-        @test !JuMP.isbinary(x[1])
+        JuMP.set_binary(x[1])
+        @test JuMP.is_binary(x[1])
+        @test_throws AssertionError JuMP.set_integer(x[1])
+        JuMP.unset_binary(x[1])
+        @test !JuMP.is_binary(x[1])
         # TODO test binary/integer keyword arguments
     end
 
@@ -281,24 +281,24 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
         @test typeof(y) == Vector{VariableRefType}
         @test typeof(z) == Vector{VariableRefType}
 
-        @test typeof(JuMP.startvalue.(x)) == Array{Float64,3}
+        @test typeof(JuMP.start_value.(x)) == Array{Float64,3}
         # No type to infer for an empty collection.
-        @test typeof(JuMP.startvalue.(y)) == Array{Any,1}
-        @test typeof(JuMP.startvalue.(z)) == Array{Float64,1}
+        @test typeof(JuMP.start_value.(y)) == Array{Any,1}
+        @test typeof(JuMP.start_value.(z)) == Array{Float64,1}
     end
 
-    @testset "startvalue on empty things" begin
+    @testset "start_value on empty things" begin
         m = ModelType()
         @variable(m, x[1:4,  1:0,1:3], start = 0) # Array{VariableRef}
         @variable(m, y[1:4,  2:1,1:3], start = 0) # JuMPArray
         @variable(m, z[1:4,Set(),1:3], start = 0) # Dict
 
-        @test JuMP.startvalue.(x) == Array{Float64}(undef, 4, 0, 3)
+        @test JuMP.start_value.(x) == Array{Float64}(undef, 4, 0, 3)
         # TODO: Decide what to do here. I don't know if we still need to test this given broadcast syntax.
-        # @test typeof(JuMP.startvalue(y)) <: JuMP.JuMPArray{Float64}
-        # @test JuMP.size(JuMP.startvalue(y)) == (4,0,3)
-        # @test typeof(JuMP.startvalue(z)) == JuMP.JuMPArray{Float64,3,Tuple{UnitRange{Int},Set{Any},UnitRange{Int}}}
-        # @test length(JuMP.startvalue(z)) == 0
+        # @test typeof(JuMP.start_value(y)) <: JuMP.JuMPArray{Float64}
+        # @test JuMP.size(JuMP.start_value(y)) == (4,0,3)
+        # @test typeof(JuMP.start_value(z)) == JuMP.JuMPArray{Float64,3,Tuple{UnitRange{Int},Set{Any},UnitRange{Int}}}
+        # @test length(JuMP.start_value(z)) == 0
     end
 
 # Slices three-dimensional JuMPArray x[I,J,K]


### PR DESCRIPTION
Mostly focused on user-facing functions to break the important parts first. Includes `optimize` -> `optimize!` for consistency with MOI.

Closes #1382