### PR TITLE
Speed up test/operator.jl, fix bug on Julia 1.0 with Base.warn_one.

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -724,14 +724,16 @@ function operator_warn(::AbstractModel) end
 function operator_warn(model::Model)
     model.operator_counter += 1
     if model.operator_counter > 20000
-        Base.warn_once(
+        Compat.@warn(
             "The addition operator has been used on JuMP expressions a large " *
             "number of times. This warning is safe to ignore but may " *
             "indicate that model generation is slower than necessary. For " *
             "performance reasons, you should not add expressions in a loop. " *
             "Instead of x += y, use add_to_expression!(x,y) to modify x in " *
             "place. If y is a single variable, you may also use " *
-            "add_to_expression!(x, coef, y) for x += coef*y.")
+            "add_to_expression!(x, coef, y) for x += coef*y.", maxlog=1)
+        # NOTE: On Julia 1.0 (at least), maxlog=1 does not work correctly.
+        # See https://github.com/JuliaLang/julia/issues/28786.
     end
 end
 

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -319,21 +319,24 @@ function operators_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
             end
 
             if ModelType <: Model
-                # Only `Model` guaranteed to have `operator_counter`, so
+                # Only `Model` is guaranteed to have `operator_counter`, so
                 # only test for that case.
-                @testset "JuMP PR #943" begin
-                    pull943 = ModelType()
-                    @test pull943.operator_counter == 0
-                    @variable(pull943, x[1:100])
+                @testset "dot not using inefficient addition" begin
+                    # Check that dot is not falling back to default, inefficient
+                    # addition (JuMP PR #943).
+                    model = ModelType()
+                    @test model.operator_counter == 0
+                    @variable(model, x[1:100])
                     JuMP.set_start_value.(x, 1:100)
-                    @expression(pull943, testsum, sum(x[i] * i for i in 1:100))
-                    @expression(pull943, testdot1, dot(x, 1:100))
-                    @expression(pull943, testdot2, dot(1:100, x))
-                    @test pull943.operator_counter == 0
-                    testadd = testdot1 + testdot2
-                    @test pull943.operator_counter == 1  # Check triggerable.
-                    @test JuMP.value(testsum, JuMP.start_value) ≈ JuMP.value(testdot1, JuMP.start_value)
-                    @test JuMP.value(testsum, JuMP.start_value) ≈ JuMP.value(testdot2, JuMP.start_value)
+                    @expression(model, test_sum, sum(x[i] * i for i in 1:100))
+                    @expression(model, test_dot1, dot(x, 1:100))
+                    @expression(model, test_dot2, dot(1:100, x))
+                    @test model.operator_counter == 0
+                    test_add = test_dot1 + test_dot2
+                    @test model.operator_counter == 1  # Check triggerable.
+                    test_sum_value = JuMP.value(test_sum, JuMP.start_value)
+                    @test test_sum_value ≈ JuMP.value(test_dot1, JuMP.start_value)
+                    @test test_sum_value ≈ JuMP.value(test_dot2, JuMP.start_value)
                 end
             end
         end

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -321,7 +321,7 @@ function operators_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
             if ModelType <: Model
                 # Only `Model` is guaranteed to have `operator_counter`, so
                 # only test for that case.
-                @testset "dot not using inefficient addition" begin
+                @testset "dot doesn't trigger operator_counter" begin
                     # Check that dot is not falling back to default, inefficient
                     # addition (JuMP PR #943).
                     model = ModelType()


### PR DESCRIPTION
Operator warning used Base.warn_once, which doesn't exist on Julia 1.0.
Test was unnecessarily expensive to basically just check one function wasn't
called too many times

Comment out all other includes in test/runtests.jl, and in test/operator.jl
comment out extension test. Saving is probably 20 seconds in full test.

```
Before
real	2m6.533s
user	2m5.312s
sys	0m1.349s

After
real	1m55.578s
user	1m54.548s
sys	0m1.176s
```