### PR TITLE
Expose JuMP.delete and JuMP.is_valid methods

### DIFF
--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -448,10 +448,10 @@ julia> x = @variable(model, [i=1:2], basename="x", lower_bound=i, integer=true)
 
 ## User-defined containers
 
-Finally, in the section [Variable containers](@ref), we explained how JuMP
-supports the efficient creation of collections of JuMP variables in three types
-of containers. However, users are also free to create collections of JuMP
-variables in their own datastructures. For example, the following code creates a
+In the section [Variable containers](@ref), we explained how JuMP supports the
+efficient creation of collections of JuMP variables in three types of
+containers. However, users are also free to create collections of JuMP variables
+in their own datastructures. For example, the following code creates a
 dictionary with symmetric matrices as the values:
 ```jldoctest; setup=:(model=Model())
 julia> variables = Dict{Symbol, Symmetric{JuMP.VariableRef,
@@ -470,9 +470,9 @@ Dict{Symbol,Symmetric{JuMP.VariableRef,Array{JuMP.VariableRef,2}}} with 2 entrie
 
 ## Deleting variables
 
-Finally, JuMP supports the deletion of optimization variables. To delete
-variables, we can use the `JuMP.delete` method. We can also check whether `x`
-is a valid JuMP variable in `model` using the `JuMP.is_valid` method:
+JuMP supports the deletion of optimization variables. To delete variables, we
+can use the `JuMP.delete` method. We can also check whether `x` is a valid JuMP
+variable in `model` using the `JuMP.is_valid` method:
 ```jldoctest variables_delete
 julia> @variable(model, x)
 x

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -476,9 +476,12 @@ is a valid JuMP variable in `model` using the `JuMP.is_valid` method:
 ```jldoctest variables_delete
 julia> @variable(model, x)
 x
+
 julia> JuMP.is_valid(model, x)
 true
+
 julia> JuMP.delete(model, x)
+
 julia> JuMP.is_valid(model, x)
 false
 ```

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -470,7 +470,18 @@ Dict{Symbol,Symmetric{JuMP.VariableRef,Array{JuMP.VariableRef,2}}} with 2 entrie
 
 ## Deleting variables
 
-**TODO(@odow):** explain how to delete variables.
+Finally, JuMP supports the deletion of optimization variables. To delete
+variables, we can use the `JuMP.delete` method. We can also check whether `x`
+is a valid JuMP variable in `model` using the `JuMP.is_valid` method:
+```jldoctest variables_delete
+julia> @variable(model, x)
+x
+julia> JuMP.is_valid(model, x)
+true
+julia> JuMP.delete(model, x)
+julia> JuMP.is_valid(model, x)
+false
+```
 
 ## Reference
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -487,8 +487,10 @@ end
 Delete the constraint associated with `constraint_ref` from the model `model`.
 """
 function delete(model::Model, constraint_ref::ConstraintRef{Model})
-    # TODO: should model be a parameter in the constraint_ref?
-    @assert model === constraint_ref.m
+    if model !== constraint_ref.m
+        error("The constraint reference you are trying to delete does not " *
+              "belong to the model.")
+    end
     MOI.delete!(model.moi_backend, index(constraint_ref))
 end
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -475,13 +475,26 @@ if VERSION >= v"0.7-"
     Base.broadcastable(cref::ConstraintRef) = Ref(cref)
 end
 
-# TODO: should model be a parameter here?
-function MOI.delete!(m::Model, cr::ConstraintRef{Model})
-    @assert m === cr.m
-    MOI.delete!(m.moi_backend, index(cr))
+"""
+    delete(model::Model, constraint_ref::ConstraintRef)
+
+Delete the constraint associated with `constraint_ref` from the model `model`.
+"""
+function delete(model::Model, constraint_ref::ConstraintRef{Model})
+    # TODO: should model be a parameter in the constraint_ref?
+    @assert model === constraint_ref.m
+    MOI.delete!(model.moi_backend, index(constraint_ref))
 end
 
-MOI.isvalid(m::Model, cr::ConstraintRef{Model}) = cr.m === m && MOI.isvalid(m.moi_backend, cr.index)
+"""
+    is_valid(model::Model, constraint_ref::ConstraintRef{Model})
+
+Return `true` if `constraint_ref` refers to a valid constraint in `model`.
+"""
+function is_valid(model::Model, constraint_ref::ConstraintRef{Model})
+    return (model === constraint_ref.m &&
+            MOI.isvalid(model.moi_backend, constraint_ref.index))
+end
 
 """
     addconstraint(m::Model, c::AbstractConstraint, name::String="")

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -105,12 +105,25 @@ end
 
 isequal_canonical(v::VariableRef, other::VariableRef) = isequal(v, other)
 
-function MOI.delete!(m::Model, v::VariableRef)
-    @assert m === v.m
-    MOI.delete!(m.moi_backend, v.index)
+"""
+    delete(model::Model, variable_ref::VariableRef)
+
+Delete the variable associated with `variable_ref` from the model `model`.
+"""
+function delete(model::Model, variable_ref::VariableRef)
+    @assert model === variable_ref.m
+    MOI.delete!(model.moi_backend, variable_ref.index)
 end
 
-MOI.isvalid(m::Model, v::VariableRef) = (v.m === m) && MOI.isvalid(m.moi_backend, v.index)
+"""
+    is_valid(model::Model, variable_ref::VariableRef)
+
+Return `true` if `variable` refers to a valid variable in `model`.
+"""
+function is_valid(model::Model, variable_ref::VariableRef)
+    return (model === variable_ref.m &&
+            MOI.isvalid(model.moi_backend, variable_ref.index))
+end
 
 # The default hash is slow. It's important for the performance of AffExpr to
 # define our own.
@@ -293,10 +306,10 @@ end
 
 Delete the lower bound constraint of a variable.
 """
-function deletelowerbound(v::VariableRef)
-    MOI.delete!(v.m, LowerBoundRef(v))
-    delete!(v.m.variable_to_lower_bound, index(v))
-    nothing
+function deletelowerbound(variable_ref::VariableRef)
+    JuMP.delete(variable_ref.m, LowerBoundRef(variable_ref))
+    delete!(variable_ref.m.variable_to_lower_bound, index(variable_ref))
+    return nothing
 end
 
 """
@@ -350,10 +363,10 @@ end
 
 Delete the upper bound constraint of a variable.
 """
-function deleteupperbound(v::VariableRef)
-    MOI.delete!(v.m, UpperBoundRef(v))
-    delete!(v.m.variable_to_upper_bound, index(v))
-    nothing
+function deleteupperbound(variable_ref::VariableRef)
+    JuMP.delete(variable_ref.m, UpperBoundRef(variable_ref))
+    delete!(variable_ref.m.variable_to_upper_bound, index(variable_ref))
+    return nothing
 end
 
 """
@@ -402,10 +415,10 @@ end
 
 Delete the fixing constraint of a variable.
 """
-function unfix(v::VariableRef)
-    MOI.delete!(v.m, FixRef(v))
-    delete!(v.m.variable_to_fix, index(v))
-    nothing
+function unfix(variable_ref::VariableRef)
+    JuMP.delete(variable_ref.m, FixRef(variable_ref))
+    delete!(variable_ref.m.variable_to_fix, index(variable_ref))
+    return nothing
 end
 
 """
@@ -448,9 +461,10 @@ function setinteger(v::VariableRef)
     nothing
 end
 
-function unsetinteger(v::VariableRef)
-    MOI.delete!(v.m, IntegerRef(v))
-    delete!(v.m.variable_to_integrality, index(v))
+function unsetinteger(variable_ref::VariableRef)
+    JuMP.delete(variable_ref.m, IntegerRef(variable_ref))
+    delete!(variable_ref.m.variable_to_integrality, index(variable_ref))
+    return nothing
 end
 
 function IntegerRef(v::VariableRef)
@@ -481,9 +495,10 @@ function setbinary(v::VariableRef)
     nothing
 end
 
-function unsetbinary(v::VariableRef)
-    MOI.delete!(v.m, BinaryRef(v))
-    delete!(v.m.variable_to_zero_one, index(v))
+function unsetbinary(variable_ref::VariableRef)
+    JuMP.delete(variable_ref.m, BinaryRef(variable_ref))
+    delete!(variable_ref.m.variable_to_zero_one, index(variable_ref))
+    return nothing
 end
 
 function BinaryRef(v::VariableRef)

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -69,6 +69,9 @@ function JuMP.set_lower_bound(vref::MyVariableRef, lower)
     vref.model.variables[vref.idx].info.has_lb = true
     vref.model.variables[vref.idx].info.lower_bound = lower
 end
+function JuMP.delete_lower_bound(variable_ref::MyVariableRef)
+    variable_ref.model.variables[variable_ref.idx].info.has_lb = false
+end
 JuMP.has_upper_bound(vref::MyVariableRef) = vref.model.variables[vref.idx].info.has_ub
 function JuMP.upper_bound(vref::MyVariableRef)
     @assert !JuMP.is_fixed(vref)
@@ -78,10 +81,17 @@ function JuMP.set_upper_bound(vref::MyVariableRef, upper)
     vref.model.variables[vref.idx].info.has_ub = true
     vref.model.variables[vref.idx].info.upper_bound = upper
 end
+function JuMP.delete_upper_bound(variable_ref::MyVariableRef)
+    variable_ref.model.variables[variable_ref.idx].info.has_ub = false
+end
 JuMP.is_fixed(vref::MyVariableRef) = vref.model.variables[vref.idx].info.has_fix
 JuMP.fix_value(vref::MyVariableRef) = vref.model.variables[vref.idx].info.fixed_value
-function JuMP.fix(vref::MyVariableRef, value)
-    vref.model.variables[vref.idx].info.fixed_value = value
+function JuMP.fix(variable_ref::MyVariableRef, value)
+    variable_ref.model.variables[variable_ref.idx].info.has_fix = true
+    variable_ref.model.variables[variable_ref.idx].info.fixed_value = value
+end
+function JuMP.unfix(variable_ref::MyVariableRef)
+    variable_ref.model.variables[variable_ref.idx].info.has_fix = false
 end
 JuMP.start_value(vref::MyVariableRef) = vref.model.variables[vref.idx].info.start
 function JuMP.set_start_value(vref::MyVariableRef, start)

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -51,11 +51,13 @@ function JuMP.addvariable(m::MyModel, v::JuMP.AbstractVariable, name::String="")
     JuMP.setname(vref, name)
     vref
 end
-function MOI.delete!(m::MyModel, vref::MyVariableRef)
-    delete!(m.variables, vref.idx)
-    delete!(m.varnames, vref.idx)
+function JuMP.delete(model::MyModel, variable_ref::MyVariableRef)
+    delete!(model.variables, variable_ref.idx)
+    delete!(model.varnames, variable_ref.idx)
 end
-MOI.isvalid(m::MyModel, vref::MyVariableRef) = vref.idx in keys(m.variables)
+function JuMP.is_valid(model::MyModel, variable_ref::MyVariableRef)
+    return variable_ref.idx in keys(model.variables)
+end
 JuMP.num_variables(m::MyModel) = length(m.variables)
 
 JuMP.haslowerbound(vref::MyVariableRef) = vref.model.variables[vref.idx].info.haslb
@@ -118,11 +120,13 @@ function JuMP.addconstraint(m::MyModel, c::JuMP.AbstractConstraint, name::String
     JuMP.setname(cref, name)
     cref
 end
-function MOI.delete!(m::MyModel, cref::MyConstraintRef)
-    delete!(m.constraints, cref.idx)
-    delete!(m.connames, cref.idx)
+function JuMP.delete(model::MyModel, constraint_ref::MyConstraintRef)
+    delete!(model.constraints, constraint_ref.idx)
+    delete!(model.connames, constraint_ref.idx)
 end
-MOI.isvalid(m::MyModel, cref::MyConstraintRef) = cref.idx in keys(m.constraints)
+function JuMP.is_valid(model::MyModel, constraint_ref::MyConstraintRef)
+    return constraint_ref.idx in keys(model.constraints)
+end
 function JuMP.constraintobject(cref::MyConstraintRef)
     return cref.model.constraints[cref.idx]
 end

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -52,11 +52,13 @@ function JuMP.add_variable(m::MyModel, v::JuMP.AbstractVariable, name::String=""
     vref
 end
 function JuMP.delete(model::MyModel, variable_ref::MyVariableRef)
+    @assert JuMP.is_valid(model, variable_ref)
     delete!(model.variables, variable_ref.idx)
     delete!(model.varnames, variable_ref.idx)
 end
 function JuMP.is_valid(model::MyModel, variable_ref::MyVariableRef)
-    return variable_ref.idx in keys(model.variables)
+    return (model === variable_ref.model &&
+            variable_ref.idx in keys(model.variables))
 end
 JuMP.num_variables(m::MyModel) = length(m.variables)
 
@@ -131,11 +133,13 @@ function JuMP.add_constraint(m::MyModel, c::JuMP.AbstractConstraint, name::Strin
     cref
 end
 function JuMP.delete(model::MyModel, constraint_ref::MyConstraintRef)
+    @assert JuMP.is_valid(model, constraint_ref)
     delete!(model.constraints, constraint_ref.idx)
     delete!(model.connames, constraint_ref.idx)
 end
 function JuMP.is_valid(model::MyModel, constraint_ref::MyConstraintRef)
-    return constraint_ref.idx in keys(model.constraints)
+    return (model === constraint_ref.model &&
+            constraint_ref.idx in keys(model.constraints))
 end
 function JuMP.constraint_object(cref::MyConstraintRef)
     return cref.model.constraints[cref.idx]

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -65,10 +65,16 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         @test c[1].set == MOI.EqualTo(1.0)
         @test JuMP.isequal_canonical(c[2].func, 2.0x)
         @test c[2].set == MOI.EqualTo(3.0)
-
-        @test JuMP.is_valid(m, cref[1])
-        JuMP.delete(m, cref[1])
-        @test !JuMP.is_valid(m, cref[1])
+    end
+    @testset "delete / is_valid constraints" begin
+        model = ModelType()
+        @variable(model, x)
+        constraint_ref = @constraint(model, 2x <= 1)
+        @test JuMP.is_valid(model, constraint_ref)
+        JuMP.delete(model, constraint_ref)
+        @test !JuMP.is_valid(model, constraint_ref)
+        second_model = ModelType()
+        @test_throws Exception JuMP.delete(second_model, constraint_ref)
     end
 
     @testset "Two-sided constraints" begin

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -66,9 +66,9 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         @test JuMP.isequal_canonical(c[2].func, 2.0x)
         @test c[2].set == MOI.EqualTo(3.0)
 
-        @test MOI.isvalid(m, cref[1])
-        MOI.delete!(m, cref[1])
-        @test !MOI.isvalid(m, cref[1])
+        @test JuMP.is_valid(m, cref[1])
+        JuMP.delete(m, cref[1])
+        @test !JuMP.is_valid(m, cref[1])
     end
 
     @testset "Two-sided constraints" begin

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -39,7 +39,9 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
             @test !JuMP.is_fixed(lbonly)
             @test JuMP.is_binary(lbonly)
             @test !JuMP.is_integer(lbonly)
-            @test isequal(mcon[:lbonly],lbonly)
+            @test isequal(mcon[:lbonly], lbonly)
+            JuMP.delete_lower_bound(lbonly)
+            @test !JuMP.has_lower_bound(lbonly)
             # Name already used
             @test_throws ErrorException @variable(mcon, lbonly)
         end
@@ -63,7 +65,9 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
             @test !JuMP.is_fixed(ubonly)
             @test !JuMP.is_binary(ubonly)
             @test JuMP.is_integer(ubonly)
-            @test isequal(mcon[:ubonly],ubonly)
+            @test isequal(mcon[:ubonly], ubonly)
+            JuMP.delete_upper_bound(ubonly)
+            @test !JuMP.has_upper_bound(ubonly)
         end
 
         @testset "Upper bound" begin
@@ -104,6 +108,8 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
             @test !JuMP.has_upper_bound(fixed)
             @test JuMP.is_fixed(fixed)
             @test JuMP.fix_value(fixed) == 1.0
+            JuMP.unfix(fixed)
+            @test !JuMP.is_fixed(fixed)
         end
 
         @testset "Custom index sets" begin
@@ -188,10 +194,21 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
 
         JuMP.set_binary(x[1])
         @test JuMP.is_binary(x[1])
-        @test_throws AssertionError JuMP.set_integer(x[1])
+        @test_throws Exception JuMP.set_integer(x[1])
         JuMP.unset_binary(x[1])
         @test !JuMP.is_binary(x[1])
-        # TODO test binary/integer keyword arguments
+
+        @variable(m, y, binary = true)
+        @test JuMP.is_binary(y)
+        @test_throws Exception JuMP.set_integer(y)
+        JuMP.unset_binary(y)
+        @test !JuMP.is_binary(y)
+
+        @variable(m, z, integer = true)
+        @test JuMP.is_integer(z)
+        @test_throws Exception JuMP.set_binary(z)
+        JuMP.unset_integer(z)
+        @test !JuMP.is_integer(z)
     end
 
     @testset "repeated elements in index set (issue #199)" begin

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -134,9 +134,9 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
     @testset "isvalid and delete variable" begin
         m = ModelType()
         @variable(m, x)
-        @test MOI.isvalid(m, x)
-        MOI.delete!(m, x)
-        @test !MOI.isvalid(m, x)
+        @test JuMP.is_valid(m, x)
+        JuMP.delete(m, x)
+        @test !JuMP.is_valid(m, x)
     end
 
 

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -138,11 +138,14 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
     end
 
     @testset "isvalid and delete variable" begin
-        m = ModelType()
-        @variable(m, x)
-        @test JuMP.is_valid(m, x)
-        JuMP.delete(m, x)
-        @test !JuMP.is_valid(m, x)
+        model = ModelType()
+        @variable(model, x)
+        @test JuMP.is_valid(model, x)
+        JuMP.delete(model, x)
+        @test !JuMP.is_valid(model, x)
+        second_model = ModelType()
+        @test_throws Exception JuMP.delete(second_model, x)
+
     end
 
 
@@ -188,11 +191,13 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
         @variable(m, x[1:3])
 
         JuMP.set_integer(x[2])
+        JuMP.set_integer(x[2])  # test duplicated call
         @test JuMP.is_integer(x[2])
         JuMP.unset_integer(x[2])
         @test !JuMP.is_integer(x[2])
 
         JuMP.set_binary(x[1])
+        JuMP.set_binary(x[1])  # test duplicated call
         @test JuMP.is_binary(x[1])
         @test_throws Exception JuMP.set_integer(x[1])
         JuMP.unset_binary(x[1])


### PR DESCRIPTION
As [suggested by Miles](https://github.com/JuliaOpt/JuMP.jl/pull/1436#discussion_r212835763). 

I have prefixed `JuMP.delete` in the code to disambiguate `Base.delete!` as it was slightly confusing distinguishing between `delete` and `delete!`. 

Maybe this is a good candidate to break from the style guide and extend a Base method?

<s>There will be some conflicts with https://github.com/JuliaOpt/JuMP.jl/pull/1442</s>