### PR TITLE
[release-0.18] bumped ForwardDiff version to work on Julia 1.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
 MathProgBase 0.6 0.8
 ReverseDiffSparse 0.8 0.9
-ForwardDiff 0.5 0.9
+ForwardDiff 0.5 0.10
 Calculus
 Compat 1.0.0


### PR DESCRIPTION
Hello all, I've been using `release-0.18` on Julia 1.0 for a couple of weeks now and things have been going quite smoothly.

Today however I did `]resolve` and got some nasty error messages saying that there were unsatisfiable requirements.  I believe perhaps that is due to [this](https://github.com/JuliaLang/METADATA.jl/pull/17516)?

I have bumped the version requirement of ForwardDiff so that `release-0.18` again installs properly on Julia 1.0.  As far as I can tell at the moment, we'll need to support ForwardDiff up to 0.10 on `release-0.18`.