### PR TITLE
Refactor constraints

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -351,10 +351,6 @@ dual_status(model::Model) = MOI.get(model, MOI.DualStatus())
 set_optimize_hook(model::Model, f) = (model.optimize_hook = f)
 
 
-#############################################################################
-# AbstractConstraint
-# Abstract base type for all constraint types
-abstract type AbstractConstraint end
 # Abstract base type for all scalar types
 abstract type AbstractJuMPScalar end
 
@@ -390,155 +386,7 @@ function isequal_canonical(x::AbstractArray{<:JuMP.AbstractJuMPScalar},
     return size(x) == size(y) && all(JuMP.isequal_canonical.(x, y))
 end
 
-"""
-    AbstractShape
-
-Abstract vectorizable shape. Given a flat vector form of an object of shape
-`shape`, the original object can be obtained by [`reshape`](@ref).
-"""
-abstract type AbstractShape end
-
-"""
-    dual_shape(shape::AbstractShape)::AbstractShape
-
-Returns the shape of the dual space of the space of objects of shape `shape`. By
-default, the `dual_shape` of a shape is itself. See the examples section below
-for an example for which this is not the case.
-
-## Examples
-
-Consider polynomial constraints for which the dual is moment constraints and
-moment constraints for which the dual is polynomial constraints. Shapes for
-polynomials can be defined as follows:
-```julia
-struct Polynomial
-    coefficients::Vector{Float64}
-    monomials::Vector{Monomial}
-end
-struct PolynomialShape <: JuMP.AbstractShape
-    monomials::Vector{Monomial}
-end
-JuMP.reshape(x::Vector, shape::PolynomialShape) = Polynomial(x, shape.monomials)
-```
-and a shape for moments can be defined as follows:
-```julia
-struct Moments
-    coefficients::Vector{Float64}
-    monomials::Vector{Monomial}
-end
-struct MomentsShape <: JuMP.AbstractShape
-    monomials::Vector{Monomial}
-end
-JuMP.reshape(x::Vector, shape::MomentsShape) = Moments(x, shape.monomials)
-```
-The `dual_shape` allows to define the shape of the dual of polynomial and moment
-constraints:
-```julia
-dual_shape(shape::PolynomialShape) = MomentsShape(shape.monomials)
-dual_shape(shape::MomentsShape) = PolynomialShape(shape.monomials)
-```
-"""
-dual_shape(shape::AbstractShape) = shape
-
-"""
-    reshape(vectorized_form::Vector, shape::AbstractShape)
-
-Return an object in it original shape `shape` given its vectorized form
-`vectorized_form`.
-
-## Examples
-
-Given a [`SymmetricMatrixShape`](@ref) of vectorized form `[1, 2, 3]`, the
-following code retrieve the matrix `Symmetric(Matrix[1 2; 2 3])`:
-```julia
-reshape([1, 2, 3], SymmetricMatrixShape(2))
-```
-"""
-function reshape end
-
-"""
-    shape(c::AbstractConstraint)::AbstractShape
-
-Return the shape of the constraint `c`.
-"""
-function shape end
-
-"""
-    ScalarShape
-
-Shape of scalar constraints.
-"""
-struct ScalarShape <: AbstractShape end
-reshape(α, ::ScalarShape) = α
-
-"""
-    VectorShape
-
-Vector for which the vectorized form corresponds exactly to the vector given.
-"""
-struct VectorShape <: AbstractShape end
-reshape(vectorized_form, ::VectorShape) = vectorized_form
-
-##########################################################################
-# Constraint
-# Holds the index of a constraint in a Model.
-# TODO: Rename "m" field (breaks style guidelines).
-struct ConstraintRef{M <: AbstractModel, C, Shape <: AbstractShape}
-    m::M
-    index::C
-    shape::Shape
-end
-
-if VERSION >= v"0.7-"
-    Base.broadcastable(cref::ConstraintRef) = Ref(cref)
-end
-
-"""
-    delete(model::Model, constraint_ref::ConstraintRef)
-
-Delete the constraint associated with `constraint_ref` from the model `model`.
-"""
-function delete(model::Model, constraint_ref::ConstraintRef{Model})
-    if model !== constraint_ref.m
-        error("The constraint reference you are trying to delete does not " *
-              "belong to the model.")
-    end
-    MOI.delete(model.moi_backend, index(constraint_ref))
-end
-
-"""
-    is_valid(model::Model, constraint_ref::ConstraintRef{Model})
-
-Return `true` if `constraint_ref` refers to a valid constraint in `model`.
-"""
-function is_valid(model::Model, constraint_ref::ConstraintRef{Model})
-    return (model === constraint_ref.m &&
-            MOI.is_valid(model.moi_backend, constraint_ref.index))
-end
-
-"""
-    add_constraint(m::Model, c::AbstractConstraint, name::String="")
-
-Add a constraint `c` to `Model m` and sets its name.
-"""
-function add_constraint(m::Model, c::AbstractConstraint, name::String="")
-    f, s = moi_function_and_set(c)
-    if !MOI.supports_constraint(m.moi_backend, typeof(f), typeof(s))
-        if m.moi_backend isa MOI.Bridges.LazyBridgeOptimizer
-            bridge_message = " and there are no bridges that can reformulate it into supported constraints."
-        else
-            bridge_message = ", try using `bridge_constraints=true` in the `JuMP.Model` constructor if you believe the constraint can be reformulated to constraints supported by the solver."
-        end
-        error("Constraints of type $(typeof(f))-in-$(typeof(s)) are not supported by the solver" * bridge_message)
-    end
-    cindex = MOI.add_constraint(m.moi_backend, f, s)
-    cref = ConstraintRef(m, cindex, shape(c))
-    if !isempty(name)
-        set_name(cref, name)
-    end
-    return cref
-end
-
+include("constraints.jl")
 include("variables.jl")
 
 Base.zero(::Type{V}) where V<:AbstractVariableRef = zero(GenericAffExpr{Float64, V})
@@ -601,15 +449,6 @@ Replaces `getdual` for most use cases.
 function result_dual(cr::ConstraintRef{Model, <:MOICON})
     reshape(MOI.get(cr.m, MOI.ConstraintDual(), cr), dual_shape(cr.shape))
 end
-
-"""
-    name(v::ConstraintRef)
-
-Get a constraint's name.
-"""
-name(cr::ConstraintRef{Model,<:MOICON}) = MOI.get(cr.m, MOI.ConstraintName(), cr)
-
-set_name(cr::ConstraintRef{Model,<:MOICON}, s::String) = MOI.set(cr.m, MOI.ConstraintName(), cr, s)
 
 """
     get(m::JuMP.Model, attr::MathOptInterface.AbstractModelAttribute)

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -112,6 +112,11 @@ function value(a::GenericAffExpr{T, V}, map::Function) where {T, V}
     ret
 end
 
+"""
+    constant(aff::GenericAffExpr{C, V})::C
+
+Return the constant of the affine expression.
+"""
 constant(aff::GenericAffExpr) = aff.constant
 
 # Iterator protocol - iterates over tuples (aᵢ,xᵢ)

--- a/src/affexpr.jl
+++ b/src/affexpr.jl
@@ -112,6 +112,8 @@ function value(a::GenericAffExpr{T, V}, map::Function) where {T, V}
     ret
 end
 
+constant(aff::GenericAffExpr) = aff.constant
+
 # Iterator protocol - iterates over tuples (aᵢ,xᵢ)
 struct LinearTermIterator{GAE<:GenericAffExpr}
     aff::GAE
@@ -243,6 +245,7 @@ function MOI.ScalarAffineFunction(a::AffExpr)
     terms = map(t -> MOI.ScalarAffineTerm(t[1], index(t[2])), linear_terms(a))
     return MOI.ScalarAffineFunction(terms, a.constant)
 end
+moi_function(a::GenericAffExpr) = MOI.ScalarAffineFunction(a)
 
 function AffExpr(m::Model, f::MOI.ScalarAffineFunction)
     aff = AffExpr()
@@ -251,6 +254,12 @@ function AffExpr(m::Model, f::MOI.ScalarAffineFunction)
     end
     aff.constant = f.constant
     return aff
+end
+function jump_function(model::AbstractModel, f::MOI.ScalarAffineFunction)
+    return AffExpr(model, f)
+end
+function jump_function(model::AbstractModel, f::MOI.VectorAffineFunction)
+    return map(f -> AffExpr(model, f), MOIU.eachscalar(f))
 end
 
 """
@@ -279,6 +288,7 @@ function MOI.VectorAffineFunction(affs::Vector{AffExpr})
     end
     MOI.VectorAffineFunction(terms, constant)
 end
+moi_function(a::Vector{<:GenericAffExpr}) = MOI.VectorAffineFunction(a)
 
 function set_objective(m::Model, sense::Symbol, a::AffExpr)
     if sense == :Min
@@ -315,49 +325,6 @@ function Base.copy(a::GenericAffExpr, new_model::Model)
     return result
 end
 
-struct AffExprConstraint{V <: AbstractVariableRef,
-                         S <: MOI.AbstractScalarSet} <: AbstractConstraint
-    func::GenericAffExpr{Float64, V}
-    set::S
-end
-
-moi_function_and_set(c::AffExprConstraint) = (MOI.ScalarAffineFunction(c.func), c.set)
-shape(::AffExprConstraint) = ScalarShape()
-
 # TODO: Find somewhere to put this error message.
 #add_constraint(m::Model, c::Array{AffExprConstraint}) =
 #    error("The operators <=, >=, and == can only be used to specify scalar constraints. If you are trying to add a vectorized constraint, use the element-wise dot comparison operators (.<=, .>=, or .==) instead")
-
-struct VectorAffExprConstraint{V <: AbstractVariableRef,
-                               S <: MOI.AbstractVectorSet,
-                               Shape <: AbstractShape} <: AbstractConstraint
-    func::Vector{GenericAffExpr{Float64, V}}
-    set::S
-    shape::Shape
-end
-function VectorAffExprConstraint(func::Vector{GenericAffExpr{Float64, V}},
-                                     set::MOI.AbstractVectorSet) where V <: AbstractVariableRef
-    VectorAffExprConstraint(func, set, VectorShape())
-end
-
-
-moi_function_and_set(c::VectorAffExprConstraint) = (MOI.VectorAffineFunction(c.func), c.set)
-shape(c::VectorAffExprConstraint) = c.shape
-
-function constraint_object(ref::ConstraintRef{Model, MOICON{FuncType, SetType}}) where
-        {FuncType <: MOI.ScalarAffineFunction, SetType <: MOI.AbstractScalarSet}
-    model = ref.m
-    f = MOI.get(model, MOI.ConstraintFunction(), ref)::FuncType
-    s = MOI.get(model, MOI.ConstraintSet(), ref)::SetType
-    return AffExprConstraint(AffExpr(model, f), s)
-end
-
-function constraint_object(ref::ConstraintRef{Model, MOICON{FuncType, SetType}}) where
-        {FuncType <: MOI.VectorAffineFunction, SetType <: MOI.AbstractVectorSet}
-    model = ref.m
-    f = MOI.get(model, MOI.ConstraintFunction(), ref)::MOI.VectorAffineFunction
-    s = MOI.get(model, MOI.ConstraintSet(), ref)::SetType
-    return VectorAffExprConstraint(map(f -> AffExpr(model, f),
-                                       MOIU.eachscalar(f)),
-                                   s, ref.shape)
-end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1,6 +1,13 @@
+#  Copyright 2017, Iain Dunning, Joey Huchette, Miles Lubin, and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #############################################################################
-# AbstractShape
-# Abstract base type for the shape of constraints
+# JuMP
+# An algebraic modeling language for Julia
+# See http://github.com/JuliaOpt/JuMP.jl
+#############################################################################
+
 """
     AbstractShape
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1,0 +1,207 @@
+#############################################################################
+# AbstractShape
+# Abstract base type for the shape of constraints
+"""
+    AbstractShape
+
+Abstract vectorizable shape. Given a flat vector form of an object of shape
+`shape`, the original object can be obtained by [`reshape`](@ref).
+"""
+abstract type AbstractShape end
+
+"""
+    dual_shape(shape::AbstractShape)::AbstractShape
+
+Returns the shape of the dual space of the space of objects of shape `shape`. By
+default, the `dual_shape` of a shape is itself. See the examples section below
+for an example for which this is not the case.
+
+## Examples
+
+Consider polynomial constraints for which the dual is moment constraints and
+moment constraints for which the dual is polynomial constraints. Shapes for
+polynomials can be defined as follows:
+```julia
+struct Polynomial
+    coefficients::Vector{Float64}
+    monomials::Vector{Monomial}
+end
+struct PolynomialShape <: JuMP.AbstractShape
+    monomials::Vector{Monomial}
+end
+JuMP.reshape(x::Vector, shape::PolynomialShape) = Polynomial(x, shape.monomials)
+```
+and a shape for moments can be defined as follows:
+```julia
+struct Moments
+    coefficients::Vector{Float64}
+    monomials::Vector{Monomial}
+end
+struct MomentsShape <: JuMP.AbstractShape
+    monomials::Vector{Monomial}
+end
+JuMP.reshape(x::Vector, shape::MomentsShape) = Moments(x, shape.monomials)
+```
+The `dual_shape` allows to define the shape of the dual of polynomial and moment
+constraints:
+```julia
+dual_shape(shape::PolynomialShape) = MomentsShape(shape.monomials)
+dual_shape(shape::MomentsShape) = PolynomialShape(shape.monomials)
+```
+"""
+dual_shape(shape::AbstractShape) = shape
+
+"""
+    reshape(vectorized_form::Vector, shape::AbstractShape)
+
+Return an object in it original shape `shape` given its vectorized form
+`vectorized_form`.
+
+## Examples
+
+Given a [`SymmetricMatrixShape`](@ref) of vectorized form `[1, 2, 3]`, the
+following code retrieve the matrix `Symmetric(Matrix[1 2; 2 3])`:
+```julia
+reshape([1, 2, 3], SymmetricMatrixShape(2))
+```
+"""
+function reshape end
+
+"""
+    shape(c::AbstractConstraint)::AbstractShape
+
+Return the shape of the constraint `c`.
+"""
+function shape end
+
+"""
+    ScalarShape
+
+Shape of scalar constraints.
+"""
+struct ScalarShape <: AbstractShape end
+reshape(α, ::ScalarShape) = α
+
+"""
+    VectorShape
+
+Vector for which the vectorized form corresponds exactly to the vector given.
+"""
+struct VectorShape <: AbstractShape end
+reshape(vectorized_form, ::VectorShape) = vectorized_form
+
+##########################################################################
+# Constraint Reference
+# Holds the index of a constraint in a Model.
+# TODO: Rename "m" field (breaks style guidelines).
+struct ConstraintRef{M <: AbstractModel, C, Shape <: AbstractShape}
+    m::M
+    index::C
+    shape::Shape
+end
+
+if VERSION >= v"0.7-"
+    Base.broadcastable(cref::ConstraintRef) = Ref(cref)
+end
+
+"""
+    name(v::ConstraintRef)
+
+Get a constraint's name.
+"""
+name(cr::ConstraintRef{Model,<:MOICON}) = MOI.get(cr.m, MOI.ConstraintName(), cr)
+
+set_name(cr::ConstraintRef{Model,<:MOICON}, s::String) = MOI.set(cr.m, MOI.ConstraintName(), cr, s)
+
+"""
+    delete(model::Model, constraint_ref::ConstraintRef)
+
+Delete the constraint associated with `constraint_ref` from the model `model`.
+"""
+function delete(model::Model, constraint_ref::ConstraintRef{Model})
+    if model !== constraint_ref.m
+        error("The constraint reference you are trying to delete does not " *
+              "belong to the model.")
+    end
+    MOI.delete(model.moi_backend, index(constraint_ref))
+end
+
+"""
+    is_valid(model::Model, constraint_ref::ConstraintRef{Model})
+
+Return `true` if `constraint_ref` refers to a valid constraint in `model`.
+"""
+function is_valid(model::Model, constraint_ref::ConstraintRef{Model})
+    return (model === constraint_ref.m &&
+            MOI.is_valid(model.moi_backend, constraint_ref.index))
+end
+
+#############################################################################
+# AbstractConstraint
+# Abstract base type for all constraint types
+abstract type AbstractConstraint end
+
+struct ScalarConstraint{F <: AbstractJuMPScalar,
+                        S <: MOI.AbstractScalarSet} <: AbstractConstraint
+    func::F
+    set::S
+end
+
+moi_function_and_set(c::ScalarConstraint) = (moi_function(c.func), c.set)
+shape(::ScalarConstraint) = ScalarShape()
+function constraint_object(ref::ConstraintRef{Model, MOICON{FuncType, SetType}}) where
+        {FuncType <: MOI.AbstractScalarFunction, SetType <: MOI.AbstractScalarSet}
+    model = ref.m
+    f = MOI.get(model, MOI.ConstraintFunction(), ref)::FuncType
+    s = MOI.get(model, MOI.ConstraintSet(), ref)::SetType
+    return ScalarConstraint(jump_function(model, f), s)
+end
+
+struct VectorConstraint{F <: AbstractJuMPScalar,
+                        S <: MOI.AbstractVectorSet,
+                        Shape <: AbstractShape} <: AbstractConstraint
+    func::Vector{F}
+    set::S
+    shape::Shape
+end
+function VectorConstraint(func::Vector{<:AbstractJuMPScalar},
+                          set::MOI.AbstractVectorSet)
+    VectorConstraint(func, set, VectorShape())
+end
+
+moi_function_and_set(c::VectorConstraint) = (moi_function(c.func), c.set)
+shape(c::VectorConstraint) = c.shape
+function constraint_object(ref::ConstraintRef{Model, MOICON{FuncType, SetType}}) where
+        {FuncType <: MOI.AbstractVectorFunction, SetType <: MOI.AbstractVectorSet}
+    model = ref.m
+    f = MOI.get(model, MOI.ConstraintFunction(), ref)::FuncType
+    s = MOI.get(model, MOI.ConstraintSet(), ref)::SetType
+    return VectorConstraint(jump_function(model, f), s, ref.shape)
+end
+
+# TODO: Find somewhere to put this error message.
+#add_constraint(m::Model, c::Array{AffExprConstraint}) =
+#    error("The operators <=, >=, and == can only be used to specify scalar constraints. If you are trying to add a vectorized constraint, use the element-wise dot comparison operators (.<=, .>=, or .==) instead")
+
+"""
+    add_constraint(m::Model, c::AbstractConstraint, name::String="")
+
+Add a constraint `c` to `Model m` and sets its name.
+"""
+function add_constraint(m::Model, c::AbstractConstraint, name::String="")
+    f, s = moi_function_and_set(c)
+    if !MOI.supports_constraint(m.moi_backend, typeof(f), typeof(s))
+        if m.moi_backend isa MOI.Bridges.LazyBridgeOptimizer
+            bridge_message = " and there are no bridges that can reformulate it into supported constraints."
+        else
+            bridge_message = ", try using `bridge_constraints=true` in the `JuMP.Model` constructor if you believe the constraint can be reformulated to constraints supported by the solver."
+        end
+        error("Constraints of type $(typeof(f))-in-$(typeof(s)) are not supported by the solver" * bridge_message)
+    end
+    cindex = MOI.add_constraint(m.moi_backend, f, s)
+    cref = ConstraintRef(m, cindex, shape(c))
+    if !isempty(name)
+        set_name(cref, name)
+    end
+    return cref
+end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -61,13 +61,13 @@ dual_shape(shape::AbstractShape) = shape
 """
     reshape(vectorized_form::Vector, shape::AbstractShape)
 
-Return an object in it original shape `shape` given its vectorized form
+Return an object in its original shape `shape` given its vectorized form
 `vectorized_form`.
 
 ## Examples
 
 Given a [`SymmetricMatrixShape`](@ref) of vectorized form `[1, 2, 3]`, the
-following code retrieve the matrix `Symmetric(Matrix[1 2; 2 3])`:
+following code returns the matrix `Symmetric(Matrix[1 2; 2 3])`:
 ```julia
 reshape([1, 2, 3], SymmetricMatrixShape(2))
 ```

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -186,10 +186,6 @@ function constraint_object(ref::ConstraintRef{Model, MOICON{FuncType, SetType}})
     return VectorConstraint(jump_function(model, f), s, ref.shape)
 end
 
-# TODO: Find somewhere to put this error message.
-#add_constraint(m::Model, c::Array{AffExprConstraint}) =
-#    error("The operators <=, >=, and == can only be used to specify scalar constraints. If you are trying to add a vectorized constraint, use the element-wise dot comparison operators (.<=, .>=, or .==) instead")
-
 """
     add_constraint(m::Model, c::AbstractConstraint, name::String="")
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -358,10 +358,21 @@ function build_constraint(_error::Function,
     add_to_expression!(expr, -offset)
     return ScalarConstraint(expr, MOIU.shift_constant(set, -offset))
 end
-build_constraint(_error::Function, α::Number, set::MOI.AbstractScalarSet) = build_constraint(_error, convert(AffExpr, α), set)
+function build_constraint(_error::Function, α::Number,
+                          set::MOI.AbstractScalarSet)
+    return build_constraint(_error, convert(AffExpr, α), set)
+end
 
-build_constraint(_error::Function, x::Vector{<:AbstractJuMPScalar}, set::MOI.AbstractVectorSet) = VectorConstraint(x, set)
-build_constraint(_error::Function, x::AbstractArray, set::MOI.AbstractScalarSet) = _error("Unexpected vector in scalar constraint. Did you mean to use the dot comparison operators like .==, .<=, and .>= instead?")
+function build_constraint(_error::Function, x::Vector{<:AbstractJuMPScalar},
+                          set::MOI.AbstractVectorSet)
+    return VectorConstraint(x, set)
+end
+function build_constraint(_error::Function, x::AbstractArray,
+                          set::MOI.AbstractScalarSet)
+    return _error("Unexpected vector in scalar constraint. Did you mean to use",
+                  " the dot comparison operators like .==, .<=, and .>=",
+                  " instead?")
+end
 
 # _vectorize_like(x::Number, y::AbstractArray{AffExpr}) = (ret = similar(y, typeof(x)); fill!(ret, x))
 # function _vectorize_like{R<:Number}(x::AbstractArray{R}, y::AbstractArray{AffExpr})
@@ -408,7 +419,7 @@ to `add_constraint` with the macro keyword arguments (except the `container`
 keyword argument which is used to determine the container type).
 """
 function constraint_macro(args, macro_name::Symbol, parsefun::Function)
-    _error(str) = macro_error(macro_name, args, str)
+    _error(str...) = macro_error(macro_name, args, str...)
 
     args, kwargs, requestedcontainer = extract_kwargs(args)
 
@@ -979,7 +990,9 @@ end
 
 const EMPTYSTRING = ""
 
-macro_error(macroname, args, str) = error("In @$macroname($(join(args,","))): ", str)
+function macro_error(macroname, args, str...)
+    error("In @$macroname($(join(args,","))): ", str...)
+end
 
 # Given a basename and idxvars, returns an expression that constructs the name
 # of the object. For use within macros only.
@@ -1188,7 +1201,7 @@ end
 ```
 """
 macro variable(args...)
-    _error(str) = macro_error(:variable, args, str)
+    _error(str...) = macro_error(:variable, args, str...)
 
     model = esc(args[1])
 

--- a/src/quadexpr.jl
+++ b/src/quadexpr.jl
@@ -76,6 +76,11 @@ function map_coefficients(f::Function, q::GenericQuadExpr)
     return map_coefficients_inplace!(f, copy(q))
 end
 
+"""
+    constant(aff::GenericQuadExpr{C, V})::C
+
+Return the constant of the quadratic expression.
+"""
 constant(quad::GenericQuadExpr) = constant(quad.aff)
 
 """

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -75,9 +75,9 @@ function macros_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::Typ
     @testset "build_constraint on variable" begin
         m = ModelType()
         @variable(m, x)
-        @test JuMP.build_constraint(error, x, MOI.GreaterThan(0.0)) isa JuMP.SingleVariableConstraint{VariableRefType, MOI.GreaterThan{Float64}}
-        @test JuMP.build_constraint(error, x, MOI.LessThan(0.0)) isa JuMP.SingleVariableConstraint{VariableRefType, MOI.LessThan{Float64}}
-        @test JuMP.build_constraint(error, x, MOI.EqualTo(0)) isa JuMP.SingleVariableConstraint{VariableRefType, MOI.EqualTo{Int}}
+        @test JuMP.build_constraint(error, x, MOI.GreaterThan(0.0)) isa JuMP.ScalarConstraint{VariableRefType, MOI.GreaterThan{Float64}}
+        @test JuMP.build_constraint(error, x, MOI.LessThan(0.0)) isa JuMP.ScalarConstraint{VariableRefType, MOI.LessThan{Float64}}
+        @test JuMP.build_constraint(error, x, MOI.EqualTo(0)) isa JuMP.ScalarConstraint{VariableRefType, MOI.EqualTo{Int}}
     end
 
     @testset "Check @constraint basics" begin


### PR DESCRIPTION
This PR

* moves constraints-related code to a constraints.jl file, moving a lot of code out of JuMP.jl;
* merges SingleVariableConstraint, AffExprConstraint and QuadExprConstraint into ScalarConstraint (same for the vector version) removing a lot of duplicated code both from the definition of the constraint and from the build_constraint function calling them.

As a by-product, it improves support for constraints for which the function is a quadratic expression since the code is now shared with affine expression and variable expression.