### PR TITLE
Rename `m` field of VariableRef to `model`.

### DIFF
--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -527,4 +527,5 @@ false
 
 ```@docs
 @variable
+owner_model
 ```

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -415,11 +415,12 @@ Base.copy(x::Nothing, new_model::Model) = nothing
 Base.copy(v::AbstractArray{VariableRef}, new_model::Model) = (var -> VariableRef(new_model, var.index)).(v)
 
 function optimizer_index(v::VariableRef)
-    if mode(v.m) == Direct
+    model = owner_model(v)
+    if mode(model) == Direct
         return index(v)
     else
-        @assert caching_optimizer(v.m).state == MOIU.AttachedOptimizer
-        return caching_optimizer(v.m).model_to_optimizer_map[index(v)]
+        @assert caching_optimizer(model).state == MOIU.AttachedOptimizer
+        return caching_optimizer(model).model_to_optimizer_map[index(v)]
     end
 end
 
@@ -457,21 +458,21 @@ Return the value of the attribute `attr` from model's MOI backend.
 """
 MOI.get(m::Model, attr::MOI.AbstractModelAttribute) = MOI.get(m.moi_backend, attr)
 function MOI.get(m::Model, attr::MOI.AbstractVariableAttribute, v::VariableRef)
-    @assert m === v.m
+    @assert m === owner_model(v) # TODO: Improve the error message.
     MOI.get(m.moi_backend, attr, index(v))
 end
 function MOI.get(m::Model, attr::MOI.AbstractConstraintAttribute, cr::ConstraintRef)
-    @assert m === cr.m
+    @assert m === cr.m # TODO: Improve the error message.
     MOI.get(m.moi_backend, attr, index(cr))
 end
 
 MOI.set(m::Model, attr::MOI.AbstractModelAttribute, value) = MOI.set(m.moi_backend, attr, value)
 function MOI.set(m::Model, attr::MOI.AbstractVariableAttribute, v::VariableRef, value)
-    @assert m === v.m
+    @assert m === owner_model(v) # TODO: Improve the error message.
     MOI.set(m.moi_backend, attr, index(v), value)
 end
 function MOI.set(m::Model, attr::MOI.AbstractConstraintAttribute, cr::ConstraintRef, value)
-    @assert m === cr.m
+    @assert m === cr.m # TODO: Improve the error message.
     MOI.set(m.moi_backend, attr, index(cr), value)
 end
 

--- a/src/parse_nlp.jl
+++ b/src/parse_nlp.jl
@@ -161,7 +161,10 @@ function parseNLExpr_runtime(m::Model, x::Number, tape, parent, values)
 end
 
 function parseNLExpr_runtime(m::Model, x::VariableRef, tape, parent, values)
-    x.m === m || error("Variable in nonlinear expression does not belong to corresponding model")
+    if owner_model(x) !== m
+        error("Variable in nonlinear expression does not belong to the " *
+              "corresponding model")
+    end
     push!(tape, NodeData(MOIVARIABLE, x.index.value, parent))
     nothing
 end
@@ -259,7 +262,7 @@ function checkexpr(m::Model, ex::Expr)
     return
 end
 function checkexpr(m::Model, v::VariableRef)
-    v.m === m || error("Variable $v does not belong to this model")
+    owner_model(v) === m || error("Variable $v does not belong to this model.")
     return
 end
 checkexpr(m::Model, ex) = nothing

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -102,7 +102,7 @@ end
 
 # owner_model should be implemented by all `AbstractVariableRef`.
 """
-    owner_model(v::VariableRef)
+    owner_model(v::AbstractVariableRef)
 
 Returns the model to which `v` belongs.
 
@@ -115,6 +115,8 @@ julia> x = @variable(model)
 julia> JuMP.owner_model(x) === model
 true
 """
+function owner_model end
+
 owner_model(v::VariableRef) = v.model
 
 Base.iszero(::VariableRef) = false

--- a/test/model.jl
+++ b/test/model.jl
@@ -154,13 +154,13 @@ function dummy_optimizer_hook(::JuMP.AbstractModel) end
                         @test new_model.optimize_hook === dummy_optimizer_hook
                         @test new_model.ext[:dummy].model === new_model
                         x_new = reference_map[x]
-                        @test x_new.m === new_model
+                        @test JuMP.owner_model(x_new) === new_model
                         @test JuMP.name(x_new) == "x"
                         y_new = reference_map[y]
-                        @test y_new.m === new_model
+                        @test JuMP.owner_model(y_new) === new_model
                         @test JuMP.name(y_new) == "y"
                         z_new = reference_map[z]
-                        @test z_new.m === new_model
+                        @test JuMP.owner_model(z_new) === new_model
                         @test JuMP.name(z_new) == "z"
                         if copy_model
                             @test JuMP.LowerBoundRef(x_new) == reference_map[JuMP.LowerBoundRef(x)]


### PR DESCRIPTION
For style compliance. Also switch to `owner_model` method instead of
accessing the field directly.

The definition of VariableRef is now:
```julia
struct VariableRef <: AbstractVariableRef
    model::Model
    index::MOI.VariableIndex
end
```
which is much nicer IMO than
```julia
struct VariableRef <: AbstractVariableRef
    m::Model
    index::MOIVAR
end
```
We should do the same for `ConstraintRef` after this goes through.