### PR TITLE
fix doctest failure

### DIFF
--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -77,7 +77,7 @@ less-than-or-equal-to constraint using `<=`, but we can also create equality
 constraints using `==` and greater-than-or-equal-to constraints with `>=`:
 ```jldoctest quickstart_example; filter=r"≤|<="
 julia> @constraint(model, con, 1x + 5y <= 3)
-x + 5 y <= 3.0
+con : x + 5 y <= 3.0
 ```
 Note that in a similar manner to the `@variable` macro, we have named the
 constraint `con`. This will bind the constraint to the Julia variable `con` for


### PR DESCRIPTION
Note that doctest failures don't cause travis to fail...

We should implement https://discourse.julialang.org/t/psa-use-a-project-for-building-your-docs/14974 when we drop support for Julia 0.6, or maybe we can do it now because the docs are generated on 1.0 anyway?
