### PR TITLE
Avoid replacing doc of owner_model

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -100,7 +100,8 @@ struct VariableRef <: AbstractVariableRef
     index::MOI.VariableIndex
 end
 
-# owner_model should be implemented by all `AbstractVariableRef`.
+# owner_model should be implemented by an `AbstractVariableRef` if the field
+# name is not `model`.
 """
     owner_model(v::AbstractVariableRef)
 
@@ -115,9 +116,7 @@ julia> x = @variable(model)
 julia> JuMP.owner_model(x) === model
 true
 """
-function owner_model end
-
-owner_model(v::VariableRef) = v.model
+owner_model(v::AbstractVariableRef) = v.model
 
 Base.iszero(::VariableRef) = false
 Base.copy(v::VariableRef) = VariableRef(v.model, v.index)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -100,8 +100,8 @@ struct VariableRef <: AbstractVariableRef
     index::MOI.VariableIndex
 end
 
-# owner_model should be implemented by an `AbstractVariableRef` if the field
-# name is not `model`.
+# `AbstractVariableRef` types must override the default `owner_model` if the field
+#  name is not `model`.
 """
     owner_model(v::AbstractVariableRef)
 

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -41,7 +41,6 @@ Base.:(==)(v::MyVariableRef, w::MyVariableRef) = v.model === w.model && v.idx ==
 if VERSION >= v"0.7-"
     Base.broadcastable(v::MyVariableRef) = Ref(v)
 end
-JuMP.owner_model(v::MyVariableRef) = v.model
 JuMP.isequal_canonical(v::MyVariableRef, w::MyVariableRef) = v == w
 JuMP.variable_type(::MyModel) = MyVariableRef
 function JuMP.add_variable(m::MyModel, v::JuMP.AbstractVariable, name::String="")


### PR DESCRIPTION
function owner_model end is there both in JuMP.jl and variable.jl so one of them replaces the docstring of the other one