### PR TITLE
more helpful error message for the solver= keyword

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -188,7 +188,13 @@ an appropriate is defined in the `MathOptInterface.Bridges` module or is
 defined in another module and is explicitely added.
 """
 function Model(; caching_mode::MOIU.CachingOptimizerMode=MOIU.Automatic,
-                 bridge_constraints::Bool=true)
+                 bridge_constraints::Bool=true,
+                 solver=nothing)
+    if solver !== nothing
+        error("The solver= keyword is no longer available in JuMP 0.19 and " *
+              "later. See the JuMP documentation " *
+              "(http://www.juliaopt.org/JuMP.jl/latest/) for latest syntax.")
+    end
     universal_fallback = MOIU.UniversalFallback(JuMPMOIModel{Float64}())
     caching_opt = MOIU.CachingOptimizer(universal_fallback,
                                         caching_mode)


### PR DESCRIPTION
Starting to fill holes where people may get confused when transitioning from JuMP/MPB (e.g., https://discourse.julialang.org/t/error-to-show-a-jump-model-in-v0-7-1-0/15972/4).