### PR TITLE
Export MOI shortcut

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -18,6 +18,7 @@ using Compat.SparseArrays
 
 import MathOptInterface
 const MOI = MathOptInterface
+export MOI
 const MOIU = MOI.Utilities
 
 import Calculus

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -4,8 +4,6 @@ module JuMPExtension
 # `JuMP.Model` applies the modification to its `moi_backend` field while
 # `JuMPExtension.MyModel` stores the `AbstractVariable` (resp. `AbstractConstraint`) in a list.
 
-using MathOptInterface
-const MOI = MathOptInterface
 using JuMP
 
 mutable struct MyModel <: JuMP.AbstractModel

--- a/test/model.jl
+++ b/test/model.jl
@@ -10,13 +10,10 @@
 # test/model.jl
 #############################################################################
 
-using JuMP
-
 using Compat
 using Compat.Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+using JuMP
 const MOIT = MOI.Test
 const MOIU = MOI.Utilities
 

--- a/test/nlp_solver.jl
+++ b/test/nlp_solver.jl
@@ -21,11 +21,10 @@
 # TODO: Move these tests out of JuMP and into MOI so that JuMP can be tested
 # separately from the solver, as it is for everything except NLP.
 
-using Ipopt, JuMP
 using Compat
 using Compat.Test
-using MathOptInterface
-const MOI = MathOptInterface
+
+using Ipopt, JuMP
 
 @testset "NLP solver tests" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,15 +10,12 @@
 # test/runtests.jl
 #############################################################################
 
-using JuMP
-
 using Compat
 using Compat.LinearAlgebra  # for dot and tr
 using Compat.SparseArrays # for sparse
 using Compat.Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+using JuMP
 const MOIT = MOI.Test
 const MOIU = MOI.Utilities
 


### PR DESCRIPTION
This PR exports `MOI` from JuMP so that users of JuMP do not have to copy paste
```julia
using MathOptInterface
const MOI = MathOptInterface
```
everywhere

This was [suggested](https://discourse.julialang.org/t/first-alpha-release-of-jump-0-19-jump-mathoptinterface/16099/5) by @odow