### PR TITLE
👷 Disable osx on Travis and 0.6/0.7 on AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: julia
 os:
     - linux
+#   - osx # Disable to speed up CI. JuMP has no binary dependency so the result
+          # with osx and linux should be similar.
 julia:
     - 0.6
     - 0.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: julia
 os:
     - linux
-    - osx
 julia:
     - 0.6
     - 0.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 environment:
   matrix:
+# - julia_version: 0.6 # Disabled to speed up CI, Julia v0.6 and v0.7 are still
+# - julia_version: 0.7 # tested on Linux with Travis
   - julia_version: 1.0
 
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - julia_version: 0.6
-  - julia_version: 0.7
   - julia_version: 1.0
 
 platform:


### PR DESCRIPTION
See discussion on Gitter. osx does not provide much information as there is no binary dependency.