### PR TITLE
limited support for splatting in nonlinear expressions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,9 @@ Breaking changes:
 
 New features:
 
+- Splatting (like `f(x...)`) is recognized in restricted settings in nonlinear
+  expressions.
+
 - Support for deleting constraints and variables.
 
 - The documentation has been completely rewritten using docstrings and

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -38,7 +38,6 @@ JuMP.set_coefficient
 ## Duals
 
 ```@docs
-JuMP.has_result_dual
 JuMP.result_dual
 JuMP.shadow_price
 ```

--- a/docs/src/nlp.md
+++ b/docs/src/nlp.md
@@ -58,7 +58,8 @@ Syntax notes
 The syntax accepted in nonlinear expressions is more restricted than the syntax
 for linear and quadratic expressions. We note some important points below.
 
-- All expressions must be simple scalar operations. You cannot use `dot`,
+- With the exception of the splatting syntax discussed below, all expressions
+  must be simple scalar operations. You cannot use `dot`,
   matrix-vector products, vector slices, etc. Translate vector operations into
   explicit `sum()` operations or use the `AffExpr` plus auxiliary variable trick
   described below.
@@ -106,6 +107,23 @@ ERROR: Unrecognized function "my_function" used in nonlinear expression.
 ```julia
     my_expr = @NLexpression(model, [i = 1:n], sin(x[i]))
     my_constr = @NLconstraint(model, [i = 1:n], my_expr[i] <= 0.5)
+```
+
+- The [splatting operator](https://docs.julialang.org/en/v1/manual/faq/#...-splits-one-argument-into-many-different-arguments-in-function-calls-1)
+  `...` is recognized in a very restricted setting for expanding function
+  arguments. The expression splatted can be *only* a symbol. More complex
+  expressions are not recognized.
+
+```jldoctest; filter=r"≤|<="
+julia> model = Model();
+
+julia> @variable(model, x[1:3]);
+
+julia> @NLconstraint(model, *(x...) <= 1.0)
+x[1] * x[2] * x[3] - 1.0 ≤ 0
+
+julia> @NLconstraint(model, *((x / 2)...) <= 0.0)
+ERROR: LoadError: Unexpected expression in (*)(x / 2...). JuMP supports splatting only symbols. For example, x... is ok, but (x + 1)..., [x; y]... and g(f(y)...) are not.
 ```
 
 Nonlinear Parameters

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -70,6 +70,7 @@ it! Feel free to stick with `*` if it makes you feel more comfortable, as we
 have done with `3 * y`. (We have been intentionally inconsistent here to demonstrate different syntax; however, it is good practice to pick one way or the other consistently in your code.)
 ```jldoctest quickstart_example
 julia> @objective(model, Max, 5x + 3 * y)
+5 x + 3 y
 ```
 
 Adding constraints is a lot like setting the objective. Here we create a

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -411,6 +411,7 @@ end
 index(cr::ConstraintRef) = cr.index
 
 # TODO: Why does this method depend on the type of the constraint?
+# TODO: docstring
 function has_result_dual(model::Model,
                          REF::Type{<:ConstraintRef{Model, T}}) where {T <: MOICON}
     MOI.get(model, MOI.DualStatus()) != MOI.NoSolution

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -219,7 +219,7 @@ same variable. For example, given a constraint `2x + 3x <= 2`,
 `JuMP.set_coefficient(c, x, 4)` will create the constraint `4x <= 2`.
 
 
-```jldoctest; setup = :(using JuMP)
+```jldoctest; setup = :(using JuMP), filter=r"≤|<="
 model = Model()
 @variable(model, x)
 @constraint(model, con, 2x + 3x <= 2)

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -122,12 +122,30 @@
                                 NonlinearExprData(model, :(f($x,$y))))
     end
 
-    @testset "Error on splatting" begin
+    @testset "Parse splatting" begin
         model = Model()
         @variable(model, x[1:2])
         user_function = (x, y) -> x
         JuMP.register(model, :f, 2, user_function, autodiff=true)
-        @test_macro_throws ErrorException @NLexpression(model, f(x...))
+        @test expressions_equal(@JuMP.processNLExpr(model, f(x...)),
+                                NonlinearExprData(model, :(f($(x[1]),$(x[2])))))
+    end
+
+    @testset "Parse mixed splatting" begin
+        model = Model()
+        @variable(model, x[1:2])
+        @variable(model, y)
+        @variable(model, z[1:1])
+        @test expressions_equal(@JuMP.processNLExpr(model, (*)(x..., y, z...)),
+                                NonlinearExprData(model,
+                                                  :((*)($(x[1]), $(x[2]),
+                                                        $y, $(z[1])))))
+    end
+
+    @testset "Error on splatting non-symbols" begin
+        model = Model()
+        @variable(model, x[1:2])
+        @test_macro_throws ErrorException @NLexpression(model, (*)((x / 2)...))
     end
 
     @testset "Error on sum(x)" begin

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -148,6 +148,12 @@
         @test_macro_throws ErrorException @NLexpression(model, (*)((x / 2)...))
     end
 
+    @testset "Error on unexpected splatting" begin
+        model = Model()
+        @variable(model, x[1:2])
+        @test_macro_throws ErrorException @NLexpression(model, x...)
+    end
+
     @testset "Error on sum(x)" begin
         m = Model()
         x = [1,2,3]


### PR DESCRIPTION
It was easier to implement than keep explaining that JuMP wasn't designed for this.

Closes #1115
Also fixes pre-existing doctest failures.