### PR TITLE
Improve show extensibility for AbstractConstraint

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -147,13 +147,32 @@ end
 # Abstract base type for all constraint types
 abstract type AbstractConstraint end
 
+"""
+    function_object(constraint::AbstractConstraint)
+
+Return the function of the constraint `constraint` in the function-in-set form.
+"""
+function function_object end
+
+"""
+    set_object(constraint::AbstractConstraint)
+
+Return the set of the constraint `constraint` in the function-in-set form.
+"""
+function set_object end
+
+function moi_function_and_set(c::ScalarConstraint)
+    return (moi_function(function_object(constraint)), set_object(constraint))
+end
+
 struct ScalarConstraint{F <: AbstractJuMPScalar,
                         S <: MOI.AbstractScalarSet} <: AbstractConstraint
     func::F
     set::S
 end
 
-moi_function_and_set(c::ScalarConstraint) = (moi_function(c.func), c.set)
+function_object(constraint::ScalarConstraint) = c.func
+set_object(constraint::ScalarConstraint) = c.set
 shape(::ScalarConstraint) = ScalarShape()
 function constraint_object(ref::ConstraintRef{Model, MOICON{FuncType, SetType}}) where
         {FuncType <: MOI.AbstractScalarFunction, SetType <: MOI.AbstractScalarSet}
@@ -175,7 +194,8 @@ function VectorConstraint(func::Vector{<:AbstractJuMPScalar},
     VectorConstraint(func, set, VectorShape())
 end
 
-moi_function_and_set(c::VectorConstraint) = (moi_function(c.func), c.set)
+function_object(constraint::VectorConstraint) = c.func
+set_object(constraint::VectorConstraint) = c.set
 shape(c::VectorConstraint) = c.shape
 function constraint_object(ref::ConstraintRef{Model, MOICON{FuncType, SetType}}) where
         {FuncType <: MOI.AbstractVectorFunction, SetType <: MOI.AbstractVectorSet}

--- a/src/print.jl
+++ b/src/print.jl
@@ -322,7 +322,7 @@ Return a `String` representing the function of the constraint `constraint`
 using print mode `print_mode`.
 """
 function function_string(print_mode::PrintMode, constraint::AbstractConstraint)
-    return function_string(print_mode, function_object(constraint))
+    return function_string(print_mode, jump_function(constraint))
 end
 
 function in_set_string(print_mode, set::MOI.LessThan)
@@ -366,7 +366,7 @@ Return a `String` representing the membership to the set of the constraint
 `constraint` using print mode `print_mode`.
 """
 function in_set_string(print_mode, constraint::AbstractConstraint)
-    return in_set_string(print_mode, set_object(constraint))
+    return in_set_string(print_mode, moi_set(constraint))
 end
 
 # constraint_object is a JuMP constraint object like AffExprConstraint.

--- a/src/print.jl
+++ b/src/print.jl
@@ -272,12 +272,22 @@ end
 ## Constraints
 #------------------------------------------------------------------------
 
-function Base.show(io::IO, ref::ConstraintRef{Model})
+function Base.show(io::IO, ref::ConstraintRef)
     print(io, constraint_string(REPLMode, name(ref), constraint_object(ref)))
 end
-function Base.show(io::IO, ::MIME"text/latex", ref::ConstraintRef{Model})
+function Base.show(io::IO, ::MIME"text/latex", ref::ConstraintRef)
     print(io, constraint_string(IJuliaMode, name(ref), constraint_object(ref)))
 end
+
+"""
+    function_string(print_mode::JuMP.PrintMode,
+                    func::Union{JuMP.AbstractJuMPScalar,
+                                Vector{<:JuMP.AbstractJuMPScalar}})
+
+Return a `String` representing the function `func` using print mode
+`print_mode`.
+"""
+function function_string end
 
 function function_string(print_mode, variable::AbstractVariableRef)
     return var_string(print_mode, variable)
@@ -304,6 +314,17 @@ function function_string(print_mode, quad_vector::Vector{<:GenericQuadExpr})
     return "[" * join(quad_string.(print_mode, quad_vector), ", ") * "]"
 end
 
+"""
+    function_string(print_mode::JuMP.PrintMode,
+                    constraint::JuMP.AbstractConstraint)
+
+Return a `String` representing the function of the constraint `constraint`
+using print mode `print_mode`.
+"""
+function function_string(print_mode::PrintMode, constraint::AbstractConstraint)
+    return function_string(print_mode, function_object(constraint))
+end
+
 function in_set_string(print_mode, set::MOI.LessThan)
     return string(math_symbol(print_mode, :leq), " ", set.upper)
 end
@@ -325,8 +346,27 @@ end
 # TODO: Convert back to JuMP types for sets like PSDCone.
 # TODO: Consider fancy latex names for some sets. They're currently printed as
 # regular text in math mode which looks a bit awkward.
+"""
+    in_set_string(print_mode::JuMP.PrintMode,
+                  set::Union{JuMP.AbstractJuMPScalar,
+                             Vector{<:JuMP.AbstractJuMPScalar}})
+
+Return a `String` representing the membership to the set `set` using print mode
+`print_mode`.
+"""
 function in_set_string(print_mode, set::MOI.AbstractSet)
     return string(math_symbol(print_mode, :in), " ", set)
+end
+
+"""
+    in_set_string(print_mode::JuMP.PrintMode,
+                  constraint::JuMP.AbstractConstraint)
+
+Return a `String` representing the membership to the set of the constraint
+`constraint` using print mode `print_mode`.
+"""
+function in_set_string(print_mode, constraint::AbstractConstraint)
+    return in_set_string(print_mode, set_object(constraint))
 end
 
 # constraint_object is a JuMP constraint object like AffExprConstraint.

--- a/src/print.jl
+++ b/src/print.jl
@@ -272,6 +272,14 @@ end
 ## Constraints
 #------------------------------------------------------------------------
 
+## Notes for extensions
+# For a `ConstraintRef{ModelType, IndexType}` where `ModelType` is not
+# `JuMP.Model` or `IndexType` is not `MathOptInterface.ConstraintIndex`, the
+# methods `JuMP.name` and `JuMP.constraint_object` should be implemented for
+# printing to work. If the `AbstractConstraint` returned by `constraint_object`
+# is not `JuMP.ScalarConstraint` nor `JuMP.VectorConstraint`, then either
+# `JuMP.jump_function` or `JuMP.function_string` and either `JuMP.moi_set` or
+# `JuMP.in_set_string` should be implemented.
 function Base.show(io::IO, ref::ConstraintRef)
     print(io, constraint_string(REPLMode, name(ref), constraint_object(ref)))
 end

--- a/src/print.jl
+++ b/src/print.jl
@@ -280,7 +280,7 @@ function Base.show(io::IO, ::MIME"text/latex", ref::ConstraintRef)
 end
 
 """
-    function_string(print_mode::JuMP.PrintMode,
+    function_string(print_mode::Type{<:JuMP.PrintMode},
                     func::Union{JuMP.AbstractJuMPScalar,
                                 Vector{<:JuMP.AbstractJuMPScalar}})
 
@@ -315,13 +315,13 @@ function function_string(print_mode, quad_vector::Vector{<:GenericQuadExpr})
 end
 
 """
-    function_string(print_mode::JuMP.PrintMode,
+    function_string(print_mode::{<:JuMP.PrintMode},
                     constraint::JuMP.AbstractConstraint)
 
 Return a `String` representing the function of the constraint `constraint`
 using print mode `print_mode`.
 """
-function function_string(print_mode::PrintMode, constraint::AbstractConstraint)
+function function_string(print_mode, constraint::AbstractConstraint)
     return function_string(print_mode, jump_function(constraint))
 end
 
@@ -347,7 +347,7 @@ end
 # TODO: Consider fancy latex names for some sets. They're currently printed as
 # regular text in math mode which looks a bit awkward.
 """
-    in_set_string(print_mode::JuMP.PrintMode,
+    in_set_string(print_mode::Type{<:JuMP.PrintMode},
                   set::Union{JuMP.AbstractJuMPScalar,
                              Vector{<:JuMP.AbstractJuMPScalar}})
 
@@ -359,7 +359,7 @@ function in_set_string(print_mode, set::MOI.AbstractSet)
 end
 
 """
-    in_set_string(print_mode::JuMP.PrintMode,
+    in_set_string(print_mode::Type{<:JuMP.PrintMode},
                   constraint::JuMP.AbstractConstraint)
 
 Return a `String` representing the membership to the set of the constraint
@@ -372,8 +372,8 @@ end
 # constraint_object is a JuMP constraint object like AffExprConstraint.
 # Assumes a .func and .set member.
 function constraint_string(print_mode, constraint_name, constraint_object)
-    func_str = function_string(print_mode, constraint_object.func)
-    in_set_str = in_set_string(print_mode, constraint_object.set)
+    func_str = function_string(print_mode, constraint_object)
+    in_set_str = in_set_string(print_mode, constraint_object)
     constraint_without_name = func_str * " " * in_set_str
     if print_mode == IJuliaMode
         constraint_without_name = wrap_in_inline_math_mode(constraint_without_name)

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -1,12 +1,5 @@
 abstract type AbstractVectorSet end
 
-"""
-    moi_set(s::AbstractVectorSet, dim::Int)
-
-Returns the MOI set of dimension `dim` corresponding to the JuMP set `s`.
-"""
-function moi_set end
-
 # Used in `@constraint model f in s`
 function build_constraint(_error::Function, f::AbstractVector,
                          s::AbstractVectorSet)

--- a/test/print.jl
+++ b/test/print.jl
@@ -44,11 +44,11 @@ struct CustomConstraint{S <: JuMP.AbstractShape} <: JuMP.AbstractConstraint
     in_set_str::String
     shape::S
 end
-function JuMP.function_string(print_mode::JuMP.PrintMode,
+function JuMP.function_string(print_mode,
                               constraint::CustomConstraint)
     return constraint.function_str
 end
-function JuMP.in_set_string(print_mode::JuMP.PrintMode,
+function JuMP.in_set_string(print_mode,
                             constraint::CustomConstraint)
     return constraint.in_set_str
 end
@@ -195,7 +195,7 @@ end
             constraint = CustomConstraint(function_str, in_set_str,
                                           JuMP.ScalarShape())
             cref = JuMP.add_constraint(model, constraint, name)
-            @show string(cref)
+            @test string(cref) == "$name : $function_str $in_set_str"
         end
         test_constraint("fun", "set", "name")
         test_constraint("a", "b", "c")

--- a/test/print.jl
+++ b/test/print.jl
@@ -38,6 +38,43 @@ Base.:(*)(α::Float64, u::UnitNumber) = UnitNumber(α * u.α)
 Base.abs(u::UnitNumber) = UnitNumber(abs(u.α))
 Base.isless(u::UnitNumber, v::UnitNumber) = isless(u.α, v.α)
 
+# Used to test extensibility of JuMP printing for `JuMP.AbstractConstraint`
+struct CustomConstraint{S <: JuMP.AbstractShape} <: JuMP.AbstractConstraint
+    function_str::String
+    in_set_str::String
+    shape::S
+end
+function JuMP.function_string(print_mode::JuMP.PrintMode,
+                              constraint::CustomConstraint)
+    return constraint.function_str
+end
+function JuMP.in_set_string(print_mode::JuMP.PrintMode,
+                            constraint::CustomConstraint)
+    return constraint.in_set_str
+end
+struct CustomIndex
+    value::Int
+end
+function JuMP.add_constraint(model::JuMP.Model, constraint::CustomConstraint,
+                             name::String)
+    if !haskey(model.ext, :custom)
+        model.ext[:custom_constraints] = CustomConstraint[]
+        model.ext[:custom_names] = String[]
+    end
+    constraints = model.ext[:custom_constraints]
+    push!(constraints, constraint)
+    push!(model.ext[:custom_names], name)
+    return JuMP.ConstraintRef(model, CustomIndex(length(constraints)),
+                              constraint.shape)
+end
+function JuMP.constraint_object(cref::JuMP.ConstraintRef{JuMP.Model,
+                                                         CustomIndex})
+    return cref.model.ext[:custom_constraints][cref.index.value]
+end
+function JuMP.name(cref::JuMP.ConstraintRef{JuMP.Model, CustomIndex})
+    return cref.model.ext[:custom_names][cref.index.value]
+end
+
 @testset "Printing" begin
 
     @testset "expressions" begin
@@ -150,6 +187,18 @@ Base.isless(u::UnitNumber, v::UnitNumber) = isless(u.α, v.α)
         constr = @NLconstraint(model, expr - param <= 0)
         io_test(REPLMode, constr, "(subexpression[1] - parameter[1]) - 0.0 $le 0")
         io_test(IJuliaMode, constr, "(subexpression_{1} - parameter_{1}) - 0.0 \\leq 0")
+    end
+
+    @testset "Custom constraint" begin
+        model = Model()
+        function test_constraint(function_str, in_set_str, name)
+            constraint = CustomConstraint(function_str, in_set_str,
+                                          JuMP.ScalarShape())
+            cref = JuMP.add_constraint(model, constraint, name)
+            @show string(cref)
+        end
+        test_constraint("fun", "set", "name")
+        test_constraint("a", "b", "c")
     end
 end
 


### PR DESCRIPTION
In printing, the function and set are accessed by the `.func` and `.set` field so it assumes that any `AbstractConstraint` has this field.
With this PR, an `AbstractConstraint` can either implement `jump_function` and `set_function` or even have custom printing by implementing `function_string` and `in_set_string`