### PR TITLE
Fix docstrings in backend.

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -294,9 +294,8 @@ and whether there are any bridges in the model.
 
 If JuMP is in direct mode (i.e., the model was created using [`JuMP.direct_model`](@ref)),
 the backend with be the optimizer passed to `direct_model`. If JuMP is in manual
-or automatic mode, the backend will either be a
-[`MOI.Utilities.CachingOptimizer`](@ref) or a
-[`MOI.Bridges.LazyBridgeOptimizer`](@ref).
+or automatic mode, the backend will either be a `MOI.Utilities.CachingOptimizer`
+or a `MOI.Bridges.LazyBridgeOptimizer`.
 
 This function should only be used by advanced users looking to access low-level
 MathOptInterface or solver-specific functionality.


### PR DESCRIPTION
Introduced by #1591 because I added a `[ci skip]` forgetting about the documentation build.