### PR TITLE
✨ Implement size for JuMPArray

### DIFF
--- a/src/JuMPArray.jl
+++ b/src/JuMPArray.jl
@@ -87,8 +87,7 @@ Base.setindex!(A::JuMPArray, v, idx::CartesianIndex) = A.data[idx] = v
 
 # AbstractArray interface
 
-# We don't define size because it causes 'end' to behave incorrectly. Better to error.
-Base.size(A::JuMPArray) = error("JuMPArray does not define size().")
+Base.size(A::JuMPArray) = size(A.data)
 if VERSION < v"0.7-"
     Base.linearindices(A::JuMPArray) = error("JuMPArray does not support this operation.")
     Base.indices(A::JuMPArray) = A.axes

--- a/src/JuMPArray.jl
+++ b/src/JuMPArray.jl
@@ -87,11 +87,14 @@ Base.setindex!(A::JuMPArray, v, idx::CartesianIndex) = A.data[idx] = v
 
 # AbstractArray interface
 
-Base.size(A::JuMPArray) = size(A.data)
 if VERSION < v"0.7-"
+    # We don't define size because it causes 'end' to behave incorrectly. Better
+    # to error.
+    Base.size(A::JuMPArray) = error("JuMPArray does not define size().")
     Base.linearindices(A::JuMPArray) = error("JuMPArray does not support this operation.")
     Base.indices(A::JuMPArray) = A.axes
 else
+    Base.size(A::JuMPArray) = size(A.data)
     Base.LinearIndices(A::JuMPArray) = error("JuMPArray does not support this operation.")
     Base.axes(A::JuMPArray) = A.axes
 end

--- a/test/containers.jl
+++ b/test/containers.jl
@@ -90,8 +90,10 @@ end
 @testset "JuMPArray" begin
     @testset "Range index set" begin
         A = @inferred JuMPArray([1.0,2.0], 2:3)
-        @test size(A) == (2,)
-        @test size(A, 1) == 2
+        if VERSION >= v"0.7-"
+            @test size(A) == (2,)
+            @test size(A, 1) == 2
+        end
         @test @inferred A[2] == 1.0
         @test A[3] == 2.0
         @test A[2,1] == 1.0
@@ -113,8 +115,10 @@ And data, a 2-element Array{Float64,1}:
 
     @testset "Symbol index set" begin
         A = @inferred JuMPArray([1.0,2.0], [:a, :b])
-        @test size(A) == (2,)
-        @test size(A, 1) == 2
+        if VERSION >= v"0.7-"
+            @test size(A) == (2,)
+            @test size(A, 1) == 2
+        end
         @test @inferred A[:a] == 1.0
         @test A[:b] == 2.0
         @test length.(Compat.axes(A)) == (2,)
@@ -132,9 +136,11 @@ And data, a 2-element Array{Float64,1}:
 
     @testset "Mixed range/symbol index sets" begin
         A = @inferred JuMPArray([1 2; 3 4], 2:3, [:a, :b])
-        @test size(A) == (2, 2)
-        @test size(A, 1) == 2
-        @test size(A, 2) == 2
+        if VERSION >= v"0.7-"
+            @test size(A) == (2, 2)
+            @test size(A, 1) == 2
+            @test size(A, 2) == 2
+        end
         @test length.(Compat.axes(A)) == (2,2)
         @test @inferred A[2,:a] == 1
         @test A[3,:a] == 3
@@ -162,11 +168,13 @@ And data, a 2×2 Array{$Int,2}:
             A = @inferred JuMPArray(zeros(2,2,2,2), 2:3, [:a, :b], -1:0,
                                     ["a","b"])
         end
-        @test size(A) == (2, 2, 2, 2)
-        @test size(A, 1) == 2
-        @test size(A, 2) == 2
-        @test size(A, 3) == 2
-        @test size(A, 4) == 2
+        if VERSION >= v"0.7-"
+            @test size(A) == (2, 2, 2, 2)
+            @test size(A, 1) == 2
+            @test size(A, 2) == 2
+            @test size(A, 3) == 2
+            @test size(A, 4) == 2
+        end
         A[2,:a,-1,"a"] = 1.0
         f = 0.0
         for I in eachindex(A)
@@ -229,7 +237,9 @@ And data, a 2×2×2×2 Array{Float64,4}:
         a = Array{Int,0}(undef)
         a[] = 10
         A = JuMPArray(a)
-        @test size(A) == tuple()
+        if VERSION >= v"0.7-"
+            @test size(A) == tuple()
+        end
         @test A[] == 10
         A[] = 1
         @test sprint(show, A) == """

--- a/test/containers.jl
+++ b/test/containers.jl
@@ -90,6 +90,8 @@ end
 @testset "JuMPArray" begin
     @testset "Range index set" begin
         A = @inferred JuMPArray([1.0,2.0], 2:3)
+        @test size(A) == (2,)
+        @test size(A, 1) == 2
         @test @inferred A[2] == 1.0
         @test A[3] == 2.0
         @test A[2,1] == 1.0
@@ -111,6 +113,8 @@ And data, a 2-element Array{Float64,1}:
 
     @testset "Symbol index set" begin
         A = @inferred JuMPArray([1.0,2.0], [:a, :b])
+        @test size(A) == (2,)
+        @test size(A, 1) == 2
         @test @inferred A[:a] == 1.0
         @test A[:b] == 2.0
         @test length.(Compat.axes(A)) == (2,)
@@ -128,6 +132,9 @@ And data, a 2-element Array{Float64,1}:
 
     @testset "Mixed range/symbol index sets" begin
         A = @inferred JuMPArray([1 2; 3 4], 2:3, [:a, :b])
+        @test size(A) == (2, 2)
+        @test size(A, 1) == 2
+        @test size(A, 2) == 2
         @test length.(Compat.axes(A)) == (2,2)
         @test @inferred A[2,:a] == 1
         @test A[3,:a] == 3
@@ -155,6 +162,11 @@ And data, a 2×2 Array{$Int,2}:
             A = @inferred JuMPArray(zeros(2,2,2,2), 2:3, [:a, :b], -1:0,
                                     ["a","b"])
         end
+        @test size(A) == (2, 2, 2, 2)
+        @test size(A, 1) == 2
+        @test size(A, 2) == 2
+        @test size(A, 3) == 2
+        @test size(A, 4) == 2
         A[2,:a,-1,"a"] = 1.0
         f = 0.0
         for I in eachindex(A)
@@ -217,6 +229,7 @@ And data, a 2×2×2×2 Array{Float64,4}:
         a = Array{Int,0}(undef)
         a[] = 10
         A = JuMPArray(a)
+        @test size(A) == tuple()
         @test A[] == 10
         A[] = 1
         @test sprint(show, A) == """

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -416,8 +416,9 @@ function test_variable_end_indexing(ModelType)
         @test x[end,1] == x[2, 1]
         @test x[0, end-1] == x[0, 3]
         @test z[end] == z[2]
-        # TODO: This probably isn't hard to make work.
-        @test_throws ErrorException x[end-1]
+        # TODO: It is redirected to x[11] as it is the 11th element but linear
+        #       indexing is not supported
+        @test_throws KeyError x[end-1]
     else
         @test_throws ErrorException x[end,1]
         @test_throws ErrorException x[end-1]


### PR DESCRIPTION
We used to not define it as it gives wrong results with `end`, see https://github.com/JuliaOpt/JuMP.jl/pull/1102#discussion_r139846886
This was resolved in https://github.com/JuliaLang/julia/pull/24899 so with Julia v0.7 onward we can define `size` for non 1-based arrays.

Closes #1294