### PR TITLE
result_value -> value, result_dual -> dual

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,7 +40,7 @@ Breaking changes:
   distinguish between previously indistinguishable cases (e.g. did the solver
   have a feasible solution when it stopped because of the time limit?).
 
-- Starting values are separate from result values. Use `result_value` to query
+- Starting values are separate from result values. Use `value` to query
   the value of a variable in a solution. Use `start_value` and `set_start_value`
   to get and set an initial starting point provided to the solver.
 

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -38,6 +38,6 @@ JuMP.set_coefficient
 ## Duals
 
 ```@docs
-JuMP.result_dual
+JuMP.dual
 JuMP.shadow_price
 ```

--- a/docs/src/nlp.md
+++ b/docs/src/nlp.md
@@ -39,12 +39,12 @@ model = Model(with_optimizer(Ipopt.Optimizer))
 @NLobjective(model, Min, (1 - x) ^ 2 + 100 * (y - x ^ 2) ^ 2)
 
 JuMP.optimize!(model)
-println("x = ", JuMP.result_value(x), " y = ", JuMP.result_value(y))
+println("x = ", JuMP.value(x), " y = ", JuMP.value(y))
 
 # adding a (linear) constraint
 @constraint(model, x + y == 10)
 JuMP.optimize!(model)
-println("x = ", JuMP.result_value(x), " y = ", JuMP.result_value(y))
+println("x = ", JuMP.value(x), " y = ", JuMP.value(y))
 ```
 
 TODO: Add links to NLP examples after they are updated.
@@ -166,12 +166,12 @@ model = Model(with_optimizer(Ipopt.Optimizer))
 @NLparameter(model, x == 1.0)
 @NLobjective(model, Min, (z - x) ^ 2)
 JuMP.optimize!(model)
-JuMP.result_value(z) # Equals 1.0.
+JuMP.value(z) # Equals 1.0.
 
 # Now, update the value of x to solve a different problem.
 JuMP.set_value(x, 5.0)
 JuMP.optimize!(model)
-JuMP.result_value(z) # Equals 5.0
+JuMP.value(z) # Equals 5.0
 ```
 
 Using nonlinear parameters can be faster than creating a new model from scratch

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -149,17 +149,17 @@ julia> JuMP.objective_value(model)
 ```
 We can also query the primal result values of the `x` and `y` variables:
 ```jldoctest quickstart_example
-julia> JuMP.result_value(x)
+julia> JuMP.value(x)
 2.0
 
-julia> JuMP.result_value(y)
+julia> JuMP.value(y)
 0.2
 ```
 
 We can also query the value of the dual variable associated with the constraint
 `con` (which we bound to a Julia variable when defining the constraint):
 ```jldoctest quickstart_example
-julia> JuMP.result_dual(con)
+julia> JuMP.dual(con)
 -0.6
 ```
 
@@ -169,7 +169,7 @@ little trickier as we first need to obtain a reference to the constraint:
 julia> x_upper = JuMP.UpperBoundRef(x)
 x <= 2.0
 
-julia> JuMP.result_dual(x_upper)
+julia> JuMP.dual(x_upper)
 -4.4
 ```
 A similar process can be followed to obtain the dual of the lower bound
@@ -178,6 +178,6 @@ constraint on `y`:
 julia> y_lower = JuMP.LowerBoundRef(y)
 y >= 0.0
 
-julia> JuMP.result_dual(y_lower)
+julia> JuMP.dual(y_lower)
 0.0
 ```

--- a/examples/basic.jl
+++ b/examples/basic.jl
@@ -31,5 +31,5 @@ print(m)
 JuMP.optimize!(m)
 
 println("Objective value: ", JuMP.objective_value(m))
-println("x = ", JuMP.result_value(x))
-println("y = ", JuMP.result_value(y))
+println("x = ", JuMP.value(x))
+println("y = ", JuMP.value(y))

--- a/examples/cannery.jl
+++ b/examples/cannery.jl
@@ -22,7 +22,7 @@ function PrintSolution(is_optimal, plants, markets, ship)
     if is_optimal
       for i in 1:length(plants)
         for j in 1:length(markets)
-          println("  $(plants[i]) $(markets[j]) = $(JuMP.result_value(ship[i,j]))")
+          println("  $(plants[i]) $(markets[j]) = $(JuMP.value(ship[i,j]))")
         end
       end
     else

--- a/examples/cluster.jl
+++ b/examples/cluster.jl
@@ -51,7 +51,7 @@ mod = Model(with_optimizer(solver))
 
 JuMP.optimize!(mod)
 
-Z_val = JuMP.result_value.(Z)
+Z_val = JuMP.value.(Z)
 println("Raw solution")
 println(round.(Z_val, digits=4))
 

--- a/examples/corr_sdp.jl
+++ b/examples/corr_sdp.jl
@@ -36,11 +36,11 @@ m = Model(with_optimizer(CSDP.Optimizer))
 # Find upper bound
 @objective(m, Max, X[1,3])
 JuMP.optimize!(m)
-println("Maximum value is ", JuMP.result_value.(X)[1,3])
-@assert +0.8719 <= JuMP.result_value.(X)[1,3] <= +0.8720
+println("Maximum value is ", JuMP.value.(X)[1,3])
+@assert +0.8719 <= JuMP.value.(X)[1,3] <= +0.8720
 
 # Find lower bound
 @objective(m, Min, X[1,3])
 JuMP.optimize!(m)
-println("Minimum value is ", JuMP.result_value.(X)[1,3])
-@assert -0.9779 >= JuMP.result_value.(X)[1,3] >= -0.9799
+println("Minimum value is ", JuMP.value.(X)[1,3])
+@assert -0.9779 >= JuMP.value.(X)[1,3] >= -0.9799

--- a/examples/diet.jl
+++ b/examples/diet.jl
@@ -23,7 +23,7 @@ function PrintSolution(is_optimal, foods, buy)
     println("RESULTS:")
     if is_optimal
         for i = 1:length(foods)
-            println("  $(foods[i]) = $(JuMP.result_value(buy[i]))")
+            println("  $(foods[i]) = $(JuMP.value(buy[i]))")
         end
     else
         println("The solver did not find an optimal solution.")

--- a/examples/knapsack.jl
+++ b/examples/knapsack.jl
@@ -38,6 +38,6 @@ JuMP.optimize!(m)
 println("Objective is: ", JuMP.objective_value(m))
 println("Solution is:")
 for i = 1:5
-    print("x[$i] = ", JuMP.result_value(x[i]))
+    print("x[$i] = ", JuMP.value(x[i]))
     println(", p[$i]/w[$i] = ", profit[i]/weight[i])
 end

--- a/examples/mindistortion.jl
+++ b/examples/mindistortion.jl
@@ -57,4 +57,4 @@ end
 
 JuMP.optimize!(m)
 
-println(JuMP.result_value.(cSq))
+println(JuMP.value.(cSq))

--- a/examples/minellipse.jl
+++ b/examples/minellipse.jl
@@ -50,5 +50,5 @@ for i in 1:m
 end
 JuMP.optimize!(model)
 
-X_val = JuMP.result_value.(X)
+X_val = JuMP.value.(X)
 println(X_val)

--- a/examples/mle.jl
+++ b/examples/mle.jl
@@ -20,9 +20,9 @@ m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
 
 JuMP.optimize!(m)
 
-println("μ = ", JuMP.result_value(μ))
+println("μ = ", JuMP.value(μ))
 println("mean(data) = ", mean(data))
-println("σ^2 = ", JuMP.result_value(σ)^2)
+println("σ^2 = ", JuMP.value(σ)^2)
 println("var(data) = ", var(data))
 println("MLE objective: ", JuMP.objective_value(m))
 
@@ -31,7 +31,7 @@ println("MLE objective: ", JuMP.objective_value(m))
 
 JuMP.optimize!(m)
 println("\nWith constraint μ == σ^2:")
-println("μ = ", JuMP.result_value(μ))
-println("σ^2 = ", JuMP.result_value(σ)^2)
+println("μ = ", JuMP.value(μ))
+println("σ^2 = ", JuMP.value(σ)^2)
 
 println("Constrained MLE objective: ", JuMP.objective_value(m))

--- a/examples/multi.jl
+++ b/examples/multi.jl
@@ -19,7 +19,7 @@ function PrintSolution(is_optimal, Trans, ORIG, DEST, PROD)
       for i in 1:length(ORIG)
         for j in 1:length(DEST)
           for p in 1:length(PROD)
-            print(" $(PROD[p]) $(ORIG[i]) $(DEST[j]) = $(JuMP.result_value(Trans[i,j, p]))\t")
+            print(" $(PROD[p]) $(ORIG[i]) $(DEST[j]) = $(JuMP.value(Trans[i,j, p]))\t")
           end
           println()
         end

--- a/examples/prod.jl
+++ b/examples/prod.jl
@@ -21,17 +21,17 @@ function PrintSolution(is_optimal, CREWS, HIRE, LAYOFF)
     if is_optimal
       println("Crews")
       for t = 0:length(CREWS.data)-1
-        print(" $(JuMP.result_value(CREWS[t])) ")
+        print(" $(JuMP.value(CREWS[t])) ")
       end
       println()
       println("Hire")
       for t = 1:length(HIRE.data)
-        print(" $(JuMP.result_value(HIRE[t])) ")
+        print(" $(JuMP.value(HIRE[t])) ")
       end
       println()
       println("Layoff")
       for t = 1:length(LAYOFF.data)
-        print(" $(JuMP.result_value(LAYOFF[t])) ")
+        print(" $(JuMP.value(LAYOFF[t])) ")
       end
       println()
     else

--- a/examples/qcp.jl
+++ b/examples/qcp.jl
@@ -39,5 +39,5 @@ JuMP.optimize!(m)
 
 # Solution
 println("Objective value: ", JuMP.objective_value(m))
-println("x = ", JuMP.result_value(x))
-println("y = ", JuMP.result_value(y))
+println("x = ", JuMP.value(x))
+println("y = ", JuMP.value(y))

--- a/examples/rosenbrock.jl
+++ b/examples/rosenbrock.jl
@@ -16,6 +16,6 @@ let
 
     JuMP.optimize!(m)
 
-    println("x = ", JuMP.result_value(x), " y = ", JuMP.result_value(y))
+    println("x = ", JuMP.value(x), " y = ", JuMP.value(y))
 
 end

--- a/examples/steelT3.jl
+++ b/examples/steelT3.jl
@@ -98,18 +98,18 @@ function PrintSolution(is_optimal, area, Make, Inventory, Sell, product, Time)
       for p in product
         println("Make $(p)")
         for t in 1:T
-          print("$(JuMP.result_value(Make[p,t]))\t")
+          print("$(JuMP.value(Make[p,t]))\t")
         end
         println()
         println("Inventory $(p)")
         for t in 1:T
-          print("$(JuMP.result_value(Inventory[p,t]))\t")
+          print("$(JuMP.value(Inventory[p,t]))\t")
         end
         println()
         for a in area[p]
           println("Sell $(p) $(a)")
           for t in 1:T
-            print("$(JuMP.result_value(Sell[p,a,t])) \t")
+            print("$(JuMP.value(Sell[p,a,t])) \t")
           end
         println()
         end

--- a/examples/sudoku.jl
+++ b/examples/sudoku.jl
@@ -69,7 +69,7 @@ function SolveModel(initgrid)
 
     # Check solution
     if is_optimal
-        mipSol = JuMP.result_value.(x)
+        mipSol = JuMP.value.(x)
         sol = zeros(Int,9,9)
         for row in 1:9, col in 1:9, val in 1:9
             if mipSol[row, col, val] >= 0.9

--- a/examples/transp.jl
+++ b/examples/transp.jl
@@ -61,7 +61,7 @@ if is_optimal
 	for i in 1:length(ORIG)
 		@printf("%s", ORIG[i])
 		for j in 1:length(DEST)
-			@printf("\t%d", JuMP.result_value(Trans[i,j]))
+			@printf("\t%d", JuMP.value(Trans[i,j]))
 		end
 		@printf("\n")
 	end

--- a/examples/urbanplan.jl
+++ b/examples/urbanplan.jl
@@ -78,7 +78,7 @@ function SolveUrban()
 
     # Print results
     println("Best objective: $(round(JuMP.objective_value(m)))")
-    println(JuMP.result_value.(x))
+    println(JuMP.value.(x))
 end
 
 SolveUrban()

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -429,19 +429,19 @@ index(cr::ConstraintRef) = cr.index
 
 # TODO: Why does this method depend on the type of the constraint?
 # TODO: docstring
-function has_result_dual(model::Model,
+function has_dual(model::Model,
                          REF::Type{<:ConstraintRef{Model, T}}) where {T <: MOICON}
     MOI.get(model, MOI.DualStatus()) != MOI.NoSolution
 end
 
 """
-    result_dual(cr::ConstraintRef)
+    dual(cr::ConstraintRef)
 
 Get the dual value of this constraint in the result returned by a solver.
-Use `has_result_dual` to check if a result exists before asking for values.
+Use `has_dual` to check if a result exists before asking for values.
 See also [`shadow_price`](@ref).
 """
-function result_dual(cr::ConstraintRef{Model, <:MOICON})
+function dual(cr::ConstraintRef{Model, <:MOICON})
     reshape(MOI.get(cr.model, MOI.ConstraintDual(), cr), dual_shape(cr.shape))
 end
 

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -236,12 +236,12 @@ function assert_isfinite(a::AffExpr)
 end
 
 """
-    result_value(v::GenericAffExpr)
+    value(v::GenericAffExpr)
 
 Evaluate an `GenericAffExpr` given the result returned by a solver.
 Replaces `getvalue` for most use cases.
 """
-result_value(a::GenericAffExpr) = value(a, result_value)
+value(a::GenericAffExpr) = value(a, value)
 
 # Note: No validation is performed that the variables in the AffExpr belong to
 # the same model.

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -276,14 +276,14 @@ end
     shadow_price(constraint::ConstraintRef)
 
 The change in the objective from an infinitesimal relaxation of the constraint.
-This value is computed from [`result_dual`](@ref) and can be queried only when
-`has_result_dual` is `true` and the objective sense is `MinSense` or `MaxSense`
+This value is computed from [`dual`](@ref) and can be queried only when
+`has_dual` is `true` and the objective sense is `MinSense` or `MaxSense`
 (not `FeasibilitySense`). For linear constraints, the shadow prices differ at
-most in sign from the `result_dual` value depending on the objective sense.
+most in sign from the `dual` value depending on the objective sense.
 
 ## Notes
 
-- The function simply translates signs from `result_dual` and does not validate
+- The function simply translates signs from `dual` and does not validate
   the conditions needed to guarantee the sensitivity interpretation of the
   shadow price. The caller is responsible, e.g., for checking whether the solver
   converged to an optimal primal-dual pair or a proof of infeasibility.
@@ -330,34 +330,34 @@ end
 function shadow_price(constraint::ConstraintRef{Model, MOICON{F, S}}
                       ) where {S <: MOI.LessThan, F}
     model = constraint.model
-    if !has_result_dual(model, typeof(constraint))
+    if !has_dual(model, typeof(constraint))
         error("The shadow price is not available because no dual result is " *
               "available.")
     end
-    return shadow_price_less_than_(result_dual(constraint),
+    return shadow_price_less_than_(dual(constraint),
                                    objective_sense(model))
 end
 
 function shadow_price(constraint::ConstraintRef{Model, MOICON{F, S}}
                       ) where {S <: MOI.GreaterThan, F}
     model = constraint.model
-    if !has_result_dual(model, typeof(constraint))
+    if !has_dual(model, typeof(constraint))
         error("The shadow price is not available because no dual result is " *
               "available.")
     end
-    return shadow_price_greater_than_(result_dual(constraint),
+    return shadow_price_greater_than_(dual(constraint),
                                       objective_sense(model))
 end
 
 function shadow_price(constraint::ConstraintRef{Model, MOICON{F, S}}
                       ) where {S <: MOI.EqualTo, F}
     model = constraint.model
-    if !has_result_dual(model, typeof(constraint))
+    if !has_dual(model, typeof(constraint))
         error("The shadow price is not available because no dual result is " *
               "available.")
     end
     sense = objective_sense(model)
-    dual_val = result_dual(constraint)
+    dual_val = dual(constraint)
     if dual_val > 0
         # Treat the equality constraint as if it were a GreaterThan constraint.
         return shadow_price_greater_than_(dual_val, sense)

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -145,7 +145,7 @@ function initNLP(m::Model)
     end
 end
 
-function result_dual(c::ConstraintRef{Model,NonlinearConstraintIndex})
+function dual(c::ConstraintRef{Model,NonlinearConstraintIndex})
     initNLP(c.m)
     nldata::NLPData = c.m.nlp_data
     # The array is cleared on every solve.

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -245,4 +245,4 @@ function value(ex::GenericQuadExpr{CoefType, VarType},
     return ret
 end
 
-JuMP.result_value(ex::JuMP.GenericQuadExpr) = value(ex, JuMP.result_value)
+JuMP.value(ex::JuMP.GenericQuadExpr) = value(ex, JuMP.value)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -537,14 +537,14 @@ function set_start_value(v::VariableRef, val::Number)
 end
 
 """
-    result_value(v::VariableRef)
+    value(v::VariableRef)
 
 Get the value of this variable in the result returned by a solver.
-Use `has_result_values` to check if a result exists before asking for values.
+Use `has_values` to check if a result exists before asking for values.
 Replaces `getvalue` for most use cases.
 """
-result_value(v::VariableRef) = MOI.get(owner_model(v), MOI.VariablePrimal(), v)
-function has_result_values(model::Model)
+value(v::VariableRef) = MOI.get(owner_model(v), MOI.VariablePrimal(), v)
+function has_values(model::Model)
     return MOI.get(model, MOI.PrimalStatus()) != MOI.NoSolution
 end
 

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -304,7 +304,7 @@ function test_shadow_price(model_string, constraint_dual, constraint_shadow)
         MOI.set(mock_optimizer, MOI.ConstraintDual(),
                 JuMP.optimizer_index(constraint_ref),
                 constraint_dual[constraint_name])
-        @test JuMP.result_dual(constraint_ref) ==
+        @test JuMP.dual(constraint_ref) ==
               constraint_dual[constraint_name]
         @test JuMP.shadow_price(constraint_ref) ==
               constraint_shadow[constraint_name]

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -56,20 +56,20 @@
         MOI.set(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizer_index(JuMP.LowerBoundRef(y)), 1.0)
 
         #@test JuMP.isattached(m)
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
 
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.result_value(x) == 1.0
-        @test JuMP.result_value(y) == 0.0
-        @test JuMP.result_value(x + y) == 1.0
+        @test JuMP.value(x) == 1.0
+        @test JuMP.value(y) == 0.0
+        @test JuMP.value(x + y) == 1.0
         @test JuMP.objective_value(m) == -1.0
 
         @test JuMP.dual_status(m) == MOI.FeasiblePoint
-        @test JuMP.result_dual(c) == -1
-        @test JuMP.result_dual(JuMP.UpperBoundRef(x)) == 0.0
-        @test JuMP.result_dual(JuMP.LowerBoundRef(y)) == 1.0
+        @test JuMP.dual(c) == -1
+        @test JuMP.dual(JuMP.UpperBoundRef(x)) == 0.0
+        @test JuMP.dual(JuMP.LowerBoundRef(y)) == 1.0
     end
 
     @testset "LP (Direct mode)" begin
@@ -96,20 +96,20 @@
         JuMP.optimize!(m)
 
         #@test JuMP.isattached(m)
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
 
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.result_value(x) == 1.0
-        @test JuMP.result_value(y) == 0.0
-        @test JuMP.result_value(x + y) == 1.0
+        @test JuMP.value(x) == 1.0
+        @test JuMP.value(y) == 0.0
+        @test JuMP.value(x + y) == 1.0
         @test JuMP.objective_value(m) == -1.0
 
         @test JuMP.dual_status(m) == MOI.FeasiblePoint
-        @test JuMP.result_dual(c) == -1
-        @test JuMP.result_dual(JuMP.UpperBoundRef(x)) == 0.0
-        @test JuMP.result_dual(JuMP.LowerBoundRef(y)) == 1.0
+        @test JuMP.dual(c) == -1
+        @test JuMP.dual(JuMP.UpperBoundRef(x)) == 0.0
+        @test JuMP.dual(JuMP.LowerBoundRef(y)) == 1.0
     end
 
     # TODO: test Manual mode
@@ -154,18 +154,18 @@
         JuMP.optimize!(m)
 
         #@test JuMP.isattached(m)
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
 
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.result_value(x) == 1.0
-        @test JuMP.result_value(y) == 0.0
+        @test JuMP.value(x) == 1.0
+        @test JuMP.value(y) == 0.0
         @test JuMP.objective_value(m) == 1.0
 
-        @test !JuMP.has_result_dual(m, typeof(JuMP.FixRef(x)))
-        @test !JuMP.has_result_dual(m, typeof(JuMP.IntegerRef(x)))
-        @test !JuMP.has_result_dual(m, typeof(JuMP.BinaryRef(y)))
+        @test !JuMP.has_dual(m, typeof(JuMP.FixRef(x)))
+        @test !JuMP.has_dual(m, typeof(JuMP.IntegerRef(x)))
+        @test !JuMP.has_dual(m, typeof(JuMP.BinaryRef(y)))
     end
 
     @testset "QCQP" begin
@@ -207,21 +207,21 @@
         MOI.set(mockoptimizer, MOI.ConstraintDual(), JuMP.optimizer_index(c3), 3.0)
 
         #@test JuMP.isattached(m)
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
 
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.result_value(x) == 1.0
-        @test JuMP.result_value(y) == 0.0
+        @test JuMP.value(x) == 1.0
+        @test JuMP.value(y) == 0.0
         @test JuMP.objective_value(m) == -1.0
 
         @test JuMP.dual_status(m) == MOI.FeasiblePoint
-        @test JuMP.result_dual(c1) == -1.0
-        @test JuMP.result_dual(c2) == 2.0
-        @test JuMP.result_dual(c3) == 3.0
+        @test JuMP.dual(c1) == -1.0
+        @test JuMP.dual(c2) == 2.0
+        @test JuMP.dual(c3) == 3.0
 
-        @test JuMP.result_value(2 * x + 3 * y * x) == 2.0
+        @test JuMP.value(2 * x + 3 * y * x) == 2.0
     end
 
     @testset "SOC" begin
@@ -268,20 +268,20 @@
         JuMP.optimize!(m)
 
         #@test JuMP.isattached(m)
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
 
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.result_value(x) == 1.0
-        @test JuMP.result_value(y) == 0.0
-        @test JuMP.result_value(z) == 0.0
+        @test JuMP.value(x) == 1.0
+        @test JuMP.value(y) == 0.0
+        @test JuMP.value(z) == 0.0
 
-        @test JuMP.has_result_dual(m, typeof(varsoc))
-        @test JuMP.result_dual(varsoc) == [-1.0, -2.0, -3.0]
+        @test JuMP.has_dual(m, typeof(varsoc))
+        @test JuMP.dual(varsoc) == [-1.0, -2.0, -3.0]
 
-        @test JuMP.has_result_dual(m, typeof(affsoc))
-        @test JuMP.result_dual(affsoc) == [1.0, 2.0, 3.0]
+        @test JuMP.has_dual(m, typeof(affsoc))
+        @test JuMP.dual(affsoc) == [1.0, 2.0, 3.0]
     end
 
     @testset "SDP" begin
@@ -339,21 +339,21 @@
         JuMP.optimize!(m)
 
         #@test JuMP.isattached(m)
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
 
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.result_value.(x) == [1.0 2.0; 2.0 4.0]
-        @test JuMP.has_result_dual(m, typeof(var_psd))
-        @test JuMP.result_dual(var_psd) isa Symmetric
-        @test JuMP.result_dual(var_psd) == [1.0 2.0; 2.0 3.0]
-        @test JuMP.has_result_dual(m, typeof(sym_psd))
-        @test JuMP.result_dual(sym_psd) isa Symmetric
-        @test JuMP.result_dual(sym_psd) == [4.0 5.0; 5.0 6.0]
-        @test JuMP.has_result_dual(m, typeof(con_psd))
-        @test JuMP.result_dual(con_psd) isa Matrix
-        @test JuMP.result_dual(con_psd) == [7.0 9.0; 8.0 10.0]
+        @test JuMP.value.(x) == [1.0 2.0; 2.0 4.0]
+        @test JuMP.has_dual(m, typeof(var_psd))
+        @test JuMP.dual(var_psd) isa Symmetric
+        @test JuMP.dual(var_psd) == [1.0 2.0; 2.0 3.0]
+        @test JuMP.has_dual(m, typeof(sym_psd))
+        @test JuMP.dual(sym_psd) isa Symmetric
+        @test JuMP.dual(sym_psd) == [4.0 5.0; 5.0 6.0]
+        @test JuMP.has_dual(m, typeof(con_psd))
+        @test JuMP.dual(con_psd) isa Matrix
+        @test JuMP.dual(con_psd) == [7.0 9.0; 8.0 10.0]
 
     end
 

--- a/test/nlp_solver.jl
+++ b/test/nlp_solver.jl
@@ -47,11 +47,11 @@ const MOI = MathOptInterface
 
         JuMP.optimize!(m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.result_value.(x) ≈ [1.000000, 4.742999, 3.821150, 1.379408] atol=1e-3
+        @test JuMP.value.(x) ≈ [1.000000, 4.742999, 3.821150, 1.379408] atol=1e-3
     end
 
     @testset "HS071 (no macros)" begin
@@ -73,11 +73,11 @@ const MOI = MathOptInterface
 
         JuMP.optimize!(m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.result_value.(x) ≈ [1.000000, 4.742999, 3.821150, 1.379408] atol=1e-3
+        @test JuMP.value.(x) ≈ [1.000000, 4.742999, 3.821150, 1.379408] atol=1e-3
     end
 
     @testset "HS109" begin
@@ -121,7 +121,7 @@ const MOI = MathOptInterface
 
         JuMP.optimize!m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
@@ -139,7 +139,7 @@ const MOI = MathOptInterface
 
         JuMP.optimize!(m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         # Ipopt returns AlmostSuccess and NearlyFeasiblePoint on this instance.
         # @test JuMP.termination_status(m) == MOI.Success
         # @test JuMP.primal_status(m) == MOI.FeasiblePoint
@@ -162,7 +162,7 @@ const MOI = MathOptInterface
 
         JuMP.optimize!m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
@@ -183,7 +183,7 @@ const MOI = MathOptInterface
 
         JuMP.optimize!m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
@@ -218,7 +218,7 @@ const MOI = MathOptInterface
 
         JuMP.optimize!m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
@@ -264,7 +264,7 @@ const MOI = MathOptInterface
 
         JuMP.optimize!(m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
@@ -332,11 +332,11 @@ const MOI = MathOptInterface
 
         JuMP.optimize!(m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
-        @test JuMP.result_value.(x[1:4]) ≈ [8.0, 49.0, 3.0, 1.0] atol=1e-4
+        @test JuMP.value.(x[1:4]) ≈ [8.0, 49.0, 3.0, 1.0] atol=1e-4
         @test JuMP.objective_value(m) ≈ 664.82045 atol=1e-5
     end
 
@@ -349,7 +349,7 @@ const MOI = MathOptInterface
         @NLconstraint(m, l <= x <= u)
         JuMP.optimize!(m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
         @test JuMP.objective_value(m) ≈ u atol=1e-6
@@ -357,7 +357,7 @@ const MOI = MathOptInterface
         @NLobjective(m, Min, x)
         JuMP.optimize!(m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
         @test JuMP.objective_value(m) ≈ l atol=1e-6
@@ -372,7 +372,7 @@ const MOI = MathOptInterface
         JuMP.addNLconstraint(m, :($l <= $x <= $u))
         JuMP.optimize!(m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
         @test JuMP.objective_value(m) ≈ u atol=1e-6
@@ -380,7 +380,7 @@ const MOI = MathOptInterface
         JuMP.setNLobjective(m, :Min, x)
         JuMP.optimize!(m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
         @test JuMP.objective_value(m) ≈ l atol=1e-6
@@ -398,36 +398,36 @@ const MOI = MathOptInterface
         @NLconstraint(m, cons3, 7.0*y <= z + r[6]/1.9)
 
         function test_result()
-            @test JuMP.has_result_values(m)
+            @test JuMP.has_values(m)
             @test JuMP.termination_status(m) == MOI.Success
             @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
 
-            @test JuMP.result_value(x) ≈ 0.9774436 atol=1e-6
-            @test JuMP.result_value(y) ≈ 1.0225563 atol=1e-6
-            @test JuMP.result_value(z) ≈ 4.0 atol=1e-6
-            @test JuMP.result_value(r[3]) ≈ 0.5112781 atol=1e-6
-            @test JuMP.result_value(r[4]) ≈ 0.0 atol=1e-6
-            @test JuMP.result_value(r[5]) ≈ 0.0 atol=1e-6
-            @test JuMP.result_value(r[6]) ≈ 6.0 atol=1e-6
+            @test JuMP.value(x) ≈ 0.9774436 atol=1e-6
+            @test JuMP.value(y) ≈ 1.0225563 atol=1e-6
+            @test JuMP.value(z) ≈ 4.0 atol=1e-6
+            @test JuMP.value(r[3]) ≈ 0.5112781 atol=1e-6
+            @test JuMP.value(r[4]) ≈ 0.0 atol=1e-6
+            @test JuMP.value(r[5]) ≈ 0.0 atol=1e-6
+            @test JuMP.value(r[6]) ≈ 6.0 atol=1e-6
             @test JuMP.dual_status(m) == MOI.FeasiblePoint
             # Reduced costs
-            @test JuMP.result_dual(JuMP.LowerBoundRef(x)) ≈ 0.0 atol=1e-6
-            @test JuMP.result_dual(JuMP.UpperBoundRef(y)) ≈ 0.0 atol=1e-6
-            @test JuMP.result_dual(JuMP.UpperBoundRef(z)) ≈ -1.0714286 atol=1e-6
-            @test JuMP.result_dual(JuMP.LowerBoundRef(r[3])) ≈ 0.0 atol=1e-6
-            @test JuMP.result_dual(JuMP.UpperBoundRef(r[3])) ≈ 0.0 atol=1e-6
-            @test JuMP.result_dual(JuMP.LowerBoundRef(r[4])) ≈ 1.0 atol=1e-6
-            @test JuMP.result_dual(JuMP.UpperBoundRef(r[4])) ≈ 0.0 atol=1e-6
-            @test JuMP.result_dual(JuMP.LowerBoundRef(r[5])) ≈ 1.0 atol=1e-6
-            @test JuMP.result_dual(JuMP.UpperBoundRef(r[5])) ≈ 0.0 atol=1e-6
-            @test JuMP.result_dual(JuMP.UpperBoundRef(r[6])) ≈ -0.03759398 atol=1e-6
-            @test JuMP.result_dual(JuMP.LowerBoundRef(r[6])) ≈ 0.0 atol=1e-6
+            @test JuMP.dual(JuMP.LowerBoundRef(x)) ≈ 0.0 atol=1e-6
+            @test JuMP.dual(JuMP.UpperBoundRef(y)) ≈ 0.0 atol=1e-6
+            @test JuMP.dual(JuMP.UpperBoundRef(z)) ≈ -1.0714286 atol=1e-6
+            @test JuMP.dual(JuMP.LowerBoundRef(r[3])) ≈ 0.0 atol=1e-6
+            @test JuMP.dual(JuMP.UpperBoundRef(r[3])) ≈ 0.0 atol=1e-6
+            @test JuMP.dual(JuMP.LowerBoundRef(r[4])) ≈ 1.0 atol=1e-6
+            @test JuMP.dual(JuMP.UpperBoundRef(r[4])) ≈ 0.0 atol=1e-6
+            @test JuMP.dual(JuMP.LowerBoundRef(r[5])) ≈ 1.0 atol=1e-6
+            @test JuMP.dual(JuMP.UpperBoundRef(r[5])) ≈ 0.0 atol=1e-6
+            @test JuMP.dual(JuMP.UpperBoundRef(r[6])) ≈ -0.03759398 atol=1e-6
+            @test JuMP.dual(JuMP.LowerBoundRef(r[6])) ≈ 0.0 atol=1e-6
 
             # Constraint duals
-            @test JuMP.result_dual(cons1) ≈ 0.333333 atol=1e-6
-            @test JuMP.result_dual(cons2) ≈ -1.0 atol=1e-6
-            @test JuMP.result_dual(cons3) ≈ -0.0714286 atol=1e-6
+            @test JuMP.dual(cons1) ≈ 0.333333 atol=1e-6
+            @test JuMP.dual(cons2) ≈ -1.0 atol=1e-6
+            @test JuMP.dual(cons3) ≈ -0.0714286 atol=1e-6
         end
 
         JuMP.optimize!(m)
@@ -450,11 +450,11 @@ const MOI = MathOptInterface
         @constraint(m, x + x^2 + x*y + y^2 <= 1)
         JuMP.optimize!(m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
         @test JuMP.objective_value(m) ≈ -1-4/sqrt(3) atol=1e-6
-        @test JuMP.result_value(x) + JuMP.result_value(y) ≈ -1/3 atol=1e-3
+        @test JuMP.value(x) + JuMP.value(y) ≈ -1/3 atol=1e-3
     end
 
     @testset "Quadratic inequality constraints, NL objective" begin
@@ -465,11 +465,11 @@ const MOI = MathOptInterface
         @constraint(m, x + x^2 + x*y + y^2 <= 1)
         JuMP.optimize!(m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
         @test JuMP.objective_value(m) ≈ -1-4/sqrt(3) atol=1e-6
-        @test JuMP.result_value(x) + JuMP.result_value(y) ≈ -1/3 atol=1e-3
+        @test JuMP.value(x) + JuMP.value(y) ≈ -1/3 atol=1e-3
     end
 
     @testset "Quadratic equality constraints" begin
@@ -479,11 +479,11 @@ const MOI = MathOptInterface
         @NLobjective(m, Max, x[1] - x[2])
         JuMP.optimize!(m)
 
-        @test JuMP.has_result_values(m)
+        @test JuMP.has_values(m)
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
         @test JuMP.objective_value(m) ≈ sqrt(1/2) atol=1e-6
-        @test JuMP.result_value.(x) ≈ [sqrt(1/2), 0] atol=1e-6
+        @test JuMP.value.(x) ≈ [sqrt(1/2), 0] atol=1e-6
     end
 
     @testset "Fixed variables" begin
@@ -495,7 +495,7 @@ const MOI = MathOptInterface
         for α in 1:4
             JuMP.fix(x, α)
             JuMP.optimize!(m)
-            @test JuMP.result_value(y) ≈ α^2 atol=1e-6
+            @test JuMP.value(y) ≈ α^2 atol=1e-6
         end
     end
 end


### PR DESCRIPTION
`result` is no longer used in JuMP names, so that should lessen the confusion with MOI.InfeasibleNoResult.

From 0.18 the diff is now:
`getvalue` -> `value`
`getdual` -> `dual`
`setvalue` -> `set_start_value`

Closes #1544

@chkwon 