### PR TITLE
Add Compat to vector_speedtest.jl

### DIFF
--- a/test/perf/vector_speedtest.jl
+++ b/test/perf/vector_speedtest.jl
@@ -1,3 +1,4 @@
+import Compat
 using JuMP
 
 function test(n::Int)


### PR DESCRIPTION
File is using Compat but it wasn't imported.