### PR TITLE
Modernize test/perf/speed.jl

### DIFF
--- a/test/perf/speed.jl
+++ b/test/perf/speed.jl
@@ -21,9 +21,6 @@ import BenchmarkTools: @benchmark, allocs
 using Compat
 using Compat.Random
 using JuMP
-@static if VERSION >= v"0.7.0-DEV.3406"
-    srand(seed) = Random.seed!(seed)
-end
 
 """
     p_median(num_facility, num_customer, num_location)
@@ -38,7 +35,7 @@ We use anonymous variables to remove the cost of name generation from the
 benchmark.
 """
 function p_median(num_facilities, num_customers, num_locations)
-    srand(10)
+    Random.seed!(10)
     customer_locations = [rand(1:num_locations) for _ in 1:num_customers]
 
     model = Model()


### PR DESCRIPTION
Output on Julia 1.0.0:

```
IAINMBP:JuMP idunning$ j1 --project=. test/perf/speed.jl
P-Median(100 facilities, 100 customers, 5000 locations) benchmark:
BenchmarkTools.Trial:
  memory estimate:  2.04 GiB
  allocs estimate:  28562192
  --------------
  minimum time:     2.877 s (40.82% GC)
  median time:      3.038 s (44.02% GC)
  mean time:        3.038 s (44.02% GC)
  maximum time:     3.200 s (46.89% GC)
  --------------
  samples:          2
  evals/sample:     1
Cont5(n=500) benchmark:
BenchmarkTools.Trial:
  memory estimate:  1.16 GiB
  allocs estimate:  15563463
  --------------
  minimum time:     1.519 s (36.65% GC)
  median time:      1.585 s (40.13% GC)
  mean time:        1.581 s (39.81% GC)
  maximum time:     1.637 s (42.14% GC)
  --------------
  samples:          4
  evals/sample:     1
```

Comparing with numbers from #1403:

PMedian
- release-0.18: ~1.0
- master, with name generation: ~4.6
- this PR: ~2.9

Cont5

- release-0.18: ~0.4
- master, with name generation: ~2.2
- this PR: ~1.6