### PR TITLE
WIP: Base.show for Model

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -318,6 +318,37 @@ function mode(model::Model)
     end
 end
 
+# Internal function.
+function try_get_solver_name(model_like)
+    try
+        return MOI.get(model_like, MOI.SolverName())
+    catch ex
+        if isa(ex, ArgumentError)
+            return "SolverName() attribute not implemented by the optimizer."
+        else
+            rethrow(ex)
+        end
+    end
+end
+
+"""
+    solver_name(model::Model)
+
+If available, returns the `SolverName` property of the underlying optimizer.
+Returns `"No optimizer attached"` in `Automatic` or `Manual` modes when no
+optimizer is attached. Returns
+"SolverName() attribute not implemented by the optimizer." if the attribute is
+not implemented.
+"""
+function solver_name(model::Model)
+    if mode(model) != Direct &&
+        caching_optimizer(model).state == MOIU.NoOptimizer
+        return "No optimizer attached."
+    else
+        return try_get_solver_name(backend(model))
+    end
+end
+
 """
     num_variables(model::Model)
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -103,6 +103,19 @@ function test_model()
         @test optimizer.a == 1
         @test optimizer.b == 2
     end
+
+    @testset "solver_name" begin
+        @testset "Not attached" begin
+            model = Model()
+            @test JuMP.solver_name(model) == "No optimizer attached."
+        end
+
+        @testset "Mock" begin
+            model = Model(with_optimizer(MOIU.MockOptimizer,
+                                         SimpleLPModel{Float64}()))
+            @test JuMP.solver_name(model) == "Mock"
+        end
+    end
 end
 
 @testset "Model" begin


### PR DESCRIPTION
Demo:
```julia
using JuMP, GLPK

m = Model(with_optimizer(GLPK.Optimizer))
@variable(m, x[1:2] >= 0)
@constraint(m, c, sum(x) <= 1)
julia> m
A JuMP Model
Variables: 2
`MathOptInterface.SingleVariable`-in-`MathOptInterface.GreaterThan{Float64}`: 2 constraints
`MathOptInterface.ScalarAffineFunction{Float64}`-in-`MathOptInterface.LessThan{Float64}`: 1 constraints
Model mode: Automatic
CachingOptimizer state: EmptyOptimizer
Solver name: SolverName() attribute not implemented by the optimizer.
Names registered in the model: c, x

julia> JuMP.optimize!(m)
julia> m
A JuMP Model
Variables: 2
`MathOptInterface.SingleVariable`-in-`MathOptInterface.GreaterThan{Float64}`: 2 constraints
`MathOptInterface.ScalarAffineFunction{Float64}`-in-`MathOptInterface.LessThan{Float64}`: 1 constraints
Model mode: Automatic
CachingOptimizer state: AttachedOptimizer
Solver name: SolverName() attribute not implemented by the optimizer.
Names registered in the model: c, x
```

Depends on https://github.com/JuliaOpt/MathOptInterface.jl/pull/565.