### PR TITLE
Performance improvements in linear_terms and quad_terms

### DIFF
--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -139,14 +139,29 @@ if VERSION < v"0.7-"
     Base.done( lti::LinearTermIterator, state::Int) = done(lti.aff.terms, state)
     Base.next( lti::LinearTermIterator, state::Int) = reorder_iterator(next(lti.aff.terms, state)...)
 else
-    reorder_iterator(::Nothing) = nothing
-    reorder_iterator(t::Tuple{Pair,Int}) = ((first(t).second, first(t).first), last(t))
-    Base.iterate(lti::LinearTermIterator) = reorder_iterator(iterate(lti.aff.terms))
+    reverse_pair_to_tuple(p::Pair) = (p.second, p.first)
+    function Base.iterate(lti::LinearTermIterator)
+        ret = iterate(lti.aff.terms)
+        if ret === nothing
+            return nothing
+        else
+            return reverse_pair_to_tuple(ret[1]), ret[2]
+        end
+    end
     function Base.iterate(lti::LinearTermIterator, state)
-        reorder_iterator(iterate(lti.aff.terms, state))
+        ret = iterate(lti.aff.terms, state)
+        if ret === nothing
+            return nothing
+        else
+            return reverse_pair_to_tuple(ret[1]), ret[2]
+        end
     end
 end
 Base.length(lti::LinearTermIterator) = length(lti.aff.terms)
+function Base.eltype(lti::LinearTermIterator{GenericAffExpr{C, V}}
+                    ) where {C, V}
+    return Tuple{C, V}
+end
 
 """
     add_to_expression!(expression, terms...)

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -112,7 +112,7 @@ if VERSION < v"0.7-"
     Base.done(qti::QuadTermIterator, state::Int) = done(qti.quad.terms, state)
     Base.next(qti::QuadTermIterator, state::Int) = reorder_iterator(next(qti.quad.terms, state)...)
 else
-    function reorder_and_flatten(p::Pair{<:UnorderedPair,<:Any})
+    function reorder_and_flatten(p::Pair{<:UnorderedPair})
         return (p.second, p.first.a, p.first.b)
     end
     function Base.iterate(qti::QuadTermIterator)

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -94,7 +94,7 @@ linear_terms(quad::GenericQuadExpr) = LinearTermIterator(quad.aff)
 struct QuadTermIterator{GQE<:GenericQuadExpr}
     quad::GQE
 end
-
+# TODO: rename to quad_terms
 """
     quadterms(quad::GenericQuadExpr{C, V})
 
@@ -112,15 +112,31 @@ if VERSION < v"0.7-"
     Base.done(qti::QuadTermIterator, state::Int) = done(qti.quad.terms, state)
     Base.next(qti::QuadTermIterator, state::Int) = reorder_iterator(next(qti.quad.terms, state)...)
 else
-    function reorder_iterator(t::Tuple{Pair{<:UnorderedPair,<:Any},Int})
-        ((first(t).second, first(t).first.a, first(t).first.b), last(t))
+    function reorder_and_flatten(p::Pair{<:UnorderedPair,<:Any})
+        return (p.second, p.first.a, p.first.b)
     end
-    Base.iterate(qti::QuadTermIterator) = reorder_iterator(iterate(qti.quad.terms))
+    function Base.iterate(qti::QuadTermIterator)
+        ret = iterate(qti.quad.terms)
+        if ret === nothing
+            return nothing
+        else
+            return reorder_and_flatten(ret[1]), ret[2]
+        end
+    end
     function Base.iterate(qti::QuadTermIterator, state)
-        reorder_iterator(iterate(qti.quad.terms, state))
+        ret = iterate(qti.quad.terms, state)
+        if ret === nothing
+            return nothing
+        else
+            return reorder_and_flatten(ret[1]), ret[2]
+        end
     end
 end
 Base.length(qti::QuadTermIterator) = length(qti.quad.terms)
+function Base.eltype(qti::QuadTermIterator{GenericQuadExpr{C, V}}
+                    ) where {C, V}
+    return Tuple{C, V, V}
+end
 
 function add_to_expression!(quad::GenericQuadExpr{C,V}, new_coef::C, new_var1::V, new_var2::V) where {C,V}
     # Node: OrderedDict updates the *key* as well. That is, if there was a


### PR DESCRIPTION
Ref https://discourse.julialang.org/t/allocations-when-manipulating-an-iterator/17405 and https://github.com/JuliaOpt/JuMP.jl/issues/1403#issuecomment-437630140.

I see a 5x speedup in `JuMP.moi_function(::AffExpr)` and a 3.3x speedup in `JuMP.moi_function(::QuadExpr)`. This removes 2 of 5 allocations per term in the minipmed example (https://github.com/JuliaOpt/JuMP.jl/issues/1403#issuecomment-437626804).
Before:
```
0.656219 seconds (5.00 M allocations: 568.758 MiB, 37.93% gc time)
```
After:
```
0.564028 seconds (3.00 M allocations: 507.723 MiB, 30.32% gc time)
```
There are still 3 more allocations per term to track down before we can (hopefully) get back to 0.18's performance.