### PR TITLE
Add a default fallback to build_constraint

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -393,8 +393,8 @@ end
 # Generic fallback.
 function build_constraint(_error::Function, func,
         set::Union{MOI.AbstractScalarSet, MOI.AbstractVectorSet})
-    return _error("unable to add the constraint because something is wrong " *
-                  "with your syntax.")
+    return _error("unable to add the constraint because we don't recognise " *
+                  "$(func) as a valid JuMP function.")
 end
 
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -393,7 +393,7 @@ end
 # Generic fallback.
 function build_constraint(_error::Function, func,
         set::Union{MOI.AbstractScalarSet, MOI.AbstractVectorSet})
-    return _error("unable to add the constraint because we don't recognise " *
+    return _error("unable to add the constraint because we don't recognize " *
                   "$(func) as a valid JuMP function.")
 end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -390,6 +390,14 @@ function parse_constraint(_error::Function, args...)
           "       expr1 == expr2\n" * "       lb <= expr <= ub")
 end
 
+# Generic fallback.
+function build_constraint(_error::Function, func,
+        set::Union{MOI.AbstractScalarSet, MOI.AbstractVectorSet})
+    return _error("unable to add the constraint because something is wrong " *
+                  "with your syntax.")
+end
+
+
 function build_constraint(_error::Function, v::AbstractJuMPScalar,
                           set::MOI.AbstractScalarSet)
     return ScalarConstraint(v, set)

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -184,7 +184,11 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
             "In @constraint(model,[3, x] in SecondOrderCone()): unable to add " *
             "the constraint because something is wrong with your syntax."
         )
-        @test_throws err @constraint(model, [3, x] in SecondOrderCone())
+        if VERSION < v"0.7"
+            @test_throws ErrorException @constraint(model, [3, x] in SecondOrderCone())
+        else
+            @test_throws err @constraint(model, [3, x] in SecondOrderCone())
+        end
     end
 
     @testset "SDP constraint" begin

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -182,7 +182,8 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         @variable(model, x[1:2])
         err = ErrorException(
             "In @constraint(model,[3, x] in SecondOrderCone()): unable to add " *
-            "the constraint because something is wrong with your syntax."
+            "the constraint because we don't recognise " *
+            "Any[3, VariableRef[x[1], x[2]]] as a valid JuMP function."
         )
         if VERSION < v"0.7"
             @test_throws ErrorException @constraint(model, [3, x] in SecondOrderCone())

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -181,9 +181,9 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         model = ModelType()
         @variable(model, x[1:2])
         err = ErrorException(
-            "In @constraint(model,[3, x] in SecondOrderCone()): unable to add " *
-            "the constraint because we don't recognise " *
-            "Any[3, VariableRef[x[1], x[2]]] as a valid JuMP function."
+            "In @constraint(model,[3, x] in SecondOrderCone()): unable to add" *
+            " the constraint because we don't recognise $([3, x]) as a valid " *
+            "JuMP function."
         )
         if VERSION < v"0.7"
             @test_throws ErrorException @constraint(model, [3, x] in SecondOrderCone())

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -177,6 +177,16 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         # @test c.set == MOI.SecondOrderCone(1)
     end
 
+    @testset "Syntax error" begin
+        model = ModelType()
+        @variable(model, x[1:2])
+        err = ErrorException(
+            "In @constraint(model,[3, x] in SecondOrderCone()): unable to add " *
+            "the constraint because something is wrong with your syntax."
+        )
+        @test_throws err @constraint(model, [3, x] in SecondOrderCone())
+    end
+
     @testset "SDP constraint" begin
         m = ModelType()
         @variable(m, x)

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -182,7 +182,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         @variable(model, x[1:2])
         err = ErrorException(
             "In @constraint(model,[3, x] in SecondOrderCone()): unable to add" *
-            " the constraint because we don't recognise $([3, x]) as a valid " *
+            " the constraint because we don't recognize $([3, x]) as a valid " *
             "JuMP function."
         )
         if VERSION < v"0.7"


### PR DESCRIPTION
Closes #1555

The specific error that `x` should be splatted is best left for the documentation (e.g in https://github.com/JuliaOpt/JuMP.jl/pull/1597)