### PR TITLE
Change has_dual to operate on the constraint object.

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -428,18 +428,14 @@ end
 index(cr::ConstraintRef) = cr.index
 
 """
-    has_dual(con_ref::ConstraintRef)
+    has_duals(model::Model)
 
 Return true if the solver has a dual solution available to query, otherwise
 return false.
 
 See also [`dual`](@ref) and [`shadow_price`](@ref).
 """
-function has_dual(con_ref::ConstraintRef{Model, <:MOICON})
-    # TODO(odow): should we be more clever here? What about solvers that only
-    # support duals on a subset of their constraints?
-    return MOI.get(con_ref.model, MOI.DualStatus()) != MOI.NoSolution
-end
+has_duals(model::Model) = dual_status(model) != MOI.NoSolution
 
 """
     dual(cr::ConstraintRef)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -427,11 +427,18 @@ end
 
 index(cr::ConstraintRef) = cr.index
 
-# TODO: Why does this method depend on the type of the constraint?
-# TODO: docstring
-function has_dual(model::Model,
-                         REF::Type{<:ConstraintRef{Model, T}}) where {T <: MOICON}
-    MOI.get(model, MOI.DualStatus()) != MOI.NoSolution
+"""
+    has_dual(con_ref::ConstraintRef)
+
+Return true if the solver has a dual solution available to query, otherwise
+return false.
+
+See also [`dual`](@ref) and [`shadow_price`](@ref).
+"""
+function has_dual(con_ref::ConstraintRef{Model, <:MOICON})
+    # TODO(odow): should we be more clever here? What about solvers that only
+    # support duals on a subset of their constraints?
+    return MOI.get(con_ref.model, MOI.DualStatus()) != MOI.NoSolution
 end
 
 """

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -277,7 +277,7 @@ end
 
 The change in the objective from an infinitesimal relaxation of the constraint.
 This value is computed from [`dual`](@ref) and can be queried only when
-`has_dual` is `true` and the objective sense is `MinSense` or `MaxSense`
+`has_duals` is `true` and the objective sense is `MinSense` or `MaxSense`
 (not `FeasibilitySense`). For linear constraints, the shadow prices differ at
 most in sign from the `dual` value depending on the objective sense.
 
@@ -330,7 +330,7 @@ end
 function shadow_price(constraint::ConstraintRef{Model, MOICON{F, S}}
                       ) where {S <: MOI.LessThan, F}
     model = constraint.model
-    if !has_dual(constraint)
+    if !has_duals(model)
         error("The shadow price is not available because no dual result is " *
               "available.")
     end
@@ -341,7 +341,7 @@ end
 function shadow_price(constraint::ConstraintRef{Model, MOICON{F, S}}
                       ) where {S <: MOI.GreaterThan, F}
     model = constraint.model
-    if !has_dual(constraint)
+    if !has_duals(model)
         error("The shadow price is not available because no dual result is " *
               "available.")
     end
@@ -352,7 +352,7 @@ end
 function shadow_price(constraint::ConstraintRef{Model, MOICON{F, S}}
                       ) where {S <: MOI.EqualTo, F}
     model = constraint.model
-    if !has_dual(constraint)
+    if !has_duals(model)
         error("The shadow price is not available because no dual result is " *
               "available.")
     end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -330,7 +330,7 @@ end
 function shadow_price(constraint::ConstraintRef{Model, MOICON{F, S}}
                       ) where {S <: MOI.LessThan, F}
     model = constraint.model
-    if !has_dual(model, typeof(constraint))
+    if !has_dual(constraint)
         error("The shadow price is not available because no dual result is " *
               "available.")
     end
@@ -341,7 +341,7 @@ end
 function shadow_price(constraint::ConstraintRef{Model, MOICON{F, S}}
                       ) where {S <: MOI.GreaterThan, F}
     model = constraint.model
-    if !has_dual(model, typeof(constraint))
+    if !has_dual(constraint)
         error("The shadow price is not available because no dual result is " *
               "available.")
     end
@@ -352,7 +352,7 @@ end
 function shadow_price(constraint::ConstraintRef{Model, MOICON{F, S}}
                       ) where {S <: MOI.EqualTo, F}
     model = constraint.model
-    if !has_dual(model, typeof(constraint))
+    if !has_dual(constraint)
         error("The shadow price is not available because no dual result is " *
               "available.")
     end

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -163,9 +163,7 @@
         @test JuMP.value(y) == 0.0
         @test JuMP.objective_value(m) == 1.0
 
-        @test !JuMP.has_dual(JuMP.FixRef(x))
-        @test !JuMP.has_dual(JuMP.IntegerRef(x))
-        @test !JuMP.has_dual(JuMP.BinaryRef(y))
+        @test !JuMP.has_duals(m)
     end
 
     @testset "QCQP" begin
@@ -277,10 +275,8 @@
         @test JuMP.value(y) == 0.0
         @test JuMP.value(z) == 0.0
 
-        @test JuMP.has_dual(varsoc)
+        @test JuMP.has_duals(m)
         @test JuMP.dual(varsoc) == [-1.0, -2.0, -3.0]
-
-        @test JuMP.has_dual(affsoc)
         @test JuMP.dual(affsoc) == [1.0, 2.0, 3.0]
     end
 
@@ -338,20 +334,17 @@
 
         JuMP.optimize!(m)
 
-        #@test JuMP.isattached(m)
-        @test JuMP.has_values(m)
-
         @test JuMP.termination_status(m) == MOI.Success
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
+        @test JuMP.has_values(m)
         @test JuMP.value.(x) == [1.0 2.0; 2.0 4.0]
-        @test JuMP.has_dual(var_psd)
+
+        @test JuMP.has_duals(m)
         @test JuMP.dual(var_psd) isa Symmetric
         @test JuMP.dual(var_psd) == [1.0 2.0; 2.0 3.0]
-        @test JuMP.has_dual(sym_psd)
         @test JuMP.dual(sym_psd) isa Symmetric
         @test JuMP.dual(sym_psd) == [4.0 5.0; 5.0 6.0]
-        @test JuMP.has_dual(con_psd)
         @test JuMP.dual(con_psd) isa Matrix
         @test JuMP.dual(con_psd) == [7.0 9.0; 8.0 10.0]
 

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -163,9 +163,9 @@
         @test JuMP.value(y) == 0.0
         @test JuMP.objective_value(m) == 1.0
 
-        @test !JuMP.has_dual(m, typeof(JuMP.FixRef(x)))
-        @test !JuMP.has_dual(m, typeof(JuMP.IntegerRef(x)))
-        @test !JuMP.has_dual(m, typeof(JuMP.BinaryRef(y)))
+        @test !JuMP.has_dual(JuMP.FixRef(x))
+        @test !JuMP.has_dual(JuMP.IntegerRef(x))
+        @test !JuMP.has_dual(JuMP.BinaryRef(y))
     end
 
     @testset "QCQP" begin
@@ -277,10 +277,10 @@
         @test JuMP.value(y) == 0.0
         @test JuMP.value(z) == 0.0
 
-        @test JuMP.has_dual(m, typeof(varsoc))
+        @test JuMP.has_dual(varsoc)
         @test JuMP.dual(varsoc) == [-1.0, -2.0, -3.0]
 
-        @test JuMP.has_dual(m, typeof(affsoc))
+        @test JuMP.has_dual(affsoc)
         @test JuMP.dual(affsoc) == [1.0, 2.0, 3.0]
     end
 
@@ -345,13 +345,13 @@
         @test JuMP.primal_status(m) == MOI.FeasiblePoint
 
         @test JuMP.value.(x) == [1.0 2.0; 2.0 4.0]
-        @test JuMP.has_dual(m, typeof(var_psd))
+        @test JuMP.has_dual(var_psd)
         @test JuMP.dual(var_psd) isa Symmetric
         @test JuMP.dual(var_psd) == [1.0 2.0; 2.0 3.0]
-        @test JuMP.has_dual(m, typeof(sym_psd))
+        @test JuMP.has_dual(sym_psd)
         @test JuMP.dual(sym_psd) isa Symmetric
         @test JuMP.dual(sym_psd) == [4.0 5.0; 5.0 6.0]
-        @test JuMP.has_dual(m, typeof(con_psd))
+        @test JuMP.has_dual(con_psd)
         @test JuMP.dual(con_psd) isa Matrix
         @test JuMP.dual(con_psd) == [7.0 9.0; 8.0 10.0]
 


### PR DESCRIPTION
> Why does this method depend on the type of the constraint?

Answer: I have no idea. @mlubin introduced it in https://github.com/JuliaOpt/JuMP.jl/pull/1158/commits/16f867a5689ffba2b9ed6411bafb4254f042a051, but it doesn't seem needed so I reverted back to the object.