### PR TITLE
✨ Add support for ∈ and test constant shift with "in Interval" constraint

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -324,7 +324,8 @@ sense_to_set(_error::Function, ::Union{Val{:(>=)}, Val{:(≥)}}) = MOI.GreaterTh
 sense_to_set(_error::Function, ::Val{:(==)}) = MOI.EqualTo(0.0)
 sense_to_set(_error::Function, ::Val{S}) where S = _error("Unrecognized sense $S")
 
-function parse_one_operator_constraint(_error::Function, vectorized::Bool, ::Val{:in}, aff, set)
+function parse_one_operator_constraint(_error::Function, vectorized::Bool,
+                                       ::Union{Val{:in}, Val{:∈}}, aff, set)
     newaff, parseaff = parseExprToplevel(aff, :q)
     parsecode = :(q = Val{false}(); $parseaff)
     if vectorized

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -88,6 +88,13 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel})
         c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func, x + y)
         @test c.set == MOI.Interval(0.0, 1.0)
+
+        cref = @constraint(m, 2x - y + 2.0 ∈ MOI.Interval(-1.0, 1.0))
+        @test JuMP.name(cref) == ""
+
+        c = JuMP.constraint_object(cref)
+        @test JuMP.isequal_canonical(c.func, 2x - y)
+        @test c.set == MOI.Interval(-3.0, -1.0)
     end
 
     @testset "Broadcasted constraint (.==)" begin


### PR DESCRIPTION
This allows to use the symbol ∈ as well as `in` with the constraints. Users would expect it to work as ∈ redirects to `Base.in`, e.g.
```julia
julia> 2 ∈ 1:3
true
```