### PR TITLE
⚡️ Add destructive_add! for variable + variable

### DIFF
--- a/src/parse_expr.jl
+++ b/src/parse_expr.jl
@@ -92,6 +92,10 @@ function destructive_add!(ex::Number, c::T, x::Number) where T<:GenericQuadExpr
     end
 end
 
+function destructive_add!(ex::VariableRef, c::Number, x::VariableRef)
+    return GenericAffExpr(0.0, ex => 1.0, x => convert(Float64, c))
+end
+
 function destructive_add!(aff::GenericAffExpr, c::Number, x::Number)
     aff.constant += c*x
     aff


### PR DESCRIPTION
The result of `speed.jl` on master:
```
P-Median(100 facilities, 100 customers, 5000 locations) benchmark:
BenchmarkTools.Trial: 
  memory estimate:  1017.98 MiB
  allocs estimate:  16531537
  --------------
  minimum time:     2.028 s (44.50% GC)
  median time:      2.303 s (52.62% GC)
  mean time:        2.320 s (52.55% GC)
  maximum time:     2.630 s (58.70% GC)
  --------------
  samples:          3
  evals/sample:     1
Cont5(n=500) benchmark:
BenchmarkTools.Trial: 
  memory estimate:  421.65 MiB
  allocs estimate:  7545407
  --------------
  minimum time:     915.800 ms (41.56% GC)
  median time:      1.003 s (43.59% GC)
  mean time:        999.647 ms (43.82% GC)
  maximum time:     1.078 s (45.62% GC)
  --------------
  samples:          6
  evals/sample:     1
```
With this PR
```
P-Median(100 facilities, 100 customers, 5000 locations) benchmark:
BenchmarkTools.Trial: 
  memory estimate:  735.64 MiB
  allocs estimate:  13030837
  --------------
  minimum time:     1.416 s (35.18% GC)
  median time:      2.219 s (58.35% GC)
  mean time:        2.012 s (53.49% GC)
  maximum time:     2.401 s (59.80% GC)
  --------------
  samples:          3
  evals/sample:     1
Cont5(n=500) benchmark:
BenchmarkTools.Trial: 
  memory estimate:  421.08 MiB
  allocs estimate:  7538407
  --------------
  minimum time:     912.507 ms (41.36% GC)
  median time:      971.512 ms (43.71% GC)
  mean time:        971.481 ms (43.99% GC)
  maximum time:     1.038 s (46.60% GC)
  --------------
  samples:          6
  evals/sample:     1
```

Related to https://github.com/JuliaOpt/JuMP.jl/issues/1403