### PR TITLE
Replace map with typed comprehension

### DIFF
--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -262,7 +262,9 @@ value(a::GenericAffExpr) = value(a, value)
 # the same model.
 function MOI.ScalarAffineFunction(a::AffExpr)
     assert_isfinite(a)
-    terms = map(t -> MOI.ScalarAffineTerm(t[1], index(t[2])), linear_terms(a))
+    terms = MOI.ScalarAffineTerm{Float64}[MOI.ScalarAffineTerm(t[1],
+                                                               index(t[2]))
+                                          for t in linear_terms(a)]
     return MOI.ScalarAffineFunction(terms, a.constant)
 end
 moi_function(a::GenericAffExpr) = MOI.ScalarAffineFunction(a)
@@ -282,7 +284,7 @@ function jump_function(model::AbstractModel, f::MOI.ScalarAffineFunction)
     return AffExpr(model, f)
 end
 function jump_function(model::AbstractModel, f::MOI.VectorAffineFunction)
-    return map(f -> AffExpr(model, f), MOIU.eachscalar(f))
+    return AffExpr[AffExpr(model, f) for f in MOIU.eachscalar(f)]
 end
 
 """

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -208,9 +208,11 @@ GenericQuadExpr{C, V}() where {C, V} = zero(GenericQuadExpr{C, V})
 
 function MOI.ScalarQuadraticFunction(q::QuadExpr)
     assert_isfinite(q)
-    qterms = map(t -> MOI.ScalarQuadraticTerm(t[2] == t[3] ? 2t[1] : t[1],
-                                              index(t[2]),
-                                              index(t[3])), quadterms(q))
+    qterms = MOI.ScalarQuadraticTerm{Float64}[MOI.ScalarQuadraticTerm(
+                                               t[2] == t[3] ? 2t[1] : t[1],
+                                               index(t[2]),
+                                               index(t[3]))
+                                               for t in quadterms(q)]
     moi_aff = MOI.ScalarAffineFunction(q.aff)
     return MOI.ScalarQuadraticFunction(moi_aff.terms,
                                        qterms, moi_aff.constant)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -240,7 +240,7 @@ function moi_function(variables::Vector{<:AbstractVariableRef})
     return MOI.VectorOfVariables(variables)
 end
 function jump_function(model::AbstractModel, variables::MOI.VectorOfVariables)
-    return map(v -> VariableRef(model, v), variables.variables)
+    return VariableRef[VariableRef(model, v) for v in variables.variables]
 end
 
 VariableRef(m::Model, f::MOI.SingleVariable) = VariableRef(m, f.variable)


### PR DESCRIPTION
When doing `map(fun, array)`, Julia creates `itr = Generator(fun, array)` and `IteratorEltype(itr)` is `EltypeUnknown` hence it uses this function
https://github.com/JuliaLang/julia/blob/9f43871e545d6226535c49a916c633ef3455033c/base/array.jl#L639-L646
which first compute the first element, then get its type and then build the array.
If we know the resulting eltype `T`, it is more efficient to do `T[fun(el) for el in array]` as shown by the following benchmark:
```julia
_term(t) = JuMP.MOI.ScalarAffineTerm(t[1], JuMP.index(t[2]))
function affine_convert_benchmark(n)
    model = Model()
    @variable(model, x[1:n])
    aff = sum(x)
    @btime JuMP.assert_isfinite($aff)
    println("map:")
    @btime map(_term, JuMP.linear_terms($aff))
    println("typed comprehension:")
    @btime JuMP.MOI.ScalarAffineTerm{Float64}[_term(t) for t in JuMP.linear_terms($aff)]
    println("broadcast:")
    @btime _term.(JuMP.linear_terms($aff))
    println("preallocate:")
    @btime begin
        terms = Vector{JuMP.MOI.ScalarAffineTerm{Float64}}(undef, $n)
        i = 0
        for t in JuMP.linear_terms($aff)
            i += 1
            terms[i] = _term(t)
        end
    end
    println("push!:")
    @btime begin
        terms = JuMP.MOI.ScalarAffineTerm{Float64}[]
        for t in JuMP.linear_terms($aff)
            push!(terms, _term(t))
        end
    end
end
```
See the results below. Notice how bad broadcast is, it is probably because `LinearTermIterator` is not an `AbstractVector`.
The `preallocate` could also be made faster with `@inbound`.
```julia
julia> affine_convert_benchmark(1)

  6.685 ns (0 allocations: 0 bytes)
map:
  48.593 ns (3 allocations: 128 bytes)
typed comprehension:
  31.780 ns (1 allocation: 96 bytes)
broadcast:
  76.303 ns (4 allocations: 240 bytes)
preallocate:
  31.519 ns (1 allocation: 96 bytes)
push!:
  58.014 ns (2 allocations: 160 bytes)

julia> affine_convert_benchmark(2)

  7.927 ns (0 allocations: 0 bytes)
map:
  53.155 ns (3 allocations: 144 bytes)
typed comprehension:
  35.799 ns (1 allocation: 112 bytes)
broadcast:
  88.762 ns (5 allocations: 288 bytes)
preallocate:
  36.138 ns (1 allocation: 112 bytes)
push!:
  61.699 ns (2 allocations: 160 bytes)

julia> affine_convert_benchmark(3)

  10.115 ns (0 allocations: 0 bytes)
map:
  56.407 ns (3 allocations: 160 bytes)
typed comprehension:
  37.435 ns (1 allocation: 128 bytes)
broadcast:
  98.625 ns (6 allocations: 352 bytes)
preallocate:
  37.377 ns (1 allocation: 128 bytes)
push!:
  70.783 ns (2 allocations: 160 bytes)

julia> affine_convert_benchmark(4)

  10.634 ns (0 allocations: 0 bytes)
map:
  53.448 ns (3 allocations: 176 bytes)
typed comprehension:
  37.972 ns (1 allocation: 144 bytes)
broadcast:
  95.027 ns (7 allocations: 400 bytes)
preallocate:
  37.946 ns (1 allocation: 144 bytes)
push!:
  73.441 ns (2 allocations: 160 bytes)

julia> affine_convert_benchmark(5)

  11.896 ns (0 allocations: 0 bytes)
map:
  59.185 ns (3 allocations: 192 bytes)
typed comprehension:
  40.913 ns (1 allocation: 160 bytes)
broadcast:
  115.288 ns (8 allocations: 464 bytes)
preallocate:
  41.321 ns (1 allocation: 160 bytes)
push!:
  108.501 ns (3 allocations: 304 bytes)
```

The timing with `speed.jl` is:
```
P-Median(100 facilities, 100 customers, 5000 locations) benchmark:
BenchmarkTools.Trial: 
  memory estimate:  720.37 MiB
  allocs estimate:  12030568
  --------------
  minimum time:     1.367 s (35.68% GC)
  median time:      2.142 s (58.65% GC)
  mean time:        1.938 s (54.17% GC)
  maximum time:     2.304 s (60.99% GC)
  --------------
  samples:          3
  evals/sample:     1
Cont5(n=500) benchmark:
BenchmarkTools.Trial: 
  memory estimate:  410.42 MiB
  allocs estimate:  7036340
  --------------
  minimum time:     901.124 ms (41.71% GC)
  median time:      970.107 ms (44.69% GC)
  mean time:        960.528 ms (44.32% GC)
  maximum time:     994.929 ms (44.16% GC)
  --------------
  samples:          6
  evals/sample:     1
```
which is a slight improvement compared to the timing reported in https://github.com/JuliaOpt/JuMP.jl/pull/1636