### PR TITLE
⚡️ Encapsulate type instability of backend

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -294,8 +294,8 @@ end
 Return mode (Direct, Automatic, Manual) of model.
 """
 mode(model::Model) = moi_mode(backend(model))
-# the type of backend(model) is unknown so we directly redirects to another
-# function
+# The type of backend(model) is unknown so we directly redirect to another
+# function.
 
 # Direct mode
 moi_bridge_constraints(model::MOI.ModelLike) = false
@@ -313,8 +313,8 @@ to equivalent supported constraints when an appropriate transformation is
 available.
 """
 bridge_constraints(model::Model) = moi_bridge_constraints(backend(model))
-# the type of backend(model) is unknown so we directly redirects to another
-# function
+# The type of backend(model) is unknown so we directly redirect to another
+# function.
 
 
 """

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -238,8 +238,8 @@ end
 Add a constraint `c` to `Model model` and sets its name.
 """
 function add_constraint(model::Model, c::AbstractConstraint, name::String="")
-    # the type of backend(model) is unknown so we directly redirects to another
-    # function
+    # The type of backend(model) is unknown so we directly redirect to another
+    # function.
     cindex = moi_add_constraint(backend(model), moi_function(c), moi_set(c))
     cref = ConstraintRef(model, cindex, shape(c))
     if !isempty(name)


### PR DESCRIPTION
This PR uses the [function barrier technique](https://docs.julialang.org/en/v1/manual/performance-tips/index.html#kernel-functions-1) to reduce the impact of the type instability of `backend(model)` in `JuMP.add_constraint`.
As `JuMP.moi_add_constraint` needs to call `bridge_constraints` and `mode` with the MOI backend, we also need to apply the function barrier technique to these two functions.

This result in a small speedup in `speed.jl`. Compare the result of https://github.com/JuliaOpt/JuMP.jl/pull/1640 with the result with this PR:
```
P-Median(100 facilities, 100 customers, 5000 locations) benchmark:
BenchmarkTools.Trial: 
  memory estimate:  714.37 MiB
  allocs estimate:  12030567
  --------------
  minimum time:     1.692 s (52.39% GC)
  median time:      1.729 s (53.90% GC)
  mean time:        1.906 s (57.67% GC)
  maximum time:     2.298 s (64.40% GC)
  --------------
  samples:          3
  evals/sample:     1
Cont5(n=500) benchmark:
BenchmarkTools.Trial: 
  memory estimate:  402.77 MiB
  allocs estimate:  6785839
  --------------
  minimum time:     777.018 ms (40.46% GC)
  median time:      877.130 ms (44.78% GC)
  mean time:        871.167 ms (45.42% GC)
  maximum time:     955.600 ms (49.90% GC)
  --------------
  samples:          6
  evals/sample:     1
```