### PR TITLE
Remove javascript warning

### DIFF
--- a/0.18/index.html
+++ b/0.18/index.html
@@ -138,16 +138,7 @@
             
   <div class="section" id="jump-julia-for-mathematical-optimization">
 <h1>JuMP &#8212; Julia for Mathematical Optimization<a class="headerlink" href="#jump-julia-for-mathematical-optimization" title="Permalink to this headline">¶</a></h1>
-<div id="officialwarn" class="admonition warning">
-<p class="first admonition-title">Warning</p>
-<p class="last">This documentation is out of date. JuMP no longer uses readthedocs to host its documentation. See <a href="https://github.com/JuliaOpt/JuMP.jl">here</a> for the links to the latest release and developer documentation.
-</p>
-</div>
-<script type="text/javascript">
-if(!(location.hostname.match('readthedocs') || location.hostname.match('rtfd'))){
-    document.getElementById("officialwarn").style.display = 'none';
-}
-</script><p><a class="reference external" href="https://github.com/JuliaOpt/JuMP.jl">JuMP</a> is a domain-specific modeling language for
+<p><a class="reference external" href="https://github.com/JuliaOpt/JuMP.jl">JuMP</a> is a domain-specific modeling language for
 <a class="reference external" href="http://en.wikipedia.org/wiki/Mathematical_optimization">mathematical optimization</a>
 embedded in <a class="reference external" href="http://julialang.org/">Julia</a>.
 It currently supports a number of open-source and commercial solvers (see below)


### PR DESCRIPTION
This warning appears in searches. No longer needed since the docs aren't sync'd to readthedocs.

![image](https://user-images.githubusercontent.com/1733683/48845307-29e52700-ed6a-11e8-9757-816a43f49fb5.png)
