### PR TITLE
Document JuMPArray constuctors.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,15 @@ Breaking changes:
   conventional LP interpretations of dual values as sensitivities of the
   objective value to relaxations of constraints.
 
+- `@constraintref` is no longer defined. Instead, create the appropriate
+  container to hold constraint references manually. For example,
+  ```julia
+  constraints = Dict() # Optionally, specify types for improved performance.
+  for i in 1:N
+    constraints[i] = @constraint(model, ...)
+  end
+  ```
+
 New features:
 
 - Splatting (like `f(x...)`) is recognized in restricted settings in nonlinear

--- a/docs/src/containers.md
+++ b/docs/src/containers.md
@@ -1,13 +1,30 @@
+```@meta
+DocTestSetup = quote
+    using JuMP
+end
+```
+
 Containers
 ==========
 
-Containers can be created using the `generatecontainer` function
+JuMP provides a specialized container similar to
+[`AxisArrays`](https://github.com/JuliaArrays/AxisArrays.jl) that enables
+indexing with non-integer indices. Normally these are created automatically
+by JuMP's macros. The following constructors can be used to create them
+manually.
+
+```@docs
+JuMP.JuMPArray
+```
+
+Containers in macros
+--------------------
+
+The `generatecontainer` function encodes the logic for how containers are
+constructed in JuMP's macros.
 ```@docs
 JuMP.generatecontainer
 ```
-
-Containers in macro
--------------------
 
 In the [`@variable`](@ref) (resp. [`@constraint`](@ref)) macro, containers of
 variables (resp. constraints) can be created the following syntax

--- a/src/JuMPArray.jl
+++ b/src/JuMPArray.jl
@@ -36,7 +36,7 @@ end
 
 Construct a JuMP array with the underlying data specified by the `data` array
 and the given axes. Exactly `N` axes must be provided, and their lengths must
-match the corresponding lengths of the axes of the `data` array.
+match `size(data)` in the corresponding dimensions.
 
 # Example
 ```jldoctest

--- a/src/JuMPArray.jl
+++ b/src/JuMPArray.jl
@@ -31,9 +31,72 @@ function build_lookup(ax)
     d
 end
 
+"""
+    JuMPArray(data::Array{T, N}, axes...) where {T, N}
+
+Construct a JuMP array with the underlying data specified by the `data` array
+and the given axes. Exactly `N` axes must be provided, and their lengths must
+match the corresponding lengths of the axes of the `data` array.
+
+# Example
+```jldoctest
+julia> array = JuMP.JuMPArray([1 2; 3 4], [:a, :b], 2:3)
+2-dimensional JuMPArray{Int64,2,...} with index sets:
+    Dimension 1, Symbol[:a, :b]
+    Dimension 2, 2:3
+And data, a 2×2 Array{Int64,2}:
+ 1  2
+ 3  4
+
+julia> array[:b, 3]
+4
+```
+"""
 function JuMPArray(data::Array{T,N}, axs...) where {T,N}
     @assert length(axs) == N
     return JuMPArray(data, axs, build_lookup.(axs))
+end
+
+"""
+    JuMPArray{T}(undef, axes...) where T
+
+Construct an uninitialized JuMPArray with element-type `T` indexed over the
+given axes.
+
+# Example
+```jldoctest
+julia> array = JuMP.JuMPArray{Float64}(undef, [:a, :b], 1:2);
+
+julia> fill!(array, 1.0)
+2-dimensional JuMPArray{Float64,2,...} with index sets:
+    Dimension 1, Symbol[:a, :b]
+    Dimension 2, 1:2
+And data, a 2×2 Array{Float64,2}:
+ 1.0  1.0
+ 1.0  1.0
+
+julia> array[:a, 2] = 5.0
+5.0
+
+julia> array[:a, 2]
+5.0
+
+julia> array
+2-dimensional JuMPArray{Float64,2,...} with index sets:
+    Dimension 1, Symbol[:a, :b]
+    Dimension 2, 1:2
+And data, a 2×2 Array{Float64,2}:
+ 1.0  5.0
+ 1.0  1.0
+```
+"""
+function JuMPArray{T}(::UndefInitializer, axs...) where T
+    return construct_undef_array(T, axs)
+end
+
+function construct_undef_array(::Type{T}, axs::Tuple{Vararg{Any, N}}
+                               ) where {T, N}
+    return JuMPArray(Array{T, N}(undef, length.(axs)...), axs...)
 end
 
 lookup_index(i, lookup::Dict) = isa(i, Colon) ? Colon() : lookup[i]

--- a/src/containers.jl
+++ b/src/containers.jl
@@ -36,7 +36,7 @@ automatically checks for duplicate terms in the index sets and `false` otherwise
 
     generatecontainer(VariableRef, [:i,:j], [:(1:N), :(2:T)], :Auto)
     # Returns code equivalent to:
-    # :(JuMPArray(Array{VariableRef}(length(1:N), length(2:T)), \$indexvars...))
+    # :(JuMPArray(undef, 1:N, 2:T))
 
     generatecontainer(VariableRef, [:i,:j], [:(1:N), :(S)], :Auto)
     # Returns code that generates an Array if S is of type Base.OneTo,
@@ -85,7 +85,7 @@ function generatecontainer(T, indexvars, indexsets, requestedtype)
         end
     end
 
-    axisexpr = :(JuMP.JuMPArray(Array{$T}(undef, $sizes...)))
+    axisexpr = :(JuMP.JuMPArray{$T}(undef))
     append!(axisexpr.args, indexsets)
 
     if requestedtype == :JuMPArray

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1274,7 +1274,7 @@ The expression `varexpr` can either be
 
 * of the form `varname` creating a scalar real variable of name `varname`;
 * of the form `varname[...]` or `[...]` creating a container of variables (see
-  [Containers in macro](@ref).
+  [Containers in macros](@ref).
 
 The recognized positional arguments in `args` are the following:
 
@@ -1300,7 +1300,7 @@ The recognized keyword arguments in `kwargs` are the following:
 * `binary`: Sets whether the variable is binary or not.
 * `integer`: Sets whether the variable is integer or not.
 * `variable_type`: See the "Note for extending the variable macro" section below.
-* `container`: Specify the container type, see [Containers in macro](@ref).
+* `container`: Specify the container type, see [Containers in macros](@ref).
 
 ## Examples
 
@@ -1547,27 +1547,6 @@ macro variable(args...)
     end
     return assert_validmodel(model, macro_code)
 end
-
-# TODO: replace with a general macro that can construct any container type
-# macro constraintref(var)
-#     if isa(var,Symbol)
-#         # easy case
-#         return esc(:(local $var))
-#     else
-#         if !isexpr(var,:ref)
-#             error("Syntax error: Expected $var to be of form var[...]")
-#         end
-#
-#         varname = var.args[1]
-#         idxsets = var.args[2:end]
-#
-#         code = quote
-#             $(esc(gendict(varname, :ConstraintRef, idxsets...)))
-#             nothing
-#         end
-#         return code
-#     end
-# end
 
 # TODO: Add a docstring.
 macro NLobjective(model, sense, x)

--- a/test/containers.jl
+++ b/test/containers.jl
@@ -88,6 +88,18 @@ containermatches(c1, c2) = false
 end
 
 @testset "JuMPArray" begin
+    @testset "undef constructor" begin
+        A = @inferred JuMPArray{Int}(undef, [:a, :b], 1:2)
+        A[:a, 1] = 1
+        A[:b, 1] = 2
+        A[:a, 2] = 3
+        A[:b, 2] = 4
+        @test A[:a, 1] == 1
+        @test A[:b, 1] == 2
+        @test A[:a, 2] == 3
+        @test A[:b, 2] == 4
+    end
+
     @testset "Range index set" begin
         A = @inferred JuMPArray([1.0,2.0], 2:3)
         if VERSION >= v"0.7-"


### PR DESCRIPTION
Provide a new constructor to create uninitialized JuMPArrays.
Remove old `@constraintref` code. It's now recommended to construct the
right container manually to collect constraint references.
Closes #1303.

@jd-lara, please take a look.