### PR TITLE
Fix KeyIterator on 0.7+ in JuMP 0.18

### DIFF
--- a/src/JuMPContainer.jl
+++ b/src/JuMPContainer.jl
@@ -208,7 +208,7 @@ Base.keys(d::JuMPArray)   = KeyIterator(d)
 Base.values(d::JuMPArray) = ValueIterator(d.innerArray)
 
 # Wrapper type so that you can't access the values directly
-mutable struct ValueIterator{T,N}
+struct ValueIterator{T,N}
     x::Array{T,N}
 end
 if VERSION < v"0.7-"
@@ -221,139 +221,17 @@ else
 end
 Base.length(it::ValueIterator) = length(it.x)
 
-mutable struct KeyIterator{JA<:JuMPArray}
-    x::JA
-    dim::Int
-    next_k_cache::Array{Any,1}
-    function KeyIterator{JA}(d) where JA
-        n = ndims(d.innerArray)
-        new{JA}(d, n, Array{Any}(undef, VERSION < v"0.7-" ? n+1 : n))
-    end
+struct KeyIterator{T}
+    inner::T
 end
-
-KeyIterator(d::JA) where {JA} = KeyIterator{JA}(d)
-
-function indexability(x::JuMPArray)
-    for i in  1:length(x.indexsets)
-        if !hasmethod(getindex, (typeof(x.indexsets[i]),))
-            return false
-        end
-    end
-
-    return true
-end
+KeyIterator(d::JuMPArray) = KeyIterator(Iterators.product(d.indexsets...))
 
 if VERSION < v"0.7-"
-    function Base.start(it::KeyIterator)
-        if indexability(it.x)
-            return start(it.x.innerArray)
-        else
-            return notindexable_start(it.x)
-        end
-    end
+    Base.start(it::KeyIterator) = start(it.inner)
+    Base.next(it::KeyIterator, state) = next(it.inner, state)
+    Base.done(it::KeyIterator, state) = done(it.inner, state)
 else
-    function Base.iterate(it::KeyIterator)
-        if indexability(it.x)
-            return iterate(it.x.innerArray)
-        else
-            return notindexable_start(it.x)
-        end
-    end
+    Base.iterate(it::KeyIterator) = iterate(it.inner)
+    Base.iterate(it::KeyIterator, state) = iterate(it.inner, state)
 end
-
-if VERSION < v"0.7-"
-    @generated function notindexable_start(x::JuMPArray{T,N,NT}) where {T,N,NT}
-        quote
-            $(Expr(:tuple, 0, [:(start(x.indexsets[$i])) for i in 1:N]...))
-        end
-    end
-else
-    _add_zero(item_state::Tuple) = (item_state[1], (0, item_state[2]...))
-    function notindexable_start(x::JuMPArray{T,N,NT}) where {T,N,NT}
-        item_states = ntuple(i -> iterate(x.indexsets[i]), Val(N))
-        map(item_state -> item_state[1], item_states), item_states
-    end
-end
-
-if VERSION < v"0.7-"
-    @generated function _next(x::JuMPArray{T,N,NT}, k::Tuple) where {T,N,NT}
-        quote
-            $(Expr(:tuple, [:(next(x.indexsets[$i], k[$i+1])[1]) for i in 1:N]...))
-        end
-    end
-else
-    function _next(x::JuMPArray{T,N,NT}, k::Tuple) where {T,N,NT}
-        map(item_state -> item_state[1], k)
-    end
-end
-
-if VERSION < v"0.7-"
-    function Base.next(it::KeyIterator, k::Tuple)
-        cartesian_key = _next(it.x, k)
-        pos = -1
-        for i in 1:it.dim
-            if !done(it.x.indexsets[i], next(it.x.indexsets[i], k[i+1])[2] )
-                pos = i
-                break
-            end
-        end
-        if pos == - 1
-            it.next_k_cache[1] = 1
-            return cartesian_key, tuple(it.next_k_cache...)
-        end
-        it.next_k_cache[1] = 0
-        for i in 1:it.dim
-            if i < pos
-                it.next_k_cache[i+1] = start(it.x.indexsets[i])
-            elseif i == pos
-                it.next_k_cache[i+1] = next(it.x.indexsets[i], k[i+1])[2]
-            else
-                it.next_k_cache[i+1] = k[i+1]
-            end
-        end
-        cartesian_key, tuple(it.next_k_cache...)
-    end
-    Base.done(it::KeyIterator, k::Tuple) = (k[1] == 1)
-else
-    function Base.iterate(it::KeyIterator, k::Tuple)
-        pos = -1
-        for i in 1:it.dim
-            if iterate(it.x.indexsets[i], k[i][2]) ≠ nothing
-                pos = i
-                break
-            end
-        end
-        if pos == -1
-            return nothing
-        end
-        for i in 1:it.dim
-            if i < pos
-                it.next_k_cache[i] = iterate(it.x.indexsets[i])
-            elseif i == pos
-                it.next_k_cache[i] = iterate(it.x.indexsets[i], k[i][2])
-            else
-                it.next_k_cache[i] = k[i]
-            end
-        end
-        next_k = tuple(it.next_k_cache...)
-        _next(it.x, next_k), next_k
-    end
-end
-
-@generated __next(x::JuMPArray{T,N,NT}, k::Integer) where {T,N,NT} =
-    quote
-        subidx = _ind2sub(size(x), k)
-        $(Expr(:tuple, [:(x.indexsets[$i][subidx[$i]]) for i in 1:N]...)), next(x.innerArray,k)[2]
-    end
-
-if VERSION < v"0.7-"
-    Base.next(it::KeyIterator, k) = __next(it.x,k::Integer)
-    Base.done(it::KeyIterator, k) = done(it.x.innerArray, k::Integer)
-else
-    function Base.iterate(it::KeyIterator, k)
-        iterate(it.x.innerArray, k::Integer) ≡ nothing && (return nothing)
-        __next(it.x, k::Integer)
-    end
-end
-
-Base.length(it::KeyIterator)  = length(it.x.innerArray)
+Base.length(it::KeyIterator)  = length(it.inner)

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -219,6 +219,19 @@ end
         @test_throws ErrorException z[end]
     end
 
+    @testset "Key iterators of JuMPContainers" begin
+        m = Model()
+        @variable(m, x[2:3, 1:2])
+        @variable(m, y[2:3])
+        @variable(m, z[-1:1,[:red,"blue"]])
+        @variable(m, w[i=1:2,j=1:2 ; (j+i) % 2 == 1])
+
+        @test all(collect(keys(x)) .== [(2,1), (3,1), (2,2), (3,2)])
+        @test all(collect(keys(y)) .== [(2,), (3,)])
+        @test all(collect(keys(z)) .== [(-1,:red), (0,:red), (1,:red), (-1,"blue"), (0,"blue"), (1,"blue")])
+        @test Set(keys(w)) == Set([(1,2),(2,1)])
+    end
+
     @testset "Unsigned dimension lengths" begin
         m = Model()
         t = UInt(4)

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -226,9 +226,9 @@ end
         @variable(m, z[-1:1,[:red,"blue"]])
         @variable(m, w[i=1:2,j=1:2 ; (j+i) % 2 == 1])
 
-        @test all(collect(keys(x)) .== [(2,1), (3,1), (2,2), (3,2)])
-        @test all(collect(keys(y)) .== [(2,), (3,)])
-        @test all(collect(keys(z)) .== [(-1,:red), (0,:red), (1,:red), (-1,"blue"), (0,"blue"), (1,"blue")])
+        @test collect(keys(x)) == [(2,1), (3,1), (2,2), (3,2)]
+        @test collect(keys(y)) == [(2,), (3,)]
+        @test collect(keys(z)) .== [(-1,:red), (0,:red), (1,:red), (-1,"blue"), (0,"blue"), (1,"blue")]
         @test Set(keys(w)) == Set([(1,2),(2,1)])
     end
 


### PR DESCRIPTION
`KeyIterator`s in the 0.18 release which are created by calling `keys(b)` on a `JuMPArray` `b` are broken on Julia 0.7+, as illustrated by the tests added in the first commit.

```julia
   @testset "Key iterators of JuMPContainers" begin
       m = Model()
       @variable(m, x[2:3, 1:2])
       @variable(m, y[2:3])
       @variable(m, z[-1:1,[:red,"blue"]])
       @variable(m, w[i=1:2,j=1:2 ; (j+i) % 2 == 1])

       @test all(collect(keys(x)) .== [(2,1), (3,1), (2,2), (3,2)])
       @test all(collect(keys(y)) .== [(2,), (3,)])
       @test all(collect(keys(z)) .== [(-1,:red), (0,:red), (1,:red), (-1,"blue"), (0,"blue"), (1,"blue")])
       @test all(collect(keys(w)) .== [(1,2),(2,1)])
    end
```

The tests on variables `x` to `z` throw a `MethodError`, since the used __next function refers to the deprecated `next` function:
```
Key iterators of JuMPContainers: Error During Test at /home/coroa/.julia/dev/JuMP/test/variable.jl:229
  Test threw exception MethodError(next, ( x[2,1]  x[2,2]
 x[3,1]  x[3,2], 2), 0x0000000000006c5c)
  Expression: all(collect(keys(x)) .== [(2, 1), (3, 1), (2, 2), (3, 2)])
  MethodError: no method matching next(::Array{Variable,2}, ::Int64)
  Closest candidates are:
    next(::I, !Matched::Base.LegacyIterationCompat{I,T,S}) where {I, T, S} at essentials.jl:887
    next(!Matched::Union{Process, ProcessChain}, ::Int64) at deprecated.jl:199
    next(!Matched::AbstractString, ::Integer) at deprecated.jl:53
  Stacktrace:
   [1] __next(::JuMP.JuMPArray{Variable,2,Tuple{UnitRange{Int64},UnitRange{Int64}}}, ::Int64) at /home/coroa/.julia/dev/JuMP/src/JuMPContainer.jl:346
   [2] iterate at /home/coroa/.julia/dev/JuMP/src/JuMPContainer.jl:355 [inlined]
   [3] copyto!(::Array{Any,1}, ::JuMP.KeyIterator{JuMP.JuMPArray{Variable,2,Tuple{UnitRange{Int64},UnitRange{Int64}}}}) at ./abstractarray.jl:658
   [4] _collect at ./array.jl:563 [inlined]
   [5] collect(::JuMP.KeyIterator{JuMP.JuMPArray{Variable,2,Tuple{UnitRange{Int64},UnitRange{Int64}}}}) at ./array.jl:557
   [6] macro expansion at /home/coroa/.julia/dev/JuMP/src/macros.jl:340 [inlined]
   [7] macro expansion at /home/coroa/.julia/dev/JuMP/src/macros.jl:285 [inlined]
   [8] macro expansion at /home/coroa/.julia/dev/JuMP/test/variable.jl:24 [inlined]
   [9] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v0.7/Test/src/Test.jl:1079 [inlined]
   [10] macro expansion at /home/coroa/.julia/dev/JuMP/test/variable.jl:23 [inlined]
   [11] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v0.7/Test/src/Test.jl:1079 [inlined]
   [12] top-level scope at /home/coroa/.julia/dev/JuMP/test/variable.jl:21
```

The second commit refactors `KeyIterator` based on the `product` iterator in `Base.Iterators`.