### PR TITLE
✨ Add objective_function_type

### DIFF
--- a/docs/src/objective.md
+++ b/docs/src/objective.md
@@ -14,6 +14,7 @@ Querying the objective function and objective sense:
 ```@docs
 JuMP.objective_sense
 JuMP.objective_function
+JuMP.objective_function_type
 ```
 
 Querying the objective value and bound:

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -283,6 +283,10 @@ function AffExpr(m::Model, f::MOI.ScalarAffineFunction)
     aff.constant = f.constant
     return aff
 end
+function jump_function_type(::AbstractModel,
+                            ::Type{MOI.ScalarAffineFunction{T}}) where T
+    return GenericAffExpr{T, VariableRef}
+end
 function jump_function(model::AbstractModel, f::MOI.ScalarAffineFunction)
     return AffExpr(model, f)
 end

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -79,8 +79,19 @@ function set_objective(model::Model, sense::MOI.OptimizationSense,
     set_objective_function(model, func)
 end
 
+""""
+    objective_function_type(model::Model)::AbstractJuMPScalar
+
+Return the type of the objective function.
 """
-    objective_function(m::Model, T::Type{<:AbstractJuMPScalar})
+function objective_function_type(model::Model)
+    jump_function_type(model,
+                       MOI.get(backend(model), MOI.ObjectiveFunctionType()))
+end
+
+"""
+    objective_function(model::Model,
+                   T::Type{<:AbstractJuMPScalar}=objective_function_type(model))
 
 Return an object of type `T` representing the objective function.
 Error if the objective is not convertible to type `T`.
@@ -129,7 +140,8 @@ Stacktrace:
  [7] top-level scope at none:0
 ```
 """
-function objective_function(model::Model, FunType::Type{<:AbstractJuMPScalar})
+function objective_function(model::Model,
+             FunType::Type{<:AbstractJuMPScalar}=objective_function_type(model))
     MOIFunType = moi_function_type(FunType)
     func = MOI.get(backend(model),
                    MOI.ObjectiveFunction{MOIFunType}())::MOIFunType

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -231,6 +231,10 @@ function QuadExpr(m::Model, f::MOI.ScalarQuadraticFunction)
     end
     return quad
 end
+function jump_function_type(::AbstractModel,
+                            ::Type{MOI.ScalarQuadraticFunction{T}}) where T
+    return GenericQuadExpr{T, VariableRef}
+end
 function jump_function(model::AbstractModel, aff::MOI.ScalarQuadraticFunction)
     return QuadExpr(model, aff)
 end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -242,6 +242,7 @@ function jump_function(model::AbstractModel, variables::MOI.VectorOfVariables)
 end
 
 VariableRef(m::Model, f::MOI.SingleVariable) = VariableRef(m, f.variable)
+jump_function_type(::AbstractModel, ::Type{MOI.SingleVariable}) = VariableRef
 function jump_function(model::AbstractModel, variable::MOI.SingleVariable)
     return VariableRef(model, variable)
 end

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -222,12 +222,15 @@ JuMP.objective_sense(model::MyModel) = model.objectivesense
 function JuMP.set_objective_sense(model::MyModel, sense)
     model.objectivesense = sense
 end
-function JuMP.objective_function(m::MyModel, FT::Type)
+JuMP.objective_function_type(model::MyModel) = typeof(model.objective_function)
+JuMP.objective_function(model::MyModel) = model.objective_function
+function JuMP.objective_function(model::MyModel, FT::Type)
     # InexactError should be thrown, this is needed in `objective.jl`
-    if !(m.objective_function isa FT)
-        throw(InexactError(:objective_function, FT, typeof(m.objective_function)))
+    if !(model.objective_function isa FT)
+        throw(InexactError(:objective_function, FT,
+                           typeof(model.objective_function)))
     end
-    m.objective_function
+    model.objective_function
 end
 
 # Names

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -23,10 +23,14 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
 
         @objective(m, Min, x)
         @test JuMP.objective_sense(m) == MOI.MinSense
+        @test JuMP.objective_function_type(m) == VariableRefType
+        @test JuMP.objective_function(m) == x
         @test JuMP.objective_function(m, VariableRefType) == x
 
         @objective(m, Max, x)
         @test JuMP.objective_sense(m) == MOI.MaxSense
+        @test JuMP.objective_function_type(m) == VariableRefType
+        @test JuMP.objective_function(m) == x
         @test JuMP.objective_function(m, VariableRefType) == x
     end
 
@@ -36,10 +40,14 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
 
         @objective(m, Min, 2x)
         @test JuMP.objective_sense(m) == MOI.MinSense
+        @test JuMP.objective_function_type(m) == AffExprType
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), 2x)
         @test JuMP.isequal_canonical(JuMP.objective_function(m, AffExprType), 2x)
 
         @objective(m, Max, x + 3x + 1)
         @test JuMP.objective_sense(m) == MOI.MaxSense
+        @test JuMP.objective_function_type(m) == AffExprType
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x + 1)
         @test JuMP.isequal_canonical(JuMP.objective_function(m, AffExprType), 4x + 1)
     end
 
@@ -49,6 +57,8 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
 
         @objective(m, Min, x^2 + 2x)
         @test JuMP.objective_sense(m) == MOI.MinSense
+        @test JuMP.objective_function_type(m) == QuadExprType
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), x^2 + 2x)
         @test JuMP.isequal_canonical(JuMP.objective_function(m, QuadExprType), x^2 + 2x)
         @test_throws InexactError JuMP.objective_function(m, AffExprType)
     end


### PR DESCRIPTION
This allows to call `JuMP.objective_function(model)` without a second argument.
This was made possible by the addition of `ObjectiveFunctionType` in MOI.