### PR TITLE
Style: naming for enums

### DIFF
--- a/docs/src/style.md
+++ b/docs/src/style.md
@@ -141,6 +141,7 @@ module SomeModule end
 function some_function end
 const SOME_CONSTANT = ...
 struct SomeStruct end
+@enum SomeEnum ENUM_VALUE_A ENUM_VALUE_B
 some_local_variable = ...
 some_file.jl # Except for ModuleName.jl.
 ```


### PR DESCRIPTION
I noticed an inconsistency in how we name enum values. They should be named like constants (all caps).