### PR TITLE
🚸 Add deprecations for JuMP v0.18 functions

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -43,6 +43,17 @@ export
     @objective, @NLobjective,
     @NLparameter, @constraintref
 
+# Deprecations for JuMP v0.18 -> JuMP v0.19 transition
+Base.@deprecate(solve,             JuMP.optimize!)
+Base.@deprecate(getobjectivevalue, JuMP.objective_value)
+Base.@deprecate(getobjectivebound, JuMP.objective_bound)
+Base.@deprecate(getvalue,          JuMP.value)
+Base.@deprecate(getdual,           JuMP.dual)
+Base.@deprecate(numvar,            JuMP.num_variables)
+Base.@deprecate(numnlconstr,       JuMP.num_nl_constraints)
+Base.@deprecate(setlowerbound,     JuMP.set_lower_bound)
+Base.@deprecate(setupperbound,     JuMP.set_upper_bound)
+Base.@deprecate(linearterms,       JuMP.linear_terms)
 
 include("utils.jl")
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -44,7 +44,6 @@ export
     @NLparameter, @constraintref
 
 # Deprecations for JuMP v0.18 -> JuMP v0.19 transition
-Base.@deprecate(solve,             JuMP.optimize!)
 Base.@deprecate(getobjectivevalue, JuMP.objective_value)
 Base.@deprecate(getobjectivebound, JuMP.objective_bound)
 Base.@deprecate(getvalue,          JuMP.value)

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -60,7 +60,7 @@ function solve(::Model)
           "used to return a `Symbol` summarizing the solution while " *
           "`JuMP.optimize!` returns nothing and the status of the solution " *
           "is queried using `JuMP.termination_status`, `JuMP.primal_status` " *
-          "and JuMP.`dual_status`.")
+          "and `JuMP.dual_status`.")
 end
 
 

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -53,6 +53,17 @@ function set_optimizer(model::Model, optimizer_factory::OptimizerFactory;
     MOIU.resetoptimizer!(model, optimizer)
 end
 
+# Deprecation for JuMP v0.18 -> JuMP v0.19 transition
+export solve
+function solve(::Model)
+    error("`solve` has been replaced by `JuMP.optimize!`. Note that `solve` " *
+          "used to return a `Symbol` summarizing the solution while " *
+          "`JuMP.optimize!` returns nothing and the status of the solution " *
+          "is queried using `JuMP.termination_status`, `JuMP.primal_status` " *
+          "and JuMP.`dual_status`.")
+end
+
+
 """
     optimize!(model::Model,
               optimizer_factory::Union{Nothing, OptimizerFactory}=nothing;

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -61,6 +61,9 @@ moi_set(::RotatedSecondOrderCone, dim::Int) = MOI.RotatedSecondOrderCone(dim)
 
 # Deprecation for JuMP v0.18 -> JuMP v0.19 transition
 function LinearAlgebra.norm(::AbstractVector{<:AbstractJuMPScalar})
-    error("`@constraint(model, norm(x) <= t)` should now be written as " *
+    error("JuMP no longer performs automatic transformation of `norm()` ",
+          "expressions into second-order cone constraints. They should now ",
+          "be expressed using the SecondOrderCone() set. For example, ",
+          "`@constraint(model, norm(x) <= t)` should now be written as ",
           "`@constraint(model, [t; x] in SecondOrderCone())`")
 end

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -58,3 +58,9 @@ julia> @constraint(model, [t, x, x-1, x-2] in RotatedSecondOrderCone())
 """
 struct RotatedSecondOrderCone <: AbstractVectorSet end
 moi_set(::RotatedSecondOrderCone, dim::Int) = MOI.RotatedSecondOrderCone(dim)
+
+# Deprecation for JuMP v0.18 -> JuMP v0.19 transition
+function LinearAlgebra.norm(::AbstractVector{<:AbstractJuMPScalar})
+    error("`@constraint(model, norm(x) <= t)` should now be written as " *
+          "`@constraint(model, [t; x] in SecondOrderCone())`")
+end


### PR DESCRIPTION
This should help with the transition.

Closes #1095 