### PR TITLE
Fix bug handling Adjoints in macros

### DIFF
--- a/src/parse_expr.jl
+++ b/src/parse_expr.jl
@@ -285,6 +285,12 @@ function destructive_add!(ex::AbstractArray{<:GenericAffExpr}, c::Number,
     return result
 end
 
+# For cases such as x' * x, broadcasting the ex .+ will cause the Adjoint to be
+# collected into an Array{T, 2}. The easiest way to work around this is to undo
+# the adjoint, perform the operation, and then re-apply the adjoint.
+function destructive_add!(ex::Number, c::Number, x::Adjoint{T, Vector{T}}) where {T}
+    return (ex .+ c * x')'
+end
 
 destructive_add!(ex, c, x) = ex .+ c * x
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -274,15 +274,14 @@ end
     @testset "Adjoints" begin
         model = Model()
         @variable(model, x[1:2])
-        Q = [1.0 0.0; 0.0 1.0]
-        obj = @objective(model, Min, x' * Q * x)
-        @test JuMP.isequal_canonical(obj, sum(x.^2))
-        cref = @constraint(model, x' * Q * x <= 1)
+        obj = @objective(model, Min, x' * ones(2, 2) * x)
+        @test JuMP.isequal_canonical(obj, x[1]^2 + 2 * x[1] * x[2] + x[2]^2)
+        cref = @constraint(model, x' * ones(2, 2) * x <= 1)
         c = JuMP.constraint_object(cref)
-        @test JuMP.isequal_canonical(c.func, sum(x.^2))
+        @test JuMP.isequal_canonical(c.func, x[1]^2 + 2 * x[1] * x[2] + x[2]^2)
         @test c.set == MOI.LessThan(1.0)
         @test JuMP.isequal_canonical(
-            JuMP.destructive_add!(0.0, x', Q), (1.0 .* x)'
+            JuMP.destructive_add!(0.0, x', ones(2, 2)), x' * ones(2, 2)
         )
     end
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -270,6 +270,17 @@ end
             "DenseAxisArray, or SparseAxisArray.")
         @test_throws exception @variable(model, x[1:3], container=Oops)
     end
+
+    @testset "Adjoints" begin
+        model = Model()
+        @variable(model, x[1:2])
+        obj = @objective(model, Min, x' * x)
+        @test obj == sum(x.^2)
+        cref = @constraint(model, x' * x <= 1)
+        c = JuMP.constraint_object(cref)
+        @test JuMP.isequal_canonical(c.func, sum(x.^2))
+        @test c.set == MOI.LessThan(1.0)
+    end
 end
 
 @testset "Macros for JuMPExtension.MyModel" begin

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -274,12 +274,16 @@ end
     @testset "Adjoints" begin
         model = Model()
         @variable(model, x[1:2])
-        obj = @objective(model, Min, x' * x)
-        @test obj == sum(x.^2)
-        cref = @constraint(model, x' * x <= 1)
+        Q = [1.0 0.0; 0.0 1.0]
+        obj = @objective(model, Min, x' * Q * x)
+        @test JuMP.isequal_canonical(obj, sum(x.^2))
+        cref = @constraint(model, x' * Q * x <= 1)
         c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func, sum(x.^2))
         @test c.set == MOI.LessThan(1.0)
+        @test JuMP.isequal_canonical(
+            JuMP.destructive_add!(0.0, x', Q), (1.0 .* x)'
+        )
     end
 end
 


### PR DESCRIPTION
Not sure if this is the best way to achieve this, but it seems to work.

Closes #1667.