### PR TITLE
✅ Fix JuMPExtension print tests

### DIFF
--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -71,6 +71,20 @@ mutable struct NLPData
     evaluator
 end
 
+"""
+    nlp_objective_function(model::Model)
+
+Returns the nonlinear objective function or `nothing` if no nonlinear objective
+function is set.
+"""
+function nlp_objective_function(model::Model)
+    if model.nlp_data isa Nothing
+        return nothing
+    else
+        return model.nlp_data.nlobj
+    end
+end
+
 function create_nlp_block_data(m::Model)
     @assert m.nlp_data !== nothing
     bounds = MOI.NLPBoundsPair[]

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -78,7 +78,7 @@ Returns the nonlinear objective function or `nothing` if no nonlinear objective
 function is set.
 """
 function nlp_objective_function(model::Model)
-    if model.nlp_data isa Nothing
+    if model.nlp_data === nothing
         return nothing
     else
         return model.nlp_data.nlobj

--- a/src/print.jl
+++ b/src/print.jl
@@ -163,13 +163,7 @@ function Base.show(io::IO, model::AbstractModel)
     println(io, "Variable", plural(num_variables(model)), ": ",
             num_variables(model))
     if sense != MOI.FEASIBILITY_SENSE
-        nlobj = nlp_objective_function(model)
-        if nlobj === nothing
-            println(io, "Objective function type: ",
-                    objective_function_type(model))
-        else
-            println(io, "Objective function type: Nonlinear")
-        end
+        show_objective_function_summary(io, model)
     end
     show_constraints_summary(io, model)
     show_backend_summary(io, model)
@@ -216,12 +210,7 @@ function model_string(print_mode, model::AbstractModel)
             str *= "\\quad"
         end
         str *= sep
-        nlobj = nlp_objective_function(model)
-        if nlobj === nothing
-            str *= function_string(print_mode, objective_function(model))
-        else
-            str *= nl_expr_string(model, print_mode, nlobj)
-        end
+        str *= objective_function_string(print_mode, model)
     end
     str *= eol
     str *= ijl ? "\\text{Subject to} \\quad" : "Subject to" * eol
@@ -230,6 +219,24 @@ function model_string(print_mode, model::AbstractModel)
         str = "\\begin{alignat*}{1}" * str * "\\end{alignat*}\n"
     end
     return str
+end
+
+function show_objective_function_summary(io::IO, model::Model)
+    nlobj = nlp_objective_function(model)
+    print(io, "Objective function type: ")
+    if nlobj === nothing
+        println(io, objective_function_type(model))
+    else
+        println(io, "Nonlinear")
+    end
+end
+function objective_function_string(print_mode, model::Model)
+   nlobj = nlp_objective_function(model)
+   if nlobj === nothing
+       return function_string(print_mode, objective_function(model))
+   else
+       return nl_expr_string(model, print_mode, nlobj)
+   end
 end
 
 #------------------------------------------------------------------------

--- a/src/print.jl
+++ b/src/print.jl
@@ -164,7 +164,7 @@ function Base.show(io::IO, model::AbstractModel)
             num_variables(model))
     if sense != MOI.FEASIBILITY_SENSE
         nlobj = nlp_objective_function(model)
-        if nlobj isa Nothing
+        if nlobj === nothing
             println(io, "Objective function type: ",
                     objective_function_type(model))
         else

--- a/src/print.jl
+++ b/src/print.jl
@@ -377,7 +377,7 @@ function constraints_string(print_mode, model::Model, sep, eol)
             str *= sep * constraint_string(print_mode, con) * eol
         end
     end
-    if model isa Model && model.nlp_data !== nothing
+    if model.nlp_data !== nothing
         for nl_constraint in model.nlp_data.nlconstr
             str *= sep * nl_constraint_string(model, print_mode, nl_constraint)
             str *= eol

--- a/src/print.jl
+++ b/src/print.jl
@@ -148,6 +148,9 @@ plural(n) = (n==1 ? "" : "s")
 #------------------------------------------------------------------------
 ## Model
 #------------------------------------------------------------------------
+
+# An `AbstractModel` subtype should implement `show_objective_function_summary`,
+# `show_constraints_summary` and `show_backend_summary` for this method to work.
 function Base.show(io::IO, model::AbstractModel)
     println(io, "A JuMP Model")
     sense = objective_sense(model)
@@ -192,6 +195,9 @@ end
 function Base.show(io::IO, ::MIME"text/latex", model::AbstractModel)
     print(io, wrap_in_math_mode(model_string(IJuliaMode, model)))
 end
+
+# An `AbstractModel` subtype should implement `objective_function_string` and
+# `constraints_string` for this method to work.
 function model_string(print_mode, model::AbstractModel)
     ijl = print_mode == IJuliaMode
     sep = ijl ? " & " : " "

--- a/src/print.jl
+++ b/src/print.jl
@@ -354,6 +354,11 @@ end
 ## Constraints
 #------------------------------------------------------------------------
 
+"""
+    show_constraints_summary(io::IO, model::Model)
+
+Write to `io` a summary of the number of constraints.
+"""
 function show_constraints_summary(io::IO, model::Model)
     for (F, S) in MOI.get(model, MOI.ListOfConstraints())
         num_constraints = MOI.get(model, MOI.NumberOfConstraints{F, S}())
@@ -366,6 +371,12 @@ function show_constraints_summary(io::IO, model::Model)
     end
 end
 
+"""
+    constraints_string(print_mode, model::Model, sep, eol)::String
+
+Return a `String` containing the constraints of the model, each on a line
+starting with `sep` and ending with `eol` (which already contains `\n`).
+"""
 function constraints_string(print_mode, model::Model, sep, eol)
     str = ""
     for (F, S) in MOI.get(model, MOI.ListOfConstraints())

--- a/src/print.jl
+++ b/src/print.jl
@@ -221,6 +221,11 @@ function model_string(print_mode, model::AbstractModel)
     return str
 end
 
+"""
+    show_objective_function_summary(io::IO, model::AbstractModel)
+
+Write to `io` a summary of the objective function type.
+"""
 function show_objective_function_summary(io::IO, model::Model)
     nlobj = nlp_objective_function(model)
     print(io, "Objective function type: ")
@@ -230,6 +235,12 @@ function show_objective_function_summary(io::IO, model::Model)
         println(io, "Nonlinear")
     end
 end
+
+"""
+    objective_function_string(print_mode, model::AbstractModel)::String
+
+Return a `String` describing the objective function of the model.
+"""
 function objective_function_string(print_mode, model::Model)
    nlobj = nlp_objective_function(model)
    if nlobj === nothing
@@ -362,7 +373,7 @@ end
 #------------------------------------------------------------------------
 
 """
-    show_constraints_summary(io::IO, model::Model)
+    show_constraints_summary(io::IO, model::AbstractModel)
 
 Write to `io` a summary of the number of constraints.
 """
@@ -379,9 +390,9 @@ function show_constraints_summary(io::IO, model::Model)
 end
 
 """
-    constraints_string(print_mode, model::Model, sep, eol)::String
+    constraints_string(print_mode, model::AbstractModel, sep, eol)::String
 
-Return a `String` containing the constraints of the model, each on a line
+Return a `String` describing the constraints of the model, each on a line
 starting with `sep` and ending with `eol` (which already contains `\n`).
 """
 function constraints_string(print_mode, model::Model, sep, eol)

--- a/src/print.jl
+++ b/src/print.jl
@@ -217,7 +217,7 @@ function model_string(print_mode, model::AbstractModel)
         end
         str *= sep
         nlobj = nlp_objective_function(model)
-        if nlobj isa Nothing
+        if nlobj === nothing
             str *= function_string(print_mode, objective_function(model))
         else
             str *= nl_expr_string(model, print_mode, nlobj)

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -219,6 +219,7 @@ function JuMP.constraint_object(cref::MyConstraintRef)
 end
 
 # Objective
+JuMP.nlp_objective_function(::MyModel) = nothing
 function JuMP.set_objective(m::MyModel, sense::MOI.OptimizationSense,
                             f::JuMP.AbstractJuMPScalar)
     m.objectivesense = sense
@@ -297,6 +298,22 @@ function JuMP.constraint_by_name(model::MyModel, name::String)
         # or a scalar constraint
         return JuMP.ConstraintRef(model, index, JuMP.ScalarShape())
     end
+end
+
+# Show
+function JuMP.show_constraints_summary(io::IO, model::MyModel)
+    n = length(model.constraints)
+    print(io, "Constraint", JuMP.plural(n), ": ", n)
+end
+function JuMP.show_backend_summary(io::IO, model::MyModel) end
+function JuMP.constraints_string(print_mode, model::MyModel, sep, eol)
+    str = ""
+    # Sort by creation order, i.e. ConstraintIndex value
+    constraints = sort(collect(model.constraints), by = c -> c.first.value)
+    for (index, constraint) in constraints
+        str *= sep * JuMP.constraint_string(print_mode, constraint) * eol
+    end
+    return str
 end
 
 end

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -219,7 +219,6 @@ function JuMP.constraint_object(cref::MyConstraintRef)
 end
 
 # Objective
-JuMP.nlp_objective_function(::MyModel) = nothing
 function JuMP.set_objective(m::MyModel, sense::MOI.OptimizationSense,
                             f::JuMP.AbstractJuMPScalar)
     m.objectivesense = sense
@@ -301,11 +300,18 @@ function JuMP.constraint_by_name(model::MyModel, name::String)
 end
 
 # Show
+function JuMP.show_backend_summary(io::IO, model::MyModel) end
+function JuMP.show_objective_function_summary(io::IO, model::MyModel)
+    println(io, "Objective function type: ",
+            JuMP.objective_function_type(model))
+end
+function JuMP.objective_function_string(print_mode, model::MyModel)
+    return JuMP.function_string(print_mode, JuMP.objective_function(model))
+end
 function JuMP.show_constraints_summary(io::IO, model::MyModel)
     n = length(model.constraints)
     print(io, "Constraint", JuMP.plural(n), ": ", n)
 end
-function JuMP.show_backend_summary(io::IO, model::MyModel) end
 function JuMP.constraints_string(print_mode, model::MyModel, sep, eol)
     str = ""
     # Sort by creation order, i.e. ConstraintIndex value

--- a/test/print.jl
+++ b/test/print.jl
@@ -202,17 +202,7 @@ end
     end
 end
 
-"""
-    printing_test(ModelType::Type{<:JuMP.AbstractModel},
-                  moi_backend::Bool)
-
-Test printing of models of type `ModelType`. The expected model printing depends
-on `moi_backend` which indicates whether the model is stored in an MOI backend
-or is stored in its JuMP form (i.e. as `AbstractVariable`s,
-`AbstractConstraint`s and `AbstractJuMPScalar` for the objective function).
-"""
-function printing_test(ModelType::Type{<:JuMP.AbstractModel},
-                       moi_backend::Bool)
+function printing_test(ModelType::Type{<:JuMP.AbstractModel})
     @testset "VariableRef" begin
         m = ModelType()
         @variable(m, 0 <= x <= 2)
@@ -346,6 +336,11 @@ function printing_test(ModelType::Type{<:JuMP.AbstractModel},
         io_test(REPLMode, quad_constr, "2 x$sq $le 1.0")
         # TODO: Test in IJulia mode.
     end
+end
+
+# Test printing of models of type `ModelType` for which the model is stored in
+# an MOI backend
+function model_printing_test(ModelType::Type{<:JuMP.AbstractModel})
     @testset "Model" begin
         repl(s) = JuMP.math_symbol(REPLMode, s)
         le, ge, eq, fa = repl(:leq), repl(:geq), repl(:eq), repl(:for_all)
@@ -375,105 +370,73 @@ function printing_test(ModelType::Type{<:JuMP.AbstractModel},
 
         VariableType = typeof(a)
 
-        if moi_backend
-            io_test(REPLMode, model_1, """
-        Max a - b + 2 a1 - 10 x
-        Subject to
-         x binary
-         u[1] binary
-         u[2] binary
-         u[3] binary
-         a1 integer
-         b1 integer
-         c1 integer
-         z integer
-         fi $eq 9.0
-         a $ge 1.0
-         c $ge -1.0
-         a1 $ge 1.0
-         c1 $ge -1.0
-         b $le 1.0
-         c $le 1.0
-         b1 $le 1.0
-         c1 $le 1.0
-         a + b - 10 c - 2 x + c1 $le 1.0
-         a*b $le 2.0
-         [-a + 1, u[1], u[2], u[3]] $inset MathOptInterface.SecondOrderCone(4)
-        """, repl=:print)
-        else
-            # TODO variable constraints
-            io_test(REPLMode, model_1, """
-        Max a - b + 2 a1 - 10 x
-        Subject to
-         a + b - 10 c - 2 x + c1 $le 1.0
-         a*b $le 2.0
-         [-a + 1, u[1], u[2], u[3]] $inset MathOptInterface.SecondOrderCone(4)
-        """, repl=:print)
-        end
+        io_test(REPLMode, model_1, """
+    Max a - b + 2 a1 - 10 x
+    Subject to
+     x binary
+     u[1] binary
+     u[2] binary
+     u[3] binary
+     a1 integer
+     b1 integer
+     c1 integer
+     z integer
+     fi $eq 9.0
+     a $ge 1.0
+     c $ge -1.0
+     a1 $ge 1.0
+     c1 $ge -1.0
+     b $le 1.0
+     c $le 1.0
+     b1 $le 1.0
+     c1 $le 1.0
+     a + b - 10 c - 2 x + c1 $le 1.0
+     a*b $le 2.0
+     [-a + 1, u[1], u[2], u[3]] $inset MathOptInterface.SecondOrderCone(4)
+    """, repl=:print)
 
+        io_test(REPLMode, model_1, """
+    A JuMP Model
+    Maximization problem with:
+    Variables: 13
+    Objective function type: JuMP.GenericAffExpr{Float64,$VariableType}
+    `MathOptInterface.SingleVariable`-in-`MathOptInterface.ZeroOne`: 4 constraints
+    `MathOptInterface.SingleVariable`-in-`MathOptInterface.Integer`: 4 constraints
+    `MathOptInterface.SingleVariable`-in-`MathOptInterface.EqualTo{Float64}`: 1 constraint
+    `MathOptInterface.SingleVariable`-in-`MathOptInterface.GreaterThan{Float64}`: 4 constraints
+    `MathOptInterface.SingleVariable`-in-`MathOptInterface.LessThan{Float64}`: 4 constraints
+    `MathOptInterface.ScalarAffineFunction{Float64}`-in-`MathOptInterface.LessThan{Float64}`: 1 constraint
+    `MathOptInterface.ScalarQuadraticFunction{Float64}`-in-`MathOptInterface.LessThan{Float64}`: 1 constraint
+    `MathOptInterface.VectorAffineFunction{Float64}`-in-`MathOptInterface.SecondOrderCone`: 1 constraint
+    Model mode: AUTOMATIC
+    CachingOptimizer state: NO_OPTIMIZER
+    Solver name: No optimizer attached.
+    Names registered in the model: a, a1, b, b1, c, c1, fi, u, x, y, z""", repl=:show)
 
-        if moi_backend
-            io_test(REPLMode, model_1, """
-        A JuMP Model
-        Maximization problem with:
-        Variables: 13
-        Objective function type: JuMP.GenericAffExpr{Float64,$VariableType}
-        `MathOptInterface.SingleVariable`-in-`MathOptInterface.ZeroOne`: 4 constraints
-        `MathOptInterface.SingleVariable`-in-`MathOptInterface.Integer`: 4 constraints
-        `MathOptInterface.SingleVariable`-in-`MathOptInterface.EqualTo{Float64}`: 1 constraint
-        `MathOptInterface.SingleVariable`-in-`MathOptInterface.GreaterThan{Float64}`: 4 constraints
-        `MathOptInterface.SingleVariable`-in-`MathOptInterface.LessThan{Float64}`: 4 constraints
-        `MathOptInterface.ScalarAffineFunction{Float64}`-in-`MathOptInterface.LessThan{Float64}`: 1 constraint
-        `MathOptInterface.ScalarQuadraticFunction{Float64}`-in-`MathOptInterface.LessThan{Float64}`: 1 constraint
-        `MathOptInterface.VectorAffineFunction{Float64}`-in-`MathOptInterface.SecondOrderCone`: 1 constraint
-        Model mode: AUTOMATIC
-        CachingOptimizer state: NO_OPTIMIZER
-        Solver name: No optimizer attached.
-        Names registered in the model: a, a1, b, b1, c, c1, fi, u, x, y, z""", repl=:show)
-        else
-            io_test(REPLMode, model_1, """
-        A JuMP Model
-        Maximization problem with:
-        Variables: 13
-        Objective function type: JuMP.GenericAffExpr{Float64,$VariableType}
-        Constraints: 3
-        Names registered in the model: a, a1, b, b1, c, c1, fi, u, x, y, z""", repl=:show)
-        end
-
-        if moi_backend
-            io_test(IJuliaMode, model_1, """
-        \\begin{alignat*}{1}\\max\\quad & a - b + 2 a1 - 10 x\\\\
-        \\text{Subject to} \\quad & x binary\\\\
-         & u_{1} binary\\\\
-         & u_{2} binary\\\\
-         & u_{3} binary\\\\
-         & a1 integer\\\\
-         & b1 integer\\\\
-         & c1 integer\\\\
-         & z integer\\\\
-         & fi = 9.0\\\\
-         & a \\geq 1.0\\\\
-         & c \\geq -1.0\\\\
-         & a1 \\geq 1.0\\\\
-         & c1 \\geq -1.0\\\\
-         & b \\leq 1.0\\\\
-         & c \\leq 1.0\\\\
-         & b1 \\leq 1.0\\\\
-         & c1 \\leq 1.0\\\\
-         & a + b - 10 c - 2 x + c1 \\leq 1.0\\\\
-         & a\\times b \\leq 2.0\\\\
-         & [-a + 1, u_{1}, u_{2}, u_{3}] \\in MathOptInterface.SecondOrderCone(4)\\\\
-        \\end{alignat*}
-        """)
-        else
-            io_test(IJuliaMode, model_1, """
-        \\begin{alignat*}{1}\\max\\quad & a - b + 2 a1 - 10 x\\\\
-        \\text{Subject to} \\quad & a + b - 10 c - 2 x + c1 \\leq 1.0\\\\
-         & a\\times b \\leq 2.0\\\\
-         & [-a + 1, u_{1}, u_{2}, u_{3}] \\in MathOptInterface.SecondOrderCone(4)\\\\
-        \\end{alignat*}
-        """)
-        end
+        io_test(IJuliaMode, model_1, """
+    \\begin{alignat*}{1}\\max\\quad & a - b + 2 a1 - 10 x\\\\
+    \\text{Subject to} \\quad & x binary\\\\
+     & u_{1} binary\\\\
+     & u_{2} binary\\\\
+     & u_{3} binary\\\\
+     & a1 integer\\\\
+     & b1 integer\\\\
+     & c1 integer\\\\
+     & z integer\\\\
+     & fi = 9.0\\\\
+     & a \\geq 1.0\\\\
+     & c \\geq -1.0\\\\
+     & a1 \\geq 1.0\\\\
+     & c1 \\geq -1.0\\\\
+     & b \\leq 1.0\\\\
+     & c \\leq 1.0\\\\
+     & b1 \\leq 1.0\\\\
+     & c1 \\leq 1.0\\\\
+     & a + b - 10 c - 2 x + c1 \\leq 1.0\\\\
+     & a\\times b \\leq 2.0\\\\
+     & [-a + 1, u_{1}, u_{2}, u_{3}] \\in MathOptInterface.SecondOrderCone(4)\\\\
+    \\end{alignat*}
+    """)
 
         #------------------------------------------------------------------
 
@@ -482,54 +445,121 @@ function printing_test(ModelType::Type{<:JuMP.AbstractModel},
         @variable(model_2, y, Int)
         @constraint(model_2, x*y <= 1)
 
-        if moi_backend
-            io_test(REPLMode, model_2, """
-        A JuMP Model
-        Feasibility problem with:
-        Variables: 2
-        `MathOptInterface.SingleVariable`-in-`MathOptInterface.ZeroOne`: 1 constraint
-        `MathOptInterface.SingleVariable`-in-`MathOptInterface.Integer`: 1 constraint
-        `MathOptInterface.ScalarQuadraticFunction{Float64}`-in-`MathOptInterface.LessThan{Float64}`: 1 constraint
-        Model mode: AUTOMATIC
-        CachingOptimizer state: NO_OPTIMIZER
-        Solver name: No optimizer attached.
-        Names registered in the model: x, y""", repl=:show)
-        else
-            io_test(REPLMode, model_2, """
-        A JuMP Model
-        Feasibility problem with:
-        Variables: 2
-        Constraint: 1
-        Names registered in the model: x, y""", repl=:show)
-        end
+        io_test(REPLMode, model_2, """
+    A JuMP Model
+    Feasibility problem with:
+    Variables: 2
+    `MathOptInterface.SingleVariable`-in-`MathOptInterface.ZeroOne`: 1 constraint
+    `MathOptInterface.SingleVariable`-in-`MathOptInterface.Integer`: 1 constraint
+    `MathOptInterface.ScalarQuadraticFunction{Float64}`-in-`MathOptInterface.LessThan{Float64}`: 1 constraint
+    Model mode: AUTOMATIC
+    CachingOptimizer state: NO_OPTIMIZER
+    Solver name: No optimizer attached.
+    Names registered in the model: x, y""", repl=:show)
+
+        model_3 = ModelType()
+        @variable(model_3, x)
+        @constraint(model_3, x <= 3)
+
+        io_test(REPLMode, model_3, """
+    A JuMP Model
+    Feasibility problem with:
+    Variable: 1
+    `MathOptInterface.ScalarAffineFunction{Float64}`-in-`MathOptInterface.LessThan{Float64}`: 1 constraint
+    Model mode: AUTOMATIC
+    CachingOptimizer state: NO_OPTIMIZER
+    Solver name: No optimizer attached.
+    Names registered in the model: x""", repl=:show)
+    end
+end
+
+# Test printing of models of type `ModelType` for which the model is stored in
+# its JuMP form, e.g., as `AbstractVariable`s and `AbstractConstraint`s.
+function model_extension_printing_test(ModelType::Type{<:JuMP.AbstractModel})
+    @testset "Model" begin
+        repl(s) = JuMP.math_symbol(REPLMode, s)
+        le, ge, eq, fa = repl(:leq), repl(:geq), repl(:eq), repl(:for_all)
+        inset, dots = repl(:in), repl(:dots)
+        infty, union = repl(:infty), repl(:union)
+        Vert, sub2 = repl(:Vert), repl(:sub2)
+        for_all = repl(:for_all)
+
+        #------------------------------------------------------------------
+
+        model_1 = ModelType()
+        @variable(model_1, a>=1)
+        @variable(model_1, b<=1)
+        @variable(model_1, -1<=c<=1)
+        @variable(model_1, a1>=1,Int)
+        @variable(model_1, b1<=1,Int)
+        @variable(model_1, -1<=c1<=1,Int)
+        @variable(model_1, x, Bin)
+        @variable(model_1, y)
+        @variable(model_1, z, Int)
+        @variable(model_1, u[1:3], Bin)
+        @variable(model_1, fi == 9)
+        @objective(model_1, Max, a - b + 2a1 - 10x)
+        @constraint(model_1, a + b - 10c - 2x + c1 <= 1)
+        @constraint(model_1, a*b <= 2)
+        @constraint(model_1, [1 - a; u] in SecondOrderCone())
+
+        VariableType = typeof(a)
+
+        # TODO variable constraints
+        io_test(REPLMode, model_1, """
+    Max a - b + 2 a1 - 10 x
+    Subject to
+     a + b - 10 c - 2 x + c1 $le 1.0
+     a*b $le 2.0
+     [-a + 1, u[1], u[2], u[3]] $inset MathOptInterface.SecondOrderCone(4)
+    """, repl=:print)
+
+        io_test(REPLMode, model_1, """
+    A JuMP Model
+    Maximization problem with:
+    Variables: 13
+    Objective function type: JuMP.GenericAffExpr{Float64,$VariableType}
+    Constraints: 3
+    Names registered in the model: a, a1, b, b1, c, c1, fi, u, x, y, z""", repl=:show)
+
+        io_test(IJuliaMode, model_1, """
+    \\begin{alignat*}{1}\\max\\quad & a - b + 2 a1 - 10 x\\\\
+    \\text{Subject to} \\quad & a + b - 10 c - 2 x + c1 \\leq 1.0\\\\
+     & a\\times b \\leq 2.0\\\\
+     & [-a + 1, u_{1}, u_{2}, u_{3}] \\in MathOptInterface.SecondOrderCone(4)\\\\
+    \\end{alignat*}
+    """)
+
+        #------------------------------------------------------------------
 
         model_2 = ModelType()
-        @variable(model_2, x)
-        @constraint(model_2, x <= 3)
+        @variable(model_2, x, Bin)
+        @variable(model_2, y, Int)
+        @constraint(model_2, x*y <= 1)
 
-        if moi_backend
-            io_test(REPLMode, model_2, """
-        A JuMP Model
-        Feasibility problem with:
-        Variable: 1
-        `MathOptInterface.ScalarAffineFunction{Float64}`-in-`MathOptInterface.LessThan{Float64}`: 1 constraint
-        Model mode: AUTOMATIC
-        CachingOptimizer state: NO_OPTIMIZER
-        Solver name: No optimizer attached.
-        Names registered in the model: x""", repl=:show)
-        else
-            io_test(REPLMode, model_2, """
-        A JuMP Model
-        Feasibility problem with:
-        Variable: 1
-        Constraint: 1
-        Names registered in the model: x""", repl=:show)
-        end
+        io_test(REPLMode, model_2, """
+    A JuMP Model
+    Feasibility problem with:
+    Variables: 2
+    Constraint: 1
+    Names registered in the model: x, y""", repl=:show)
+
+        model_3 = ModelType()
+        @variable(model_3, x)
+        @constraint(model_3, x <= 3)
+
+        io_test(REPLMode, model_3, """
+    A JuMP Model
+    Feasibility problem with:
+    Variable: 1
+    Constraint: 1
+    Names registered in the model: x""", repl=:show)
     end
 end
 
 @testset "Printing for JuMP.Model" begin
-    printing_test(Model, true)
+    printing_test(Model)
+    model_printing_test(Model)
     @testset "Model with nonlinear terms" begin
         eq = JuMP.math_symbol(REPLMode, :eq)
         model = Model()
@@ -574,5 +604,6 @@ end
 end
 
 @testset "Printing for JuMPExtension.MyModel" begin
-    printing_test(JuMPExtension.MyModel, false)
+    printing_test(JuMPExtension.MyModel)
+    model_extension_printing_test(JuMPExtension.MyModel)
 end

--- a/test/print.jl
+++ b/test/print.jl
@@ -202,6 +202,15 @@ end
     end
 end
 
+"""
+    printing_test(ModelType::Type{<:JuMP.AbstractModel},
+                  moi_backend::Bool)
+
+Test printing of models of type `ModelType`. The expected model printing depends
+on `moi_backend` which indicates whether the model is stored in an MOI backend
+or is stored in its JuMP form (i.e. as `AbstractVariable`s,
+`AbstractConstraint`s and `AbstractJuMPScalar` for the objective function).
+"""
 function printing_test(ModelType::Type{<:JuMP.AbstractModel},
                        moi_backend::Bool)
     @testset "VariableRef" begin

--- a/test/print.jl
+++ b/test/print.jl
@@ -475,6 +475,8 @@ end
 
 # Test printing of models of type `ModelType` for which the model is stored in
 # its JuMP form, e.g., as `AbstractVariable`s and `AbstractConstraint`s.
+# This is used by `JuMPExtension` but can also be used by external packages such
+# as `StructJuMP`, see https://github.com/JuliaOpt/JuMP.jl/issues/1711
 function model_extension_printing_test(ModelType::Type{<:JuMP.AbstractModel})
     @testset "Model" begin
         repl(s) = JuMP.math_symbol(REPLMode, s)


### PR DESCRIPTION
The only change in `JuMP.Model` printing done by this PR is that the objective function type displayed is now the JuMP type and not the MOI type but I think it is better that way.

Closes https://github.com/JuliaOpt/JuMP.jl/issues/1710