### PR TITLE
Remove outdated comments

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -618,9 +618,7 @@ function operator_warn(model::Model)
             "performance reasons, you should not add expressions in a loop. " *
             "Instead of x += y, use add_to_expression!(x,y) to modify x in " *
             "place. If y is a single variable, you may also use " *
-            "add_to_expression!(x, coef, y) for x += coef*y.", maxlog=1)
-        # NOTE: On Julia 1.0 (at least), maxlog=1 does not work correctly.
-        # See https://github.com/JuliaLang/julia/issues/28786.
+            "add_to_expression!(x, coef, y) for x += coef*y.", maxlog = 1)
     end
 end
 

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -103,8 +103,6 @@ function copy_model(model::Model)
     # `backend(model` and the indices of `backend(new_model)`.
     index_map = MOI.copy_to(backend(new_model), backend(model),
                             copy_names = true)
-    # TODO copynames is needed because of https://github.com/JuliaOpt/MathOptInterface.jl/issues/494
-    #      we can remove it when this is fixed and released
 
     copy_single_variable_constraints(new_model.variable_to_lower_bound,
                                   model.variable_to_lower_bound, index_map)


### PR DESCRIPTION
We retain `copy_names = true` for explicitness.

Closes #1715 