### PR TITLE
Fix spelling of language

### DIFF
--- a/test/model.jl
+++ b/test/model.jl
@@ -4,7 +4,7 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #############################################################################
 # JuMP
-# An algebraic modeling langauge for Julia
+# An algebraic modeling language for Julia
 # See http://github.com/JuliaOpt/JuMP.jl
 #############################################################################
 # test/model.jl

--- a/test/nlp_solver.jl
+++ b/test/nlp_solver.jl
@@ -4,7 +4,7 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #############################################################################
 # JuMP
-# An algebraic modelling langauge for Julia
+# An algebraic modelling language for Julia
 # See http://github.com/JuliaOpt/JuMP.jl
 #############################################################################
 # Hock-Schittkowski Nonlinear Test Suite

--- a/test/old/expr.jl
+++ b/test/old/expr.jl
@@ -4,7 +4,7 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #############################################################################
 # JuMP
-# An algebraic modeling langauge for Julia
+# An algebraic modeling language for Julia
 # See http://github.com/JuliaOpt/JuMP.jl
 #############################################################################
 # test/expr.jl

--- a/test/old/model.jl
+++ b/test/old/model.jl
@@ -4,7 +4,7 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #############################################################################
 # JuMP
-# An algebraic modeling langauge for Julia
+# An algebraic modeling language for Julia
 # See http://github.com/JuliaOpt/JuMP.jl
 #############################################################################
 # test/model.jl

--- a/test/old/nonlinear.jl
+++ b/test/old/nonlinear.jl
@@ -4,7 +4,7 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #############################################################################
 # JuMP
-# An algebraic modeling langauge for Julia
+# An algebraic modeling language for Julia
 # See http://github.com/JuliaOpt/JuMP.jl
 #############################################################################
 # test/nonlinear.jl

--- a/test/old/print.jl
+++ b/test/old/print.jl
@@ -4,7 +4,7 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #############################################################################
 # JuMP
-# An algebraic modeling langauge for Julia
+# An algebraic modeling language for Julia
 # See http://github.com/JuliaOpt/JuMP.jl
 #############################################################################
 # test/print.jl

--- a/test/print.jl
+++ b/test/print.jl
@@ -4,7 +4,7 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #############################################################################
 # JuMP
-# An algebraic modeling langauge for Julia
+# An algebraic modeling language for Julia
 # See http://github.com/JuliaOpt/JuMP.jl
 #############################################################################
 # test/print.jl

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #############################################################################
 # JuMP
-# An algebraic modeling langauge for Julia
+# An algebraic modeling language for Julia
 # See http://github.com/JuliaOpt/JuMP.jl
 #############################################################################
 # test/runtests.jl

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -4,7 +4,7 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #############################################################################
 # JuMP
-# An algebraic modeling langauge for Julia
+# An algebraic modeling language for Julia
 # See http://github.com/JuliaOpt/JuMP.jl
 #############################################################################
 # test/utilities.jl

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -4,7 +4,7 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #############################################################################
 # JuMP
-# An algebraic modeling langauge for Julia
+# An algebraic modeling language for Julia
 # See http://github.com/JuliaOpt/JuMP.jl
 #############################################################################
 # test/variable.jl


### PR DESCRIPTION
@IainNZ was responsible for this cracker a very long time ago: https://github.com/JuliaOpt/JuMP.jl/commit/7e49d65b4c80cdb25c0a18ed7741e9dbb4eadbfb

I kinda feel like we should leave it in perpetuity.

There are some other instances in the examples, but they are fixed in #1712.