### PR TITLE
Enable test/expr for extension models (excluding copy)

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -455,9 +455,11 @@ function verify_ownership(m::Model, vec::Vector{VariableRef})
 end
 
 Base.copy(v::VariableRef, new_model::Model) = VariableRef(new_model, v.index)
-Base.copy(x::Nothing, new_model::Model) = nothing
+Base.copy(x::Nothing, new_model::AbstractModel) = nothing
 # TODO: Replace with vectorized copy?
-Base.copy(v::AbstractArray{VariableRef}, new_model::Model) = (var -> VariableRef(new_model, var.index)).(v)
+function Base.copy(v::AbstractArray{VariableRef}, new_model::AbstractModel)
+    return (var -> VariableRef(new_model, var.index)).(v)
+end
 
 function optimizer_index(v::VariableRef)
     model = owner_model(v)

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -330,7 +330,7 @@ end
 
 # Copy an affine expression to a new model by converting all the
 # variables to the new model's variables
-function Base.copy(a::GenericAffExpr, new_model::Model)
+function Base.copy(a::GenericAffExpr, new_model::AbstractModel)
     result = zero(a)
     for (coef, var) in linear_terms(a)
         add_to_expression!(result, coef, copy(var, new_model))

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -46,6 +46,8 @@ struct MyVariableRef <: JuMP.AbstractVariableRef
     idx::Int       # Index in `model.variables`
 end
 Base.copy(v::MyVariableRef) = v
+Base.copy(v::MyVariableRef, new_model::MyModel) = MyVariableRef(new_model, v.idx)
+
 Base.:(==)(v::MyVariableRef, w::MyVariableRef) = v.model === w.model && v.idx == w.idx
 Base.broadcastable(v::MyVariableRef) = Ref(v)
 JuMP.isequal_canonical(v::MyVariableRef, w::MyVariableRef) = v == w

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -11,25 +11,25 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
     QuadExprType = JuMP.GenericQuadExpr{Float64, VariableRefType}
 
     @testset "isequal(::GenericAffExpr)" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test isequal(x + 1, x + 1)
     end
 
     @testset "hash(::GenericAffExpr)" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test hash(x + 1) == hash(x + 1)
     end
 
     @testset "isequal(::GenericQuadExpr)" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test isequal(x^2 + 1, x^2 + 1)
     end
 
     @testset "hash(::GenericQuadExpr)" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test hash(x^2 + 1) == hash(x^2 + 1)
     end
@@ -68,7 +68,7 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
     end
 
     @testset "linear_terms(::AffExpr)" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x[1:10])
 
         aff = 1*x[1] + 2*x[2]
@@ -97,15 +97,6 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
         @test k == 0
     end
 
-    @testset "Copy AffExpr between models" begin
-        m = Model()
-        @variable(m, x)
-        m2 = Model()
-        aff = copy(2x + 1, m2)
-        aff_expected = 2*copy(x, m2) + 1
-        @test JuMP.isequal_canonical(aff, aff_expected)
-    end
-
     @testset "destructive_add!(ex::Number, c::Number, x::GenericAffExpr)" begin
         aff = JuMP.destructive_add!(1.0, 2.0, JuMP.GenericAffExpr(1.0, :a => 1.0))
         @test JuMP.isequal_canonical(aff, JuMP.GenericAffExpr(3.0, :a => 2.0))
@@ -117,116 +108,116 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
     end
 
     @testset "destructive_add!(ex::Number, c::VariableRef, x::VariableRef)" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @variable(m, y)
         @test_expression_with_string JuMP.destructive_add!(5.0, x, y) "x*y + 5"
     end
 
     @testset "destructive_add!(ex::Number, c::T, x::T) where T<:GenericAffExpr" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string JuMP.destructive_add!(1.0, 2x, x+1) "2 x² + 2 x + 1"
     end
 
     @testset "destructive_add!(ex::Number, c::GenericAffExpr{C,V}, x::V) where {C,V}" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string JuMP.destructive_add!(1.0, 2x, x) "2 x² + 1"
     end
 
     @testset "destructive_add!(ex::Number, c::GenericQuadExpr, x::Number)" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string JuMP.destructive_add!(0.0, x^2, 1.0) "x²"
     end
 
     @testset "destructive_add!(ex::Number, c::GenericQuadExpr, x::Number) with c == 0" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string JuMP.destructive_add!(0.0, x^2, 0.0) "0"
     end
 
     @testset "destructive_add!(aff::AffExpr,c::VariableRef,x::AffExpr)" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string JuMP.destructive_add!(2x, x, x + 1) "x² + 3 x"
     end
 
     @testset "destructive_add!(aff::GenericAffExpr{C,V},c::GenericAffExpr{C,V},x::Number) where {C,V}" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string JuMP.destructive_add!(2x, x, 1) "3 x"
     end
 
     @testset "destructive_add!(aff::GenericAffExpr{C,V}, c::GenericQuadExpr{C,V}, x::Number) where {C,V}" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string JuMP.destructive_add!(2x, x^2, 1) "x² + 2 x"
     end
 
     @testset "destructive_add!(aff::GenericAffExpr{C,V}, c::GenericQuadExpr{C,V}, x::Number) where {C,V} with x == 0" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string JuMP.destructive_add!(2x, x^2, 0) "2 x"
     end
 
     @testset "destructive_add!(aff::GenericAffExpr{C,V}, c::Number, x::GenericQuadExpr{C,V}) where {C,V} with c == 0" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string JuMP.destructive_add!(2x, 0, x^2) "2 x"
     end
 
     @testset "destructive_add!(ex::GenericAffExpr{C,V}, c::GenericAffExpr{C,V}, x::GenericAffExpr{C,V}) where {C,V}" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string JuMP.destructive_add!(2x, x + 1, x + 0) "x² + 3 x"
     end
 
     @testset "destructive_add!(quad::GenericQuadExpr{C,V},c::GenericAffExpr{C,V},x::Number) where {C,V}" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string JuMP.destructive_add!(x^2, x + 1, 1) "x² + x + 1"
     end
 
     @testset "destructive_add!(quad::GenericQuadExpr{C,V},c::V,x::GenericAffExpr{C,V}) where {C,V}" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string JuMP.destructive_add!(x^2, x, x+1) "2 x² + x"
     end
 
     @testset "destructive_add!(quad::GenericQuadExpr{C,V},c::GenericQuadExpr{C,V},x::Number) where {C,V}" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string JuMP.destructive_add!(x^2 + x, x^2 + x, 2.0) "3 x² + 3 x"
     end
 
     @testset "destructive_add!(ex::GenericQuadExpr{C,V}, c::GenericAffExpr{C,V}, x::GenericAffExpr{C,V}) where {C,V}" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string JuMP.destructive_add!(x^2 + x, x + 0, x + 1) "2 x² + 2 x"
     end
 
     @testset "(+)(::AffExpr)" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string (+)(x + 1) "x + 1"
     end
 
     @testset "(+)(::QuadExpr)" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x)
         @test_expression_with_string (+)(x^2 + 1) "x² + 1"
     end
 
     @testset "sum(::Vector{VariableRef})" begin
-        m = Model()
+        m = ModelType()
         @variable(m, x[1:2])
         @test_expression_with_string sum(x) "x[1] + x[2]"
     end
 
     @testset "expression^3 and unary*" begin
-        m = Model()
+        m = ModelType()
         x = PowVariable(1)
         # Calls (*)((x*x)^6)
         y = @expression m (x*x)^3
@@ -238,6 +229,14 @@ end
 
 @testset "Expressions for JuMP.Model" begin
     expressions_test(Model, VariableRef)
+    @testset "Copy AffExpr between models" begin
+        m = Model()
+        @variable(m, x)
+        m2 = Model()
+        aff = copy(2x + 1, m2)
+        aff_expected = 2*copy(x, m2) + 1
+        @test JuMP.isequal_canonical(aff, aff_expected)
+    end
 end
 
 @testset "Expressions for JuMPExtension.MyModel" begin

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -97,6 +97,15 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
         @test k == 0
     end
 
+    @testset "Copy AffExpr between models" begin
+        m = ModelType()
+        @variable(m, x)
+        m2 = ModelType()
+        aff = copy(2x + 1, m2)
+        aff_expected = 2*copy(x, m2) + 1
+        @test JuMP.isequal_canonical(aff, aff_expected)
+    end
+
     @testset "destructive_add!(ex::Number, c::Number, x::GenericAffExpr)" begin
         aff = JuMP.destructive_add!(1.0, 2.0, JuMP.GenericAffExpr(1.0, :a => 1.0))
         @test JuMP.isequal_canonical(aff, JuMP.GenericAffExpr(3.0, :a => 2.0))
@@ -229,14 +238,6 @@ end
 
 @testset "Expressions for JuMP.Model" begin
     expressions_test(Model, VariableRef)
-    @testset "Copy AffExpr between models" begin
-        m = Model()
-        @variable(m, x)
-        m2 = Model()
-        aff = copy(2x + 1, m2)
-        aff_expected = 2*copy(x, m2) + 1
-        @test JuMP.isequal_canonical(aff, aff_expected)
-    end
 end
 
 @testset "Expressions for JuMPExtension.MyModel" begin


### PR DESCRIPTION
Copy test fails with extension because `copy(::GenericAffExpr{Float64, MyVariableRef}, ::MyModel)` isn't defined.

@blegat do we need to implement/test this?

Closes #1747 