### PR TITLE
Prep for 0.19-beta2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@ adopters. Additional breaking changes may occur between development tags.
 The documentation has known gaps. When using a development tag, be prepared to
 peek into the JuMP source code and tests for examples of how things work.
 
-Latest development tag: `v0.19-beta` (`] add JuMP#v0.19-beta`).
+Latest development tag: `v0.19-beta2` (`] add JuMP#v0.19-beta2`).
 
 Breaking changes:
 


### PR DESCRIPTION
Needed because 0.19-beta is incompatible with MOI 0.8.1.