### PR TITLE
🎨 quadterm -> quad_terms

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -246,7 +246,7 @@ Base.:/(q::GenericQuadExpr, a::GenericAffExpr) = error("Cannot divide a quadrati
 # GenericQuadExpr--GenericQuadExpr
 function Base.:+(q1::GenericQuadExpr, q2::GenericQuadExpr)
     result = copy(q1)
-    for (coef, var1, var2) in quadterms(q2)
+    for (coef, var1, var2) in quad_terms(q2)
         add_to_expression!(result, coef, var1, var2)
     end
     for (coef, var) in linear_terms(q2)
@@ -257,7 +257,7 @@ function Base.:+(q1::GenericQuadExpr, q2::GenericQuadExpr)
 end
 function Base.:-(q1::GenericQuadExpr, q2::GenericQuadExpr)
     result = copy(q1)
-    for (coef, var1, var2) in quadterms(q2)
+    for (coef, var1, var2) in quad_terms(q2)
         add_to_expression!(result, -coef, var1, var2)
     end
     for (coef, var) in linear_terms(q2)

--- a/src/parse_expr.jl
+++ b/src/parse_expr.jl
@@ -225,7 +225,7 @@ end
 
 function destructive_add!(quad::GenericQuadExpr{C,V},c::GenericQuadExpr{C,V},x::Number) where {C,V}
     if !iszero(x)
-        for (coef, var1, var2) in quadterms(c)
+        for (coef, var1, var2) in quad_terms(c)
             add_to_expression!(quad, x*coef, var1, var2)
         end
         quad.aff = destructive_add!(quad.aff,c.aff,x)
@@ -235,7 +235,7 @@ end
 
 function destructive_add!(quad::GenericQuadExpr{C,V},c::Number,x::GenericQuadExpr{C,V}) where {C,V}
     if !iszero(c)
-        for (coef, var1, var2) in quadterms(x)
+        for (coef, var1, var2) in quad_terms(x)
             add_to_expression!(quad, c*coef, var1, var2)
         end
         quad.aff = destructive_add!(quad.aff,c,x.aff)

--- a/src/print.jl
+++ b/src/print.jl
@@ -330,13 +330,13 @@ function Base.show(io::IO, ::MIME"text/latex", q::GenericQuadExpr)
 end
 
 function quad_string(mode, q::GenericQuadExpr)
-    length(quadterms(q)) == 0 && return aff_string(mode, q.aff)
+    length(quad_terms(q)) == 0 && return aff_string(mode, q.aff)
 
     # Odd terms are +/i, even terms are the variables/coeffs
-    term_str = Array{String}(undef, 2 * length(quadterms(q)))
+    term_str = Array{String}(undef, 2 * length(quad_terms(q)))
     elm = 1
     if length(term_str) > 0
-        for (coef, var1, var2) in quadterms(q)
+        for (coef, var1, var2) in quad_terms(q)
             is_zero_for_printing(coef) && continue  # e.g. x - x
 
             pre = is_one_for_printing(coef) ? "" : string_round(abs(coef)) * " "


### PR DESCRIPTION
In accordance to the [JuMP style guide](http://www.juliaopt.org/JuMP.jl/dev/style/).