### PR TITLE
[style] sanitize exports from utils.jl

### DIFF
--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -749,19 +749,19 @@ end
 
 function hessian_slice_inner(d, ex, R, input_ϵ, output_ϵ, ::Type{Val{CHUNK}}) where CHUNK
 
-    subexpr_forward_values_ϵ = reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},d.subexpression_forward_values_ϵ)
-    subexpr_reverse_values_ϵ = reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},d.subexpression_reverse_values_ϵ)
-    forward_storage_ϵ = reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},d.forward_storage_ϵ)
-    reverse_storage_ϵ = reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},d.reverse_storage_ϵ)
-    partials_storage_ϵ = reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},d.partials_storage_ϵ)
+    subexpr_forward_values_ϵ = _reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},d.subexpression_forward_values_ϵ)
+    subexpr_reverse_values_ϵ = _reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},d.subexpression_reverse_values_ϵ)
+    forward_storage_ϵ = _reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},d.forward_storage_ϵ)
+    reverse_storage_ϵ = _reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},d.reverse_storage_ϵ)
+    partials_storage_ϵ = _reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},d.partials_storage_ϵ)
     zero_ϵ = zero(ForwardDiff.Partials{CHUNK,Float64})
 
     user_operators = d.m.nlp_data.user_operators::Derivatives.UserOperatorRegistry
     # do a forward pass
     for expridx in ex.dependent_subexpressions
         subexpr = d.subexpressions[expridx]
-        sub_forward_storage_ϵ = reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},subexpr.forward_storage_ϵ)
-        sub_partials_storage_ϵ = reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},subexpr.partials_storage_ϵ)
+        sub_forward_storage_ϵ = _reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},subexpr.forward_storage_ϵ)
+        sub_partials_storage_ϵ = _reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},subexpr.partials_storage_ϵ)
         subexpr_forward_values_ϵ[expridx] = forward_eval_ϵ(subexpr.forward_storage, sub_forward_storage_ϵ, subexpr.partials_storage, sub_partials_storage_ϵ, subexpr.nd, subexpr.adj, input_ϵ, subexpr_forward_values_ϵ, user_operators)
     end
     forward_eval_ϵ(ex.forward_storage, forward_storage_ϵ, ex.partials_storage,
@@ -778,8 +778,8 @@ function hessian_slice_inner(d, ex, R, input_ϵ, output_ϵ, ::Type{Val{CHUNK}}) 
     for i in length(ex.dependent_subexpressions):-1:1
         expridx = ex.dependent_subexpressions[i]
         subexpr = d.subexpressions[expridx]
-        sub_reverse_storage_ϵ = reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},subexpr.reverse_storage_ϵ)
-        sub_partials_storage_ϵ = reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},subexpr.partials_storage_ϵ)
+        sub_reverse_storage_ϵ = _reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},subexpr.reverse_storage_ϵ)
+        sub_partials_storage_ϵ = _reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64},subexpr.partials_storage_ϵ)
         reverse_eval_ϵ(output_ϵ, subexpr.reverse_storage, sub_reverse_storage_ϵ,subexpr.partials_storage,sub_partials_storage_ϵ,subexpr.nd,subexpr.adj,d.subexpression_reverse_values,subexpr_reverse_values_ϵ,d.subexpression_reverse_values[expridx],subexpr_reverse_values_ϵ[expridx])
     end
 end
@@ -799,8 +799,8 @@ function hessian_slice(d, ex, x, H, scale, nzcount, recovery_tmp_storage,::Type{
 
     input_ϵ_raw = d.input_ϵ
     output_ϵ_raw = d.output_ϵ
-    input_ϵ = reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64}, input_ϵ_raw)
-    output_ϵ = reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64}, output_ϵ_raw)
+    input_ϵ = _reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64}, input_ϵ_raw)
+    output_ϵ = _reinterpret_unsafe(ForwardDiff.Partials{CHUNK,Float64}, output_ϵ_raw)
 
 
     # compute hessian-vector products
@@ -865,9 +865,9 @@ function hessian_slice(d, ex, x, H, scale, nzcount, recovery_tmp_storage,::Type{
     # Output is in R, now recover
 
     #output_slice = view(H, (nzcount+1):(nzcount+nzthis))
-    output_slice = VectorView(nzcount, nzthis, pointer(H))
+    output_slice = _VectorView(nzcount, nzthis, pointer(H))
     Coloring.recover_from_matmat!(output_slice, R, ex.rinfo, recovery_tmp_storage)
-    rmul!(output_slice, scale)
+    _rmul!(output_slice, scale)
     return nzthis
 
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,41 +3,49 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# lightweight unsafe view for vectors
-# it seems that the only way to avoid triggering
-# allocations is to have only bitstype fields, so
-# we store a pointer.
-struct VectorView{T} <: DenseVector{T}
+# Lightweight unsafe view for vectors. It seems that the only way to avoid
+# triggering allocations is to have only bitstype fields, so we store a pointer.
+struct _VectorView{T} <: DenseVector{T}
     offset::Int
     len::Int
     ptr::Ptr{T}
 end
 
-Base.getindex(v::VectorView,idx::Integer) = unsafe_load(v.ptr, idx+v.offset)
-Base.setindex!(v::VectorView,value,idx::Integer) = unsafe_store!(v.ptr,value,idx+v.offset)
-function Base.setindex!(v::VectorView{T},value::T,idx::Vector{Int}) where T
+Base.getindex(v::_VectorView, idx::Integer) = unsafe_load(v.ptr, idx + v.offset)
+
+function Base.setindex!(v::_VectorView, value, idx::Integer)
+    unsafe_store!(v.ptr, value, idx + v.offset)
+    return v
+end
+
+function Base.setindex!(v::_VectorView{T}, value::T, idx::Vector{Int}) where {T}
     for i in idx
         v[i] = value
     end
+    return v
 end
-Base.length(v::VectorView) = v.len
-function Base.fill!(v::VectorView{T},value) where T
-    val = convert(T,value)
+
+Base.length(v::_VectorView) = v.len
+
+function Base.fill!(v::_VectorView{T}, value) where {T}
+    val = convert(T, value)
     for i in 1:length(v)
         v[i] = val
     end
-    nothing
+    return v
 end
-function rmul!(v::VectorView{T},value::T) where T<:Number
+
+function _rmul!(v::_VectorView{T}, value::T) where {T<:Number}
     for i in 1:length(v)
         v[i] *= value
     end
-    nothing
+    return
 end
-function reinterpret_unsafe(::Type{T}, x::Vector{R}) where {T, R}
+
+function _reinterpret_unsafe(::Type{T}, x::Vector{R}) where {T, R}
     # how many T's fit into x?
     @assert isbitstype(T) && isbitstype(R)
     len = length(x) * sizeof(R)
     p = reinterpret(Ptr{T}, pointer(x))
-    return VectorView(0, div(len, sizeof(T)), p)
+    return _VectorView(0, div(len, sizeof(T)), p)
 end


### PR DESCRIPTION
Part of #1790.

`utils.jl` should probably be folded into `nlp.jl`.