### PR TITLE
Update steelT3.jl

### DIFF
--- a/examples/steelT3.jl
+++ b/examples/steelT3.jl
@@ -93,7 +93,7 @@ function example_steelT3(; verbose = true)
 
     if verbose
         println("RESULTS:")
-        for p in product
+        for p in prod
             println("make $(p)")
             for t in 1:T
                 print(JuMP.value(make[p, t]), "\t")


### PR DESCRIPTION
Corrected typo in the `verbose==true` branch of `example_steelT3()` function:
* `product` should be `prod`.
