### PR TITLE
Remove unused method check_belongs_to_model

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -475,11 +475,7 @@ function Base.showerror(io::IO, ex::VariableNotOwnedError)
 end
 
 function check_belongs_to_model(vec::Vector{VariableRef}, m::Model)
-    n = length(vec)
-    @inbounds for i in 1:n
-        vec[i].m !== m && return false
-    end
-    return true
+    @inbounds all(owner_model(m) === model for m in vec)
 end
 
 Base.copy(v::VariableRef, new_model::Model) = VariableRef(new_model, v.index)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -474,8 +474,14 @@ function Base.showerror(io::IO, ex::VariableNotOwnedError)
     print(io, "VariableNotOwnedError: Variable not owned by model present in $(ex.context)")
 end
 
-function check_belongs_to_model(vec::Vector{VariableRef}, m::Model)
-    @inbounds all(owner_model(m) === model for m in vec)
+function check_belongs_to_model(vec::Vector{VariableRef}, model::Model)
+        if  @inbounds all(owner_model(m) === model for m in vec)
+            return true
+            # return nothing #This would match the scalar implimentation
+        else
+            return false
+            # throw(VariableNotOwned(vec)) #This would match the scalar implimentation
+        end
 end
 
 Base.copy(v::VariableRef, new_model::Model) = VariableRef(new_model, v.index)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -474,15 +474,6 @@ function Base.showerror(io::IO, ex::VariableNotOwnedError)
     print(io, "VariableNotOwnedError: Variable not owned by model present in $(ex.context)")
 end
 
-function check_belongs_to_model(vec::Vector{VariableRef}, model::Model)
-        if  @inbounds all(owner_model(m) === model for m in vec)
-            return true
-            # return nothing #This would match the scalar implimentation
-        else
-            return false
-            # throw(VariableNotOwned(vec)) #This would match the scalar implimentation
-        end
-end
 
 Base.copy(v::VariableRef, new_model::Model) = VariableRef(new_model, v.index)
 Base.copy(x::Nothing, new_model::AbstractModel) = nothing

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -468,25 +468,6 @@ function test_variable_symmetric(ModelType)
     @test y[1, 2] === y[2, 1]
 end
 
-function test_check_belongs_to_model(ModelType)
-    model = ModelType()
-    different_model = ModelType()
-    @variable(model, x[1:2], start = 0.0)
-    @test JuMP.check_belongs_to_model(x[1], model) == nothing
-    @test JuMP.check_belongs_to_model(x, model) == true
-
-    @variable(different_model, y[1:2], start = 0.0)
-    @test_throws JuMP.VariableNotOwned JuMP.check_belongs_to_model(y[1], model)
-    @test JuMP.check_belongs_to_model(y, model) == false
-
-    z = [ x[1], y[1] ]
-    @show typeof(z)
-    @test JuMP.check_belongs_to_model(z[1], model) == nothing
-    @test_throws JuMP.VariableNotOwned  JuMP.check_belongs_to_model(z[2], model)
-    # @test_throws JuMP.VariableNotOwnedError  JuMP.check_belongs_to_model(z, model)
-    @test  JuMP.check_belongs_to_model(z, model) == false
-end
-
 function variables_test(ModelType::Type{<:JuMP.AbstractModel},
                         VariableRefType::Type{<:JuMP.AbstractVariableRef})
     @testset "Variable name" begin
@@ -613,9 +594,6 @@ end
         @test JuMP.is_binary(q)
         @test !JuMP.is_integer(q)
         @test JuMP.start_value(q) === 0.5
-    end
-    @testset "Variable Model Ownership" begin
-        test_check_belongs_to_model(Model)
     end
 
 end

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -468,6 +468,25 @@ function test_variable_symmetric(ModelType)
     @test y[1, 2] === y[2, 1]
 end
 
+function test_check_belongs_to_model(ModelType)
+    model = ModelType()
+    different_model = ModelType()
+    @variable(model, x[1:2], start = 0.0)
+    @test JuMP.check_belongs_to_model(x[1], model) == nothing
+    @test JuMP.check_belongs_to_model(x, model) == true
+
+    @variable(different_model, y[1:2], start = 0.0)
+    @test_throws JuMP.VariableNotOwned JuMP.check_belongs_to_model(y[1], model)
+    @test JuMP.check_belongs_to_model(y, model) == false
+
+    z = [ x[1], y[1] ]
+    @show typeof(z)
+    @test JuMP.check_belongs_to_model(z[1], model) == nothing
+    @test_throws JuMP.VariableNotOwned  JuMP.check_belongs_to_model(z[2], model)
+    # @test_throws JuMP.VariableNotOwnedError  JuMP.check_belongs_to_model(z, model)
+    @test  JuMP.check_belongs_to_model(z, model) == false
+end
+
 function variables_test(ModelType::Type{<:JuMP.AbstractModel},
                         VariableRefType::Type{<:JuMP.AbstractVariableRef})
     @testset "Variable name" begin
@@ -595,6 +614,10 @@ end
         @test !JuMP.is_integer(q)
         @test JuMP.start_value(q) === 0.5
     end
+    @testset "Variable Model Ownership" begin
+        test_check_belongs_to_model(Model)
+    end
+
 end
 
 @testset "Variables for JuMPExtension.MyModel" begin

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -595,7 +595,6 @@ end
         @test !JuMP.is_integer(q)
         @test JuMP.start_value(q) === 0.5
     end
-
 end
 
 @testset "Variables for JuMPExtension.MyModel" begin


### PR DESCRIPTION
I noticed that the vector case of check_belongs_to_model had a bug in it.   So I fixed it and added tests.

Please note that the vector method returns a Bool while the scalar method throws an exception or returns nothing.  I left that implementation detail the same.