### PR TITLE
🔥 Remove reorder_iterator

### DIFF
--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -101,10 +101,6 @@ quadratic part of the quadratic expression.
 """
 quad_terms(quad::GenericQuadExpr) = QuadTermIterator(quad)
 
-function reorder_iterator(p::Pair{UnorderedPair{V},C}, state::Int) where {C,V}
-    return ((p.second, p.first.a, p.first.b), state)
-end
-
 function reorder_and_flatten(p::Pair{<:UnorderedPair})
     return (p.second, p.first.a, p.first.b)
 end


### PR DESCRIPTION
The function does not seem to be used anywhere (`grep reorder_iterator * -r` only returns find this function definition but no use anywhere).