### PR TITLE
Improve inferrability of JuMP functions

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -298,7 +298,7 @@ end
 # Internal function.
 function _try_get_solver_name(model_like)
     try
-        return MOI.get(model_like, MOI.SolverName())
+        return MOI.get(model_like, MOI.SolverName())::String
     catch ex
         if isa(ex, ArgumentError)
             return "SolverName() attribute not implemented by the optimizer."
@@ -384,7 +384,7 @@ end
 
 Returns number of variables in `model`.
 """
-num_variables(model::Model) = MOI.get(model, MOI.NumberOfVariables())
+num_variables(model::Model) = MOI.get(model, MOI.NumberOfVariables())::Int64
 
 """
     num_nl_constraints(model::Model)
@@ -405,7 +405,7 @@ Return the reason why the solver stopped (i.e., the MathOptInterface model
 attribute `TerminationStatus`).
 """
 function termination_status(model::Model)
-    return MOI.get(model, MOI.TerminationStatus())
+    return MOI.get(model, MOI.TerminationStatus())::MOI.TerminationStatusCode
 end
 
 """
@@ -415,7 +415,7 @@ Return the status of the most recent primal solution of the solver (i.e., the
 MathOptInterface model attribute `PrimalStatus`).
 """
 function primal_status(model::Model)
-    return MOI.get(model, MOI.PrimalStatus())
+    return MOI.get(model, MOI.PrimalStatus())::MOI.ResultStatusCode
 end
 
 """
@@ -425,7 +425,7 @@ Return the status of the most recent dual solution of the solver (i.e., the
 MathOptInterface model attribute `DualStatus`).
 """
 function dual_status(model::Model)
-    return MOI.get(model, MOI.DualStatus())
+    return MOI.get(model, MOI.DualStatus())::MOI.ResultStatusCode
 end
 
 set_optimize_hook(model::Model, f) = (model.optimize_hook = f)
@@ -502,28 +502,6 @@ function optimizer_index(cr::ConstraintRef{Model})
 end
 
 index(cr::ConstraintRef) = cr.index
-
-"""
-    has_duals(model::Model)
-
-Return true if the solver has a dual solution available to query, otherwise
-return false.
-
-See also [`dual`](@ref) and [`shadow_price`](@ref).
-"""
-has_duals(model::Model) = dual_status(model) != MOI.NO_SOLUTION
-
-"""
-    dual(cr::ConstraintRef)
-
-Get the dual value of this constraint in the result returned by a solver.
-Use `has_dual` to check if a result exists before asking for values.
-See also [`shadow_price`](@ref).
-"""
-function dual(cr::ConstraintRef{Model, <:_MOICON})
-    return reshape_result(MOI.get(cr.model, MOI.ConstraintDual(), cr),
-                          dual_shape(cr.shape))
-end
 
 """
     struct OptimizeNotCalled <: Exception end

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -380,11 +380,11 @@ function add_bridge(model::Model,
 end
 
 """
-    num_variables(model::Model)
+    num_variables(model::Model)::Int64
 
 Returns number of variables in `model`.
 """
-num_variables(model::Model) = MOI.get(model, MOI.NumberOfVariables())::Int64
+num_variables(model::Model)::Int64 = MOI.get(model, MOI.NumberOfVariables())
 
 """
     num_nl_constraints(model::Model)

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -531,13 +531,13 @@ end
 # Returns the value of MOI.ConstraintPrimal in a type-stable way
 function _constraint_primal(
     cref::ConstraintRef{Model, <:_MOICON{
-        <:MOI.AbstractScalarFunction, <:MOI.AbstractScalarSet}})
-    return MOI.get(cref.model, MOI.ConstraintPrimal(), cref)::Float64
+        <:MOI.AbstractScalarFunction, <:MOI.AbstractScalarSet}})::Float64
+    return MOI.get(cref.model, MOI.ConstraintPrimal(), cref)
 end
 function _constraint_primal(
     cref::ConstraintRef{Model, <:_MOICON{
-        <:MOI.AbstractVectorFunction, <:MOI.AbstractVectorSet}})
-    return MOI.get(cref.model, MOI.ConstraintPrimal(), cref)::Vector{Float64}
+        <:MOI.AbstractVectorFunction, <:MOI.AbstractVectorSet}})::Vector{Float64}
+    return MOI.get(cref.model, MOI.ConstraintPrimal(), cref)
 end
 
 """
@@ -564,13 +564,13 @@ end
 # Returns the value of MOI.ConstraintPrimal in a type-stable way
 function _constraint_dual(
     cref::ConstraintRef{Model, <:_MOICON{
-        <:MOI.AbstractScalarFunction, <:MOI.AbstractScalarSet}})
-    return MOI.get(cref.model, MOI.ConstraintDual(), cref)::Float64
+        <:MOI.AbstractScalarFunction, <:MOI.AbstractScalarSet}})::Float64
+    return MOI.get(cref.model, MOI.ConstraintDual(), cref)
 end
 function _constraint_dual(
     cref::ConstraintRef{Model, <:_MOICON{
-        <:MOI.AbstractVectorFunction, <:MOI.AbstractVectorSet}})
-    return MOI.get(cref.model, MOI.ConstraintDual(), cref)::Vector{Float64}
+        <:MOI.AbstractVectorFunction, <:MOI.AbstractVectorSet}})::Vector{Float64}
+    return MOI.get(cref.model, MOI.ConstraintDual(), cref)
 end
 
 

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -15,14 +15,14 @@
 Return the best known bound on the optimal objective value after a call to
 `optimize!(model)`.
 """
-objective_bound(model::Model) = MOI.get(model, MOI.ObjectiveBound())::Float64
+objective_bound(model::Model)::Float64 = MOI.get(model, MOI.ObjectiveBound())
 
 """
     objective_value(model::Model)
 
 Return the objective value after a call to `optimize!(model)`.
 """
-objective_value(model::Model) = MOI.get(model, MOI.ObjectiveValue())::Float64
+objective_value(model::Model)::Float64 = MOI.get(model, MOI.ObjectiveValue())
 
 """
     objective_sense(model::Model)::MathOptInterface.OptimizationSense

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -15,14 +15,14 @@
 Return the best known bound on the optimal objective value after a call to
 `optimize!(model)`.
 """
-objective_bound(model::Model) = MOI.get(model, MOI.ObjectiveBound())
+objective_bound(model::Model) = MOI.get(model, MOI.ObjectiveBound())::Float64
 
 """
     objective_value(model::Model)
 
 Return the objective value after a call to `optimize!(model)`.
 """
-objective_value(model::Model) = MOI.get(model, MOI.ObjectiveValue())
+objective_value(model::Model) = MOI.get(model, MOI.ObjectiveValue())::Float64
 
 """
     objective_sense(model::Model)::MathOptInterface.OptimizationSense
@@ -30,7 +30,7 @@ objective_value(model::Model) = MOI.get(model, MOI.ObjectiveValue())
 Return the objective sense.
 """
 function objective_sense(model::Model)
-    return MOI.get(model, MOI.ObjectiveSense())
+    return MOI.get(model, MOI.ObjectiveSense())::MOI.OptimizationSense
 end
 
 """

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -203,7 +203,7 @@ end
 
 Get a variable's name attribute.
 """
-name(v::VariableRef) = MOI.get(owner_model(v), MOI.VariableName(), v)
+name(v::VariableRef) = MOI.get(owner_model(v), MOI.VariableName(), v)::String
 
 """
     set_name(v::VariableRef, s::AbstractString)
@@ -386,7 +386,7 @@ Return the lower bound of a variable. Error if one does not exist. See also
 """
 function lower_bound(v::VariableRef)
     cset = MOI.get(owner_model(v), MOI.ConstraintSet(),
-                   LowerBoundRef(v))::MOI.GreaterThan
+                   LowerBoundRef(v))::MOI.GreaterThan{Float64}
     return cset.lower
 end
 
@@ -465,7 +465,7 @@ Return the upper bound of a variable. Error if one does not exist. See also
 """
 function upper_bound(v::VariableRef)
     cset = MOI.get(owner_model(v), MOI.ConstraintSet(),
-                   UpperBoundRef(v))::MOI.LessThan
+                   UpperBoundRef(v))::MOI.LessThan{Float64}
     return cset.upper
 end
 
@@ -544,7 +544,8 @@ Return the value to which a variable is fixed. Error if one does not exist. See
 also [`is_fixed`](@ref).
 """
 function fix_value(v::VariableRef)
-    cset = MOI.get(owner_model(v), MOI.ConstraintSet(), FixRef(v))::MOI.EqualTo
+    cset = MOI.get(owner_model(v), MOI.ConstraintSet(),
+                   FixRef(v))::MOI.EqualTo{Float64}
     return cset.value
 end
 
@@ -687,7 +688,8 @@ Return the start value (MOI attribute `VariablePrimalStart`) of the variable
 `v`. See also [`set_start_value`](@ref).
 """
 function start_value(v::VariableRef)
-    return MOI.get(owner_model(v), MOI.VariablePrimalStart(), v)
+    return MOI.get(
+        owner_model(v), MOI.VariablePrimalStart(), v)::Union{Nothing, Float64}
 end
 
 
@@ -698,7 +700,8 @@ Set the start value (MOI attribute `VariablePrimalStart`) of the variable `v` to
 `value`.
 """
 function set_start_value(variable::VariableRef, value::Number)
-    return MOI.set(owner_model(variable), MOI.VariablePrimalStart(), variable, value)
+    return MOI.set(owner_model(variable), MOI.VariablePrimalStart(), variable,
+                   convert(Float64, value))
 end
 
 """
@@ -707,7 +710,9 @@ end
 Get the value of this variable in the result returned by a solver. Use
 [`has_values`](@ref) to check if a result exists before asking for values.
 """
-value(v::VariableRef) = MOI.get(owner_model(v), MOI.VariablePrimal(), v)
+function value(v::VariableRef)
+    return MOI.get(owner_model(v), MOI.VariablePrimal(), v)::Float64
+end
 
 """
     has_values(model::Model)
@@ -774,6 +779,7 @@ all_variables(model)
 ```
 """
 function all_variables(model::Model)
-    return VariableRef[VariableRef(model, idx) for idx in
-                        MOI.get(model, MOI.ListOfVariableIndices())]
+    all_indices = MOI.get(
+        model, MOI.ListOfVariableIndices())::Vector{MOI.VariableIndex}
+    return VariableRef[VariableRef(model, idx) for idx in all_indices]
 end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -687,9 +687,8 @@ end
 Return the start value (MOI attribute `VariablePrimalStart`) of the variable
 `v`. See also [`set_start_value`](@ref).
 """
-function start_value(v::VariableRef)
-    return MOI.get(
-        owner_model(v), MOI.VariablePrimalStart(), v)::Union{Nothing, Float64}
+function start_value(v::VariableRef)::Union{Nothing, Float64}
+    return MOI.get(owner_model(v), MOI.VariablePrimalStart(), v)
 end
 
 
@@ -710,8 +709,8 @@ end
 Get the value of this variable in the result returned by a solver. Use
 [`has_values`](@ref) to check if a result exists before asking for values.
 """
-function value(v::VariableRef)
-    return MOI.get(owner_model(v), MOI.VariablePrimal(), v)::Float64
+function value(v::VariableRef)::Float64
+    return MOI.get(owner_model(v), MOI.VariablePrimal(), v)
 end
 
 """

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -77,7 +77,7 @@ function update_variable_info(vref::MyVariableRef, info::JuMP.VariableInfo)
 end
 
 JuMP.has_lower_bound(vref::MyVariableRef) = variable_info(vref).has_lb
-function JuMP.lower_bound(vref::MyVariableRef)
+function JuMP.lower_bound(vref::MyVariableRef)::Float64
     @assert !JuMP.is_fixed(vref)
     return variable_info(vref).lower_bound
 end
@@ -100,7 +100,7 @@ function JuMP.delete_lower_bound(vref::MyVariableRef)
                                            info.binary, info.integer))
 end
 JuMP.has_upper_bound(vref::MyVariableRef) = variable_info(vref).has_ub
-function JuMP.upper_bound(vref::MyVariableRef)
+function JuMP.upper_bound(vref::MyVariableRef)::Float64
     @assert !JuMP.is_fixed(vref)
     return variable_info(vref).upper_bound
 end
@@ -123,7 +123,9 @@ function JuMP.delete_upper_bound(vref::MyVariableRef)
                                            info.binary, info.integer))
 end
 JuMP.is_fixed(vref::MyVariableRef) = variable_info(vref).has_fix
-JuMP.fix_value(vref::MyVariableRef) = variable_info(vref).fixed_value
+function JuMP.fix_value(vref::MyVariableRef)::Float64
+    return variable_info(vref).fixed_value
+end
 function JuMP.fix(vref::MyVariableRef, value; force::Bool = false)
     info = variable_info(vref)
     if !force && (info.has_lb || info.has_ub)
@@ -144,7 +146,9 @@ function JuMP.unfix(vref::MyVariableRef)
                                            info.has_start, info.start,
                                            info.binary, info.integer))
 end
-JuMP.start_value(vref::MyVariableRef) = variable_info(vref).start
+function JuMP.start_value(vref::MyVariableRef)::Union{Nothing, Float64}
+    return variable_info(vref).start
+end
 function JuMP.set_start_value(vref::MyVariableRef, start)
     info = variable_info(vref)
     update_variable_info(vref,
@@ -238,7 +242,7 @@ function JuMP.objective_function(model::MyModel, FT::Type)
         throw(InexactError(:objective_function, FT,
                            typeof(model.objective_function)))
     end
-    model.objective_function
+    return model.objective_function::FT
 end
 
 # Names

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -1,5 +1,5 @@
 function test_constraint_name(constraint, name, F::Type, S::Type)
-    @test JuMP.name(constraint) == name
+    @test name == @inferred JuMP.name(constraint)
     model = constraint.model
     @test constraint.index == JuMP.constraint_by_name(model, name).index
     if !(model isa JuMPExtension.MyModel)
@@ -55,7 +55,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel},
             @variable(model, x)
 
             cref = @constraint(model, 2x <= 10)
-            @test JuMP.name(cref) == ""
+            @test "" == @inferred JuMP.name(cref)
             JuMP.set_name(cref, "c")
             test_constraint_name(cref, "c", JuMP.AffExpr, MOI.LessThan{Float64})
 
@@ -131,7 +131,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel},
         @test c.set == MOI.Interval(0.0, 1.0)
 
         cref = @constraint(m, 2x - y + 2.0 ∈ MOI.Interval(-1.0, 1.0))
-        @test JuMP.name(cref) == ""
+        @test "" == @inferred JuMP.name(cref)
 
         c = JuMP.constraint_object(cref)
         @test JuMP.isequal_canonical(c.func, 2x - y)
@@ -146,7 +146,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel},
         b = [4.0, 5.0]
 
         cref = @constraint(m, A*x .== b)
-        @test size(cref) == (2,)
+        @test (2,) == @inferred size(cref)
 
         c1 = JuMP.constraint_object(cref[1])
         @test JuMP.isequal_canonical(c1.func, x[1] + 2x[2])
@@ -163,7 +163,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel},
         UB = [1.0 2.0; 3.0 4.0]
 
         cref = @constraint(m, x + 1 .<= UB)
-        @test size(cref) == (2,2)
+        @test (2,2) == @inferred size(cref)
         for i in 1:2
             for j in 1:2
                 c = JuMP.constraint_object(cref[i,j])
@@ -181,7 +181,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel},
         u = [3.0, 4.0]
 
         cref = @constraint(m, l .<= x + y + 1 .<= u)
-        @test size(cref) == (2,)
+        @test (2,) == @inferred size(cref)
 
         for i in 1:2
             c = JuMP.constraint_object(cref[i])
@@ -380,7 +380,8 @@ end
     @testset "all_constraints (scalar)" begin
         model = Model()
         @variable(model, x >= 0)
-        ref = all_constraints(model, VariableRef, MOI.GreaterThan{Float64})
+        ref = @inferred all_constraints(
+            model, VariableRef, MOI.GreaterThan{Float64})
         @test ref == [LowerBoundRef(x)]
         aff_constraints = all_constraints(model, AffExpr,
                                           MOI.GreaterThan{Float64})
@@ -402,7 +403,7 @@ end
         @constraint(model, [x, x] in SecondOrderCone())
         @constraint(model, [2x  1; 1 x] in PSDCone())
         @constraint(model, [x^2, x] in RotatedSecondOrderCone())
-        constraint_types = list_of_constraint_types(model)
+        constraint_types = @inferred list_of_constraint_types(model)
         @test Set(constraint_types) == Set([(VariableRef, MOI.ZeroOne),
             (VariableRef, MOI.GreaterThan{Float64}),
             (AffExpr, MOI.LessThan{Float64}),

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -14,6 +14,9 @@
 # that the plumbing works. This could change if JuMP gains the ability to verify
 # feasibility independently of a solver.
 
+using LinearAlgebra, Test
+using JuMP
+
 @testset "Generation and solve with fake solver" begin
     @testset "LP" begin
         m = Model()
@@ -58,19 +61,19 @@
         #@test JuMP.isattached(m)
         @test JuMP.has_values(m)
 
-        @test JuMP.termination_status(m) == MOI.OPTIMAL
-        @test JuMP.primal_status(m) == MOI.FEASIBLE_POINT
+        @test MOI.OPTIMAL == @inferred JuMP.termination_status(m)
+        @test MOI.FEASIBLE_POINT == @inferred JuMP.primal_status(m)
 
-        @test JuMP.value(x) == 1.0
-        @test JuMP.value(y) == 0.0
-        @test JuMP.value(x + y) == 1.0
-        @test JuMP.value(c) == 1.0
-        @test JuMP.objective_value(m) == -1.0
+        @test  1.0 == @inferred JuMP.value(x)
+        @test  0.0 == @inferred JuMP.value(y)
+        @test  1.0 == @inferred JuMP.value(x + y)
+        @test  1.0 == @inferred JuMP.value(c)
+        @test -1.0 == @inferred JuMP.objective_value(m)
 
-        @test JuMP.dual_status(m) == MOI.FEASIBLE_POINT
-        @test JuMP.dual(c) == -1
-        @test JuMP.dual(JuMP.UpperBoundRef(x)) == 0.0
-        @test JuMP.dual(JuMP.LowerBoundRef(y)) == 1.0
+        @test MOI.FEASIBLE_POINT == @inferred JuMP.dual_status(m)
+        @test -1.0 == @inferred JuMP.dual(c)
+        @test  0.0 == @inferred JuMP.dual(JuMP.UpperBoundRef(x))
+        @test  1.0 == @inferred JuMP.dual(JuMP.LowerBoundRef(y))
     end
 
     @testset "LP (Direct mode)" begin
@@ -99,18 +102,18 @@
         #@test JuMP.isattached(m)
         @test JuMP.has_values(m)
 
-        @test JuMP.termination_status(m) == MOI.OPTIMAL
-        @test JuMP.primal_status(m) == MOI.FEASIBLE_POINT
+        @test MOI.OPTIMAL == @inferred JuMP.termination_status(m)
+        @test MOI.FEASIBLE_POINT == @inferred JuMP.primal_status(m)
 
-        @test JuMP.value(x) == 1.0
-        @test JuMP.value(y) == 0.0
-        @test JuMP.value(x + y) == 1.0
-        @test JuMP.objective_value(m) == -1.0
+        @test  1.0 == @inferred JuMP.value(x)
+        @test  0.0 == @inferred JuMP.value(y)
+        @test  1.0 == @inferred JuMP.value(x + y)
+        @test -1.0 == @inferred JuMP.objective_value(m)
 
-        @test JuMP.dual_status(m) == MOI.FEASIBLE_POINT
-        @test JuMP.dual(c) == -1
-        @test JuMP.dual(JuMP.UpperBoundRef(x)) == 0.0
-        @test JuMP.dual(JuMP.LowerBoundRef(y)) == 1.0
+        @test MOI.FEASIBLE_POINT == @inferred JuMP.dual_status(m)
+        @test -1.0 == @inferred JuMP.dual(c)
+        @test  0.0 == @inferred JuMP.dual(JuMP.UpperBoundRef(x))
+        @test  1.0 == @inferred JuMP.dual(JuMP.LowerBoundRef(y))
     end
 
     # TODO: test Manual mode
@@ -157,12 +160,12 @@
         #@test JuMP.isattached(m)
         @test JuMP.has_values(m)
 
-        @test JuMP.termination_status(m) == MOI.OPTIMAL
-        @test JuMP.primal_status(m) == MOI.FEASIBLE_POINT
+        @test MOI.OPTIMAL == @inferred JuMP.termination_status(m)
+        @test MOI.FEASIBLE_POINT == @inferred JuMP.primal_status(m)
 
-        @test JuMP.value(x) == 1.0
-        @test JuMP.value(y) == 0.0
-        @test JuMP.objective_value(m) == 1.0
+        @test 1.0 == @inferred JuMP.value(x)
+        @test 0.0 == @inferred JuMP.value(y)
+        @test 1.0 == @inferred JuMP.objective_value(m)
 
         @test !JuMP.has_duals(m)
     end
@@ -208,19 +211,19 @@
         #@test JuMP.isattached(m)
         @test JuMP.has_values(m)
 
-        @test JuMP.termination_status(m) == MOI.OPTIMAL
-        @test JuMP.primal_status(m) == MOI.FEASIBLE_POINT
+        @test MOI.OPTIMAL == @inferred JuMP.termination_status(m)
+        @test MOI.FEASIBLE_POINT == @inferred JuMP.primal_status(m)
 
-        @test JuMP.value(x) == 1.0
-        @test JuMP.value(y) == 0.0
-        @test JuMP.objective_value(m) == -1.0
+        @test 1.0 == @inferred JuMP.value(x)
+        @test 0.0 == @inferred JuMP.value(y)
+        @test -1.0 == @inferred JuMP.objective_value(m)
 
-        @test JuMP.dual_status(m) == MOI.FEASIBLE_POINT
-        @test JuMP.dual(c1) == -1.0
-        @test JuMP.dual(c2) == 2.0
-        @test JuMP.dual(c3) == 3.0
+        @test MOI.FEASIBLE_POINT == @inferred JuMP.dual_status(m)
+        @test -1.0 == @inferred JuMP.dual(c1)
+        @test 2.0 == @inferred JuMP.dual(c2)
+        @test 3.0 == @inferred JuMP.dual(c3)
 
-        @test JuMP.value(2 * x + 3 * y * x) == 2.0
+        @test 2.0 == @inferred JuMP.value(2 * x + 3 * y * x)
     end
 
     @testset "SOC" begin
@@ -269,16 +272,16 @@
         #@test JuMP.isattached(m)
         @test JuMP.has_values(m)
 
-        @test JuMP.termination_status(m) == MOI.OPTIMAL
-        @test JuMP.primal_status(m) == MOI.FEASIBLE_POINT
+        @test MOI.OPTIMAL == @inferred JuMP.termination_status(m)
+        @test MOI.FEASIBLE_POINT == @inferred JuMP.primal_status(m)
 
-        @test JuMP.value(x) == 1.0
-        @test JuMP.value(y) == 0.0
-        @test JuMP.value(z) == 0.0
+        @test 1.0 == @inferred JuMP.value(x)
+        @test 0.0 == @inferred JuMP.value(y)
+        @test 0.0 == @inferred JuMP.value(z)
 
         @test JuMP.has_duals(m)
-        @test JuMP.dual(varsoc) == [-1.0, -2.0, -3.0]
-        @test JuMP.dual(affsoc) == [1.0, 2.0, 3.0]
+        @test [-1.0, -2.0, -3.0] == @inferred JuMP.dual(varsoc)
+        @test [ 1.0,  2.0,  3.0] == @inferred JuMP.dual(affsoc)
     end
 
     @testset "SDP" begin
@@ -331,25 +334,25 @@
 
         JuMP.optimize!(m)
 
-        @test JuMP.termination_status(m) == MOI.OPTIMAL
-        @test JuMP.primal_status(m) == MOI.FEASIBLE_POINT
+        @test MOI.OPTIMAL == @inferred JuMP.termination_status(m)
+        @test MOI.FEASIBLE_POINT == @inferred JuMP.primal_status(m)
 
         @test JuMP.has_values(m)
-        @test JuMP.value.(x) == [1.0 2.0; 2.0 4.0]
+        @test [1.0 2.0; 2.0 4.0] == JuMP.value.(x)
         @test JuMP.value(var_psd) isa Symmetric
-        @test JuMP.value(var_psd) == [1.0 2.0; 2.0 4.0]
+        @test [1.0 2.0; 2.0 4.0] == @inferred JuMP.value(var_psd)
         @test JuMP.value(sym_psd) isa Symmetric
-        @test JuMP.value(sym_psd) == [0.0 2.0; 2.0 3.0]
+        @test [0.0 2.0; 2.0 3.0] == @inferred JuMP.value(sym_psd)
         @test JuMP.value(con_psd) isa Matrix
-        @test JuMP.value(con_psd) == [0.0 2.0; 2.0 3.0]
+        @test [0.0 2.0; 2.0 3.0] == @inferred JuMP.value(con_psd)
 
         @test JuMP.has_duals(m)
         @test JuMP.dual(var_psd) isa Symmetric
-        @test JuMP.dual(var_psd) == [1.0 2.0; 2.0 3.0]
+        @test [1.0 2.0; 2.0 3.0] == @inferred JuMP.dual(var_psd)
         @test JuMP.dual(sym_psd) isa Symmetric
-        @test JuMP.dual(sym_psd) == [4.0 5.0; 5.0 6.0]
+        @test [4.0 5.0; 5.0 6.0] == @inferred JuMP.dual(sym_psd)
         @test JuMP.dual(con_psd) isa Matrix
-        @test JuMP.dual(con_psd) == [7.0 9.0; 8.0 10.0]
+        @test [7.0 9.0; 8.0 10.0] == @inferred JuMP.dual(con_psd)
 
     end
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -347,7 +347,7 @@ end
         model = Model()
         @variable(model, x)
         @test_throws ErrorException @variable(model, x)
-        @test num_variables(model) == 1
+        @test 1 == @inferred num_variables(model)
     end
 
     @testset "Anonymous expressions aren't registered" begin

--- a/test/model.jl
+++ b/test/model.jl
@@ -213,9 +213,9 @@ function test_model()
                     JuMP.add_bridge(model, NonnegativeBridge)
                     c = @constraint(model, x in Nonnegative())
                     JuMP.optimize!(model)
-                    @test JuMP.value(x) == 1.0
-                    @test JuMP.value(c) == 1.0
-                    @test JuMP.dual(c) == 2.0
+                    @test 1.0 == @inferred JuMP.value(x)
+                    @test 1.0 == @inferred JuMP.value(c)
+                    @test 2.0 == @inferred JuMP.dual(c)
                 end
                 @testset "with_optimizer at optimize!" begin
                     model = Model()
@@ -223,9 +223,9 @@ function test_model()
                     c = @constraint(model, x in Nonnegative())
                     JuMP.add_bridge(model, NonnegativeBridge)
                     JuMP.optimize!(model, factory)
-                    @test JuMP.value(x) == 1.0
-                    @test JuMP.value(c) == 1.0
-                    @test JuMP.dual(c) == 2.0
+                    @test 1.0 == @inferred JuMP.value(x)
+                    @test 1.0 == @inferred JuMP.value(c)
+                    @test 2.0 == @inferred JuMP.dual(c)
                 end
             end
             @testset "after loading the constraint to the optimizer" begin
@@ -240,9 +240,9 @@ function test_model()
                     JuMP.add_bridge(model, NonnegativeBridge)
                     c = @constraint(model, x in Nonnegative())
                     JuMP.optimize!(model)
-                    @test JuMP.value(x) == 1.0
-                    @test JuMP.value(c) == 1.0
-                    @test JuMP.dual(c) == 2.0
+                    @test 1.0 == @inferred JuMP.value(x)
+                    @test 1.0 == @inferred JuMP.value(c)
+                    @test 2.0 == @inferred JuMP.dual(c)
                 end
                 @testset "with_optimizer at optimize!" begin
                     err = MOI.UnsupportedConstraint{MOI.SingleVariable,
@@ -253,9 +253,9 @@ function test_model()
                     @test_throws err JuMP.optimize!(model, factory)
                     JuMP.add_bridge(model, NonnegativeBridge)
                     JuMP.optimize!(model)
-                    @test JuMP.value(x) == 1.0
-                    @test JuMP.value(c) == 1.0
-                    @test JuMP.dual(c) == 2.0
+                    @test 1.0 == @inferred JuMP.value(x)
+                    @test 1.0 == @inferred JuMP.value(c)
+                    @test 2.0 == @inferred JuMP.dual(c)
                 end
             end
             @testset "automatically with BridgeableConstraint" begin
@@ -266,9 +266,9 @@ function test_model()
                     bc = BridgeableConstraint(constraint, NonnegativeBridge)
                     c = add_constraint(model, bc)
                     JuMP.optimize!(model)
-                    @test JuMP.value(x) == 1.0
-                    @test JuMP.value(c) == 1.0
-                    @test JuMP.dual(c) == 2.0
+                    @test 1.0 == @inferred JuMP.value(x)
+                    @test 1.0 == @inferred JuMP.value(c)
+                    @test 2.0 == @inferred JuMP.dual(c)
                 end
                 @testset "with_optimizer at optimize!" begin
                     model = Model()
@@ -277,9 +277,9 @@ function test_model()
                     bc = BridgeableConstraint(constraint, NonnegativeBridge)
                     c = add_constraint(model, bc)
                     JuMP.optimize!(model, factory)
-                    @test JuMP.value(x) == 1.0
-                    @test JuMP.value(c) == 1.0
-                    @test JuMP.dual(c) == 2.0
+                    @test 1.0 == @inferred JuMP.value(x)
+                    @test 1.0 == @inferred JuMP.value(c)
+                    @test 2.0 == @inferred JuMP.dual(c)
                 end
             end
         end
@@ -306,13 +306,13 @@ function test_model()
     @testset "solver_name" begin
         @testset "Not attached" begin
             model = Model()
-            @test JuMP.solver_name(model) == "No optimizer attached."
+            @test "No optimizer attached." == @inferred JuMP.solver_name(model)
         end
 
         @testset "Mock" begin
             model = Model(with_optimizer(MOIU.MockOptimizer,
                                          SimpleLPModel{Float64}()))
-            @test JuMP.solver_name(model) == "Mock"
+            @test "Mock" == @inferred JuMP.solver_name(model)
         end
     end
 end
@@ -359,28 +359,28 @@ function dummy_optimizer_hook(::JuMP.AbstractModel) end
                         reference_map[z] = new_model[:z]
                         reference_map[cref] = new_model[:cref]
                     end
-                    @test MOIU.mode(JuMP.backend(new_model)) == caching_mode
+                    @test caching_mode == @inferred MOIU.mode(JuMP.backend(new_model))
                     @test new_model.optimize_hook === dummy_optimizer_hook
                     @test new_model.ext[:dummy].model === new_model
                     x_new = reference_map[x]
                     @test JuMP.owner_model(x_new) === new_model
-                    @test JuMP.name(x_new) == "x"
+                    @test "x" == @inferred JuMP.name(x_new)
                     y_new = reference_map[y]
                     @test JuMP.owner_model(y_new) === new_model
-                    @test JuMP.name(y_new) == "y"
+                    @test "y" == @inferred JuMP.name(y_new)
                     z_new = reference_map[z]
                     @test JuMP.owner_model(z_new) === new_model
-                    @test JuMP.name(z_new) == "z"
+                    @test "z" == @inferred JuMP.name(z_new)
                     if copy_model
-                        @test JuMP.LowerBoundRef(x_new) == reference_map[JuMP.LowerBoundRef(x)]
-                        @test JuMP.BinaryRef(x_new) == reference_map[JuMP.BinaryRef(x)]
-                        @test JuMP.UpperBoundRef(y_new) == reference_map[JuMP.UpperBoundRef(y)]
-                        @test JuMP.IntegerRef(y_new) == reference_map[JuMP.IntegerRef(y)]
-                        @test JuMP.FixRef(z_new) == reference_map[JuMP.FixRef(z)]
+                        @test reference_map[JuMP.LowerBoundRef(x)] == @inferred JuMP.LowerBoundRef(x_new)
+                        @test reference_map[JuMP.BinaryRef(x)] == @inferred JuMP.BinaryRef(x_new)
+                        @test reference_map[JuMP.UpperBoundRef(y)] == @inferred JuMP.UpperBoundRef(y_new)
+                        @test reference_map[JuMP.IntegerRef(y)] == @inferred JuMP.IntegerRef(y_new)
+                        @test reference_map[JuMP.FixRef(z)] == @inferred JuMP.FixRef(z_new)
                     end
                     cref_new = reference_map[cref]
                     @test cref_new.model === new_model
-                    @test JuMP.name(cref_new) == "cref"
+                    @test "cref" == @inferred JuMP.name(cref_new)
                 end
             end
         end

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -1,3 +1,6 @@
+using Test
+using JuMP
+
 struct DummyOptimizer <: MOI.AbstractOptimizer end
 MOI.is_empty(::DummyOptimizer) = true
 
@@ -22,7 +25,7 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
     @testset "objective_sense set and get" begin
         model = ModelType()
         JuMP.set_objective_sense(model, MOI.FEASIBILITY_SENSE)
-        @test JuMP.objective_sense(model) == MOI.FEASIBILITY_SENSE
+        @test MOI.FEASIBILITY_SENSE == @inferred JuMP.objective_sense(model)
     end
 
     @testset "SingleVariable objectives" begin
@@ -30,16 +33,16 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
         @variable(m, x)
 
         @objective(m, Min, x)
-        @test JuMP.objective_sense(m) == MOI.MIN_SENSE
+        @test MOI.MIN_SENSE == @inferred JuMP.objective_sense(m)
         @test JuMP.objective_function_type(m) == VariableRefType
         @test JuMP.objective_function(m) == x
-        @test JuMP.objective_function(m, VariableRefType) == x
+        @test x == @inferred JuMP.objective_function(m, VariableRefType)
 
         @objective(m, Max, x)
-        @test JuMP.objective_sense(m) == MOI.MAX_SENSE
+        @test MOI.MAX_SENSE == @inferred JuMP.objective_sense(m)
         @test JuMP.objective_function_type(m) == VariableRefType
         @test JuMP.objective_function(m) == x
-        @test JuMP.objective_function(m, VariableRefType) == x
+        @test x == @inferred JuMP.objective_function(m, VariableRefType)
     end
 
     @testset "Linear objectives" begin
@@ -47,16 +50,18 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
         @variable(m, x)
 
         @objective(m, Min, 2x)
-        @test JuMP.objective_sense(m) == MOI.MIN_SENSE
+        @test MOI.MIN_SENSE == @inferred JuMP.objective_sense(m)
         @test JuMP.objective_function_type(m) == AffExprType
         @test JuMP.isequal_canonical(JuMP.objective_function(m), 2x)
-        @test JuMP.isequal_canonical(JuMP.objective_function(m, AffExprType), 2x)
+        @test JuMP.isequal_canonical(
+            2x, @inferred JuMP.objective_function(m, AffExprType))
 
         @objective(m, Max, x + 3x + 1)
-        @test JuMP.objective_sense(m) == MOI.MAX_SENSE
+        @test MOI.MAX_SENSE == @inferred JuMP.objective_sense(m)
         @test JuMP.objective_function_type(m) == AffExprType
         @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x + 1)
-        @test JuMP.isequal_canonical(JuMP.objective_function(m, AffExprType), 4x + 1)
+        @test JuMP.isequal_canonical(
+            4x + 1, @inferred JuMP.objective_function(m, AffExprType))
     end
 
     @testset "Quadratic objectives" begin
@@ -64,10 +69,11 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
         @variable(m, x)
 
         @objective(m, Min, x^2 + 2x)
-        @test JuMP.objective_sense(m) == MOI.MIN_SENSE
+        @test MOI.MIN_SENSE == @inferred JuMP.objective_sense(m)
         @test JuMP.objective_function_type(m) == QuadExprType
         @test JuMP.isequal_canonical(JuMP.objective_function(m), x^2 + 2x)
-        @test JuMP.isequal_canonical(JuMP.objective_function(m, QuadExprType), x^2 + 2x)
+        @test JuMP.isequal_canonical(
+            x^2 + 2x, @inferred JuMP.objective_function(m, QuadExprType))
         @test_throws InexactError JuMP.objective_function(m, AffExprType)
     end
 
@@ -84,8 +90,9 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
 
         sense = MOI.MIN_SENSE
         @objective(m, sense, 2x)
-        @test JuMP.objective_sense(m) == MOI.MIN_SENSE
-        @test JuMP.isequal_canonical(JuMP.objective_function(m, AffExprType), 2x)
+        @test MOI.MIN_SENSE == @inferred JuMP.objective_sense(m)
+        @test JuMP.isequal_canonical(
+            2x, @inferred JuMP.objective_function(m, AffExprType))
 
         sense = :Min
         @test_throws ErrorException @objective(m, sense, 2x)

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -22,7 +22,7 @@ include("utilities.jl")
 end
 
 function test_variable_name(variable, name)
-    @test JuMP.name(variable) == name
+    @test name == @inferred JuMP.name(variable)
     @test variable == JuMP.variable_by_name(JuMP.owner_model(variable), name)
 end
 
@@ -65,7 +65,7 @@ function test_variable_lower_bound_rhs(ModelType)
     model = ModelType()
     @variable(model, lbonly >= 0, Bin)
     @test JuMP.has_lower_bound(lbonly)
-    @test JuMP.lower_bound(lbonly) == 0.0
+    @test 0.0 == @inferred JuMP.lower_bound(lbonly)
     @test !JuMP.has_upper_bound(lbonly)
     @test !JuMP.is_fixed(lbonly)
     @test JuMP.is_binary(lbonly)
@@ -81,7 +81,7 @@ function test_variable_lower_bound_lhs(ModelType)
     model = ModelType()
     @variable(model, 0 <= lblhs, Bin)
     @test JuMP.has_lower_bound(lblhs)
-    @test JuMP.lower_bound(lblhs) == 0.0
+    @test 0.0 == @inferred JuMP.lower_bound(lblhs)
     @test !JuMP.has_upper_bound(lblhs)
     @test !JuMP.is_fixed(lblhs)
     @test JuMP.is_binary(lblhs)
@@ -94,7 +94,7 @@ function test_variable_upper_bound_rhs(ModelType)
     @variable(model, ubonly <= 1, Int)
     @test !JuMP.has_lower_bound(ubonly)
     @test JuMP.has_upper_bound(ubonly)
-    @test JuMP.upper_bound(ubonly) == 1.0
+    @test 1.0 == @inferred JuMP.upper_bound(ubonly)
     @test !JuMP.is_fixed(ubonly)
     @test !JuMP.is_binary(ubonly)
     @test JuMP.is_integer(ubonly)
@@ -108,7 +108,7 @@ function test_variable_upper_bound_lhs(ModelType)
     @variable(model, 1 >= ublhs, Int)
     @test !JuMP.has_lower_bound(ublhs)
     @test JuMP.has_upper_bound(ublhs)
-    @test JuMP.upper_bound(ublhs) == 1.0
+    @test 1.0 == @inferred JuMP.upper_bound(ublhs)
     @test !JuMP.is_fixed(ublhs)
     @test !JuMP.is_binary(ublhs)
     @test JuMP.is_integer(ublhs)
@@ -118,9 +118,9 @@ end
 function test_variable_interval(ModelType)
     function has_bounds(var, lb, ub)
         @test JuMP.has_lower_bound(var)
-        @test JuMP.lower_bound(var) == lb
+        @test lb == @inferred JuMP.lower_bound(var)
         @test JuMP.has_upper_bound(var)
-        @test JuMP.upper_bound(var) == ub
+        @test ub == @inferred JuMP.upper_bound(var)
         @test !JuMP.is_fixed(var)
     end
     model = ModelType()
@@ -142,7 +142,7 @@ function test_variable_fix(ModelType)
     @test !JuMP.has_lower_bound(fixed)
     @test !JuMP.has_upper_bound(fixed)
     @test JuMP.is_fixed(fixed)
-    @test JuMP.fix_value(fixed) == 1.0
+    @test 1.0 == @inferred JuMP.fix_value(fixed)
     JuMP.unfix(fixed)
     @test !JuMP.is_fixed(fixed)
     JuMP.set_lower_bound(fixed, 0.0)
@@ -151,7 +151,7 @@ function test_variable_fix(ModelType)
     @test !JuMP.has_lower_bound(fixed)
     @test !JuMP.has_upper_bound(fixed)
     @test JuMP.is_fixed(fixed)
-    @test JuMP.fix_value(fixed) == 1.0
+    @test 1.0 == @inferred JuMP.fix_value(fixed)
 end
 
 function test_variable_custom_index_sets(ModelType)
@@ -159,16 +159,14 @@ function test_variable_custom_index_sets(ModelType)
     @variable(model, onerangeub[-7:1] <= 10, Int)
     @variable(model, manyrangelb[0:1, 10:20, 1:1] >= 2)
     @test JuMP.has_lower_bound(manyrangelb[0, 15, 1])
-    @test JuMP.lower_bound(manyrangelb[0, 15, 1]) == 2
+    @test 2 == @inferred JuMP.lower_bound(manyrangelb[0, 15, 1])
     @test !JuMP.has_upper_bound(manyrangelb[0, 15, 1])
 
     s = ["Green","Blue"]
     @variable(model, x[i=-10:10, s] <= 5.5, Int, start=i+1)
-    @test JuMP.upper_bound(x[-4, "Green"]) == 5.5
+    @test 5.5 == @inferred JuMP.upper_bound(x[-4, "Green"])
     test_variable_name(x[-10, "Green"], "x[-10,Green]")
-    # TODO: broken because of
-    #       https://github.com/JuliaOpt/MathOptInterface.jl/issues/302
-    # @test JuMP.start_value(x[-3, "Blue"]) == -2
+    @test JuMP.start_value(x[-3, "Blue"]) == -2
     @test isequal(model[:onerangeub][-7], onerangeub[-7])
     @test_throws KeyError model[:foo]
 end
@@ -177,8 +175,8 @@ function test_variable_anonymous(ModelType)
     model = ModelType()
     @test_throws ErrorException @variable(model, [(0, 0)])  # #922
     x = @variable(model, [(0, 2)])
-    @test JuMP.name(x[0]) == ""
-    @test JuMP.name(x[2]) == ""
+    @test "" == @inferred JuMP.name(x[0])
+    @test "" == @inferred JuMP.name(x[2])
 end
 
 function test_variable_is_valid_delete(ModelType)
@@ -194,24 +192,24 @@ end
 function test_variable_bounds_set_get(ModelType)
     model = ModelType()
     @variable(model, 0 <= x <= 2)
-    @test JuMP.lower_bound(x) == 0
-    @test JuMP.upper_bound(x) == 2
+    @test 0 == @inferred JuMP.lower_bound(x)
+    @test 2 == @inferred JuMP.upper_bound(x)
     set_lower_bound(x, 1)
-    @test JuMP.lower_bound(x) == 1
+    @test 1 == @inferred JuMP.lower_bound(x)
     set_upper_bound(x, 3)
-    @test JuMP.upper_bound(x) == 3
+    @test 3 == @inferred JuMP.upper_bound(x)
     @variable(model, q, Bin)
     @test !JuMP.has_lower_bound(q)
     @test !JuMP.has_upper_bound(q)
 
     @variable(model, 0 <= y <= 1, Bin)
-    @test JuMP.lower_bound(y) == 0
-    @test JuMP.upper_bound(y) == 1
+    @test 0 == @inferred JuMP.lower_bound(y)
+    @test 1 == @inferred JuMP.upper_bound(y)
 
     @variable(model, fixedvar == 2)
-    @test JuMP.fix_value(fixedvar) == 2.0
+    @test 2.0 == @inferred JuMP.fix_value(fixedvar)
     JuMP.fix(fixedvar, 5)
-    @test JuMP.fix_value(fixedvar) == 5
+    @test 5 == @inferred JuMP.fix_value(fixedvar)
     @test_throws Exception JuMP.lower_bound(fixedvar)
     @test_throws Exception JuMP.upper_bound(fixedvar)
 end
@@ -277,10 +275,10 @@ function test_variable_oneto_index_set(ModelType, VariableRefType)
     model = ModelType()
     auto_var = @variable(model, [Base.OneTo(3), 1:2], container=Auto)
     @test auto_var isa Matrix{VariableRefType}
-    @test size(auto_var) == (3, 2)
+    @test (3, 2) == @inferred size(auto_var)
     array_var = @variable(model, [Base.OneTo(3), 1:2], container=Array)
     @test array_var isa Matrix{VariableRefType}
-    @test size(array_var) == (3, 2)
+    @test (3, 2) == @inferred size(array_var)
     denseaxisarray_var = @variable(model, [Base.OneTo(3), 1:2], container=DenseAxisArray)
     @test denseaxisarray_var isa JuMP.Containers.DenseAxisArray{VariableRefType}
     @test length.(axes(denseaxisarray_var)) == (3, 2)
@@ -321,7 +319,7 @@ end
 
 function test_variable_condition_in_indexing(ModelType)
     function test_one_dim(x)
-        @test length(x) == 5
+        @test 5 == @inferred length(x)
         for i in 1:10
             if iseven(i)
                 @test haskey(x, i)
@@ -332,7 +330,7 @@ function test_variable_condition_in_indexing(ModelType)
     end
 
     function test_two_dim(y)
-        @test length(y) == 15
+        @test 15 == @inferred length(y)
         for j in 1:10, k in 3:2:9
             if isodd(j+k) && k <= 8
                 @test haskey(y, (j,k))
@@ -366,11 +364,11 @@ function test_variable_macro_return_type(ModelType, VariableRefType)
     @variable(model, y[1:0], start=0.0)
     @test typeof(y) == Vector{VariableRefType}
     # No type to infer for an empty collection.
-    @test typeof(JuMP.start_value.(y)) == Array{Any,1}
+    @test typeof(JuMP.start_value.(y)) == Vector{Union{Nothing, Float64}}
 
     @variable(model, z[1:4], start = 0.0)
     @test typeof(z) == Vector{VariableRefType}
-    @test typeof(JuMP.start_value.(z)) == Array{Float64,1}
+    @test typeof(JuMP.start_value.(z)) == Vector{Float64}
 end
 
 function test_variable_start_value_on_empty(ModelType)
@@ -453,7 +451,7 @@ function test_variable_unsigned_index(ModelType)
     model = ModelType()
     t = UInt(4)
     @variable(model, x[1:t])
-    @test JuMP.num_variables(model) == 4
+    @test 4 == @inferred num_variables(model)
 end
 
 function test_variable_symmetric(ModelType)
@@ -550,7 +548,7 @@ end
         model = Model()
         @variable(model, x)
         @variable(model, y)
-        @test JuMP.all_variables(model) == [x, y]
+        @test [x, y] == @inferred JuMP.all_variables(model)
     end
     @testset "@variables" begin
         model = Model()
@@ -561,35 +559,35 @@ end
             q, (Bin, start = 0.5)
         end
 
-        @test JuMP.name(x[1]) == "x[1]"
-        @test JuMP.lower_bound(x[1]) == 0
-        @test JuMP.upper_bound(x[1]) == 1
+        @test "x[1]" == @inferred JuMP.name(x[1])
+        @test 0 == @inferred JuMP.lower_bound(x[1])
+        @test 1 == @inferred JuMP.upper_bound(x[1])
         @test !JuMP.is_binary(x[1])
         @test !JuMP.is_integer(x[1])
         @test JuMP.start_value(x[1]) === nothing
 
-        @test JuMP.name(x[2]) == "x[2]"
-        @test JuMP.lower_bound(x[2]) == 0
-        @test JuMP.upper_bound(x[2]) == 2
+        @test "x[2]" == @inferred JuMP.name(x[2])
+        @test 0 == @inferred JuMP.lower_bound(x[2])
+        @test 2 == @inferred JuMP.upper_bound(x[2])
         @test !JuMP.is_binary(x[2])
         @test !JuMP.is_integer(x[2])
         @test JuMP.start_value(x[2]) === nothing
 
-        @test JuMP.name(y) == "y"
-        @test JuMP.lower_bound(y) == 2
+        @test "y" == @inferred JuMP.name(y)
+        @test 2 == @inferred JuMP.lower_bound(y)
         @test !JuMP.has_upper_bound(y)
         @test !JuMP.is_binary(y)
         @test JuMP.is_integer(y)
         @test JuMP.start_value(y) === 0.7
 
-        @test JuMP.name(z) == "z"
+        @test "z" == @inferred JuMP.name(z)
         @test !JuMP.has_lower_bound(z)
-        @test JuMP.upper_bound(z) == 3
+        @test 3 == @inferred JuMP.upper_bound(z)
         @test !JuMP.is_binary(z)
         @test !JuMP.is_integer(z)
-        @test JuMP.start_value(z) === 10
+        @test JuMP.start_value(z) === 10.0
 
-        @test JuMP.name(q) == "q"
+        @test "q" == @inferred JuMP.name(q)
         @test !JuMP.has_lower_bound(q)
         @test !JuMP.has_upper_bound(q)
         @test JuMP.is_binary(q)


### PR DESCRIPTION
As the MOI backend does not have a concrete type, Julia is not able to infer the result of the `MOI.get` calls. This PR adds type asserts to help inferrability and adds tests to unsure that the functions are now inferrable.

Closes https://github.com/JuliaOpt/JuMP.jl/issues/1824