### PR TITLE
DNMY: add solver-independent callbacks

### DIFF
--- a/examples/callbacks_glpk.jl
+++ b/examples/callbacks_glpk.jl
@@ -28,7 +28,7 @@ model = JuMP.direct_model(GLPK.Optimizer())
 # gets called.
 cb_calls = Symbol[]
 
-function my_lazy_callback(model, cb_data)
+function my_lazy_callback(cb_data)
     push!(cb_calls, :lazy)
     # Double check for sanity's sake that we have a feasible (given the
     # current constraints) point.
@@ -44,7 +44,7 @@ function my_lazy_callback(model, cb_data)
     end
 end
 
-function my_heuristic_callback(model, cb_data)
+function my_heuristic_callback(cb_data)
     push!(cb_calls, :heuristic)
     # Double check for sanity's sake that we have a feasible (given the
     # current constraints) point.

--- a/examples/callbacks_glpk.jl
+++ b/examples/callbacks_glpk.jl
@@ -1,0 +1,74 @@
+#  Copyright 2019, Iain Dunning, Joey Huchette, Miles Lubin, and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#############################################################################
+# JuMP
+# An algebraic modeling language for Julia
+# See http://github.com/JuliaOpt/JuMP.jl
+#############################################################################
+
+using JuMP, GLPK, Test
+
+# This special macro loads a module called GLPKExtensions, which exports the
+# `@lazy_constraint` macro.
+GLPK.@load_extensions
+
+model = JuMP.direct_model(GLPK.Optimizer())
+
+# Create the basic model. It is set up in such a way that the root relaxation
+# is fractional.
+@variable(model, 0 <= x <= 2, Int)
+@variable(model, 0 <= y <= 4, Int)
+@constraint(model, y <= 3.5 + x)
+@constraint(model, y <= 4.1 - 0.2x)
+@objective(model, Max, y)
+
+# This vector is going to cache the value of `cb_where` everytime our callback
+# gets called.
+cb_calls = Symbol[]
+
+function my_lazy_callback(model, cb_data)
+    push!(cb_calls, :lazy)
+    # Double check for sanity's sake that we have a feasible (given the
+    # current constraints) point.
+    @assert primal_status(model) == MOI.FEASIBLE_POINT
+    # Get the values of x and y.
+    x_val, y_val = value(x), value(y)
+    # Add the lazy constraints using the `@lazy_constraint` macro that was
+    # loaded by `@load_extensions`.
+    if y_val - x_val > 1.1 + 1e-6
+        @lazy_constraint(model, cb_data, y <= 1.1 + x)
+    elseif y_val + x_val > 3 + 1e-6
+        @lazy_constraint(model, cb_data, y <= 3 - x)
+    end
+end
+
+function my_heuristic_callback(model, cb_data)
+    push!(cb_calls, :heuristic)
+    # Double check for sanity's sake that we have a feasible (given the
+    # current constraints) point.
+    @assert primal_status(model) == MOI.FEASIBLE_POINT
+    # Get the values of x and y.
+    x_val, y_val = value(x), value(y)
+    # Provide a heuristic solution.
+    add_heuristic_solution(
+        model, cb_data, Dict(x => 1.0, y => 2.0))
+end
+
+set_callbacks(model;
+    lazy = my_lazy_callback,
+    heuristic = my_heuristic_callback
+)
+
+# Solve the model.
+optimize!(model)
+
+# Check the solution.
+@test value(x) == 1
+@test value(y) == 2
+
+# Check that our callback has been used.
+@test length(cb_calls) > 0
+@test :lazy in cb_calls
+@test :heuristic in cb_calls

--- a/examples/callbacks_glpk.jl
+++ b/examples/callbacks_glpk.jl
@@ -31,8 +31,7 @@ function my_lazy_callback(cb_data)
     @assert primal_status(model) == MOI.FEASIBLE_POINT
     # Get the values of x and y.
     x_val, y_val = value(x), value(y)
-    # Add the lazy constraints using the `@lazy_constraint` macro that was
-    # loaded by `@load_extensions`.
+    # Add the lazy constraints using the `@lazy_constraint` macro.
     if y_val - x_val > 1.1 + 1e-6
         @lazy_constraint(model, cb_data, y <= 1.1 + x)
     elseif y_val + x_val > 3 + 1e-6

--- a/examples/callbacks_glpk.jl
+++ b/examples/callbacks_glpk.jl
@@ -10,10 +10,6 @@
 
 using JuMP, GLPK, Test
 
-# This special macro loads a module called GLPKExtensions, which exports the
-# `@lazy_constraint` macro.
-GLPK.@load_extensions
-
 model = JuMP.direct_model(GLPK.Optimizer())
 
 # Create the basic model. It is set up in such a way that the root relaxation
@@ -24,8 +20,8 @@ model = JuMP.direct_model(GLPK.Optimizer())
 @constraint(model, y <= 4.1 - 0.2x)
 @objective(model, Max, y)
 
-# This vector is going to cache the value of `cb_where` everytime our callback
-# gets called.
+# This vector is going to cache a descriptive symbol everytime our callback gets
+# called.
 cb_calls = Symbol[]
 
 function my_lazy_callback(cb_data)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -680,6 +680,7 @@ include("macros.jl")
 include("optimizer_interface.jl")
 include("nlp.jl")
 include("print.jl")
+include("callbacks.jl")
 
 # JuMP exports everything except internal symbols, which are defined as those
 # whose name starts with an underscore. If you don't want all of these symbols

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -9,6 +9,28 @@
 #############################################################################
 
 """
+    set_callbacks(model::Model; lazy = nothing, heuristic = nothing)
+
+Set an (optional) lazy and heuristic callback. This can be used only when
+`JuMP.mode(mode) == DIRECT`.
+
+Each callback must be a function that takes one argument, a solver-specific type
+`cb_data`.
+
+### Example
+
+    set_callbacks(model;
+        lazy = (cb_data) -> println("Called from lazy callback.")
+    )
+"""
+function set_callbacks(model::Model; lazy = nothing, heuristic = nothing)
+    if JuMP.mode(model) != JuMP.DIRECT
+        error("You must use a solver in DIRECT mode to use callbacks in JuMP.")
+    end
+    MOI.set(JuMP.backend(model), MOI.Callbacks(lazy=lazy, heuristic=heuristic))
+end
+
+"""
     @lazy_constraint(model, cb_data, expr)
 
 Add a lazy constraint (where the constraint is given by `expr`) to `model`.
@@ -22,8 +44,8 @@ This can be called *only* from a lazy callback set by `JuMP.set_callbacks`.
 macro lazy_constraint(model, cb_data, expr)
     code = quote
         lazy_con = @build_constraint $expr
-        add_lazy_constraint(
-            $model,
+        MOI.add_lazy_constraint(
+            JuMP.backend($model),
             $cb_data,
             JuMP.moi_function(lazy_con.func),
             lazy_con.set
@@ -38,55 +60,6 @@ macro lazy_constraint(model, cb_data, expr)
 end
 
 """
-    set_callbacks(model::Model; lazy = nothing, heuristic = nothing)
-
-Set an (optional) lazy and heuristic callback. This can be used only when
-`JuMP.mode(mode) == DIRECT`.
-
-Each callback must be a function that takes two arguments: the backend
-`optimizer` object (returned by `JuMP.backend(model)`), and a solver-specific
-type `cb_data`.
-
-### Example
-
-    set_callbacks(model;
-        lazy = (optimizer, cb_data) -> println("Called from lazy callback.")
-    )
-"""
-function set_callbacks(model::Model; lazy = nothing, heuristic = nothing)
-    if JuMP.mode(model) != JuMP.DIRECT
-        error("You must use a solver in DIRECT mode to use callbacks in JuMP.")
-    end
-    _set_callbacks(JuMP.backend(model), lazy, heuristic)
-end
-
-"""
-    _set_callbacks(optimizer::MOI.ModelLike,
-                   lazy::Union{Nothing, Function},
-                   heuristic::Union{Nothing, Function})
-
-An internal JuMP function that should be overloaded by each solver.
-"""
-function _set_callbacks(optimizer, lazy, heuristic)
-    error("The model $(typeof(optimizer)) does not support callbacks.")
-end
-
-"""
-    add_lazy_constraint(model, cb_data, func, set)
-
-Add a lazy constraint `func`-in-`set` to `model`.
-
-This can be called only from a lazy callback set by `set_callbacks`.
-"""
-function add_lazy_constraint(model::JuMP.Model, cb_data, func, set)
-    add_lazy_constraint(JuMP.backend(model), cb_data, func, set)
-end
-
-function add_lazy_constraint(model, cb_data, func, set)
-    error("add_lazy_constraint not supported by this solver.")
-end
-
-"""
     add_heuristic_solution(model, cb_data, sol::Dict{JuMP.VariableRef, Float64})
 
 Provide the heuristic solution given by the variable-value mapping of `sol` to
@@ -94,10 +67,8 @@ Provide the heuristic solution given by the variable-value mapping of `sol` to
 
 This can be called only from a heuristic callback set by `set_callbacks`.
 """
-function add_heuristic_solution(model::JuMP.Model, cb_data, sol)
-    add_heuristic_solution(JuMP.backend(model), cb_data, sol)
-end
-
-function add_heuristic_solution(model, cb_data, sol)
-    error("add_heuristic_solution not supported by this solver.")
+function add_heuristic_solution(
+        model::JuMP.Model, cb_data, sol::Dict{JuMP.VariableRef, Float64})
+    MOI.add_heuristic_solution(JuMP.backend(model), cb_data, Dict(
+        index(variable) => value for (variable, value) in sol))
 end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -1,0 +1,95 @@
+#  Copyright 2019, Iain Dunning, Joey Huchette, Miles Lubin, and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#############################################################################
+# JuMP
+# An algebraic modeling language for Julia
+# See http://github.com/JuliaOpt/JuMP.jl
+#############################################################################
+
+"""
+    @lazy_constraint(model, cb_data, expr)
+
+Add a lazy constraint (where the constraint is given by `expr`) to `model`.
+
+This can be called *only* from a lazy callback set by `JuMP.set_callbacks`.
+
+### Examples
+
+    @lazy_constraint(model, cb_data, 2x + y <+ 1)
+"""
+macro lazy_constraint(model, cb_data, expr)
+    code = quote
+        lazy_con = @build_constraint $expr
+        add_lazy_constraint(
+            $model,
+            $cb_data,
+            JuMP.moi_function(lazy_con.func),
+            lazy_con.set
+        )
+
+    end
+    quote
+        let
+            $(esc(code))
+        end
+    end
+end
+
+"""
+    set_callbacks(model::Model; lazy = nothing, heuristic = nothing)
+
+Set an (optional) lazy and heuristic callback. This can be used only when
+`JuMP.mode(mode) == DIRECT`.
+
+Each callback must be a function that takes two arguments: the backend
+`optimizer` object (returned by `JuMP.backend(model)`), and a solver-specific
+type `cb_data`.
+
+### Example
+
+    set_callbacks(model;
+        lazy = (optimizer, cb_data) -> println("Called from lazy callback.")
+    )
+"""
+function set_callbacks(model::Model; lazy = nothing, heuristic = nothing)
+    if JuMP.mode(model) != JuMP.DIRECT
+        error("You must use a solver in DIRECT mode to use callbacks in JuMP.")
+    end
+    _set_callbacks(model, JuMP.backend(model), lazy, heuristic)
+end
+
+"""
+    _set_callbacks(model::Model, optimizer::MOI.ModelLike,
+                   lazy::Union{Nothing, Function},
+                   heuristic::Union{Nothing, Function})
+
+An internal JuMP function that should be overloaded by each solver.
+"""
+function _set_callbacks(model, optimizer, lazy, heuristic)
+    error("The model $(typeof(optimizer)) does not support callbacks.")
+end
+
+"""
+    add_lazy_constraint(model, cb_data, func, set)
+
+Add a lazy constraint `func`-in-`set` to `model`.
+
+This can be called only from a lazy callback set by `set_callbacks`.
+"""
+function add_lazy_constraint(model, cb_data, func, set)
+    error("add_lazy_constraint not supported by this solver.")
+end
+
+"""
+    add_heuristic_solution(model, cb_data, sol::Dict{JuMP.VariableRef, Float64})
+
+Provide the heuristic solution given by the variable-value mapping of `sol` to
+`model`.
+
+This can be called only from a heuristic callback set by `set_callbacks`.
+"""
+function add_heuristic_solution(model, cb_data, sol)
+    error("add_heuristic_solution not supported by this solver.")
+end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -57,17 +57,17 @@ function set_callbacks(model::Model; lazy = nothing, heuristic = nothing)
     if JuMP.mode(model) != JuMP.DIRECT
         error("You must use a solver in DIRECT mode to use callbacks in JuMP.")
     end
-    _set_callbacks(model, JuMP.backend(model), lazy, heuristic)
+    _set_callbacks(JuMP.backend(model), lazy, heuristic)
 end
 
 """
-    _set_callbacks(model::Model, optimizer::MOI.ModelLike,
+    _set_callbacks(optimizer::MOI.ModelLike,
                    lazy::Union{Nothing, Function},
                    heuristic::Union{Nothing, Function})
 
 An internal JuMP function that should be overloaded by each solver.
 """
-function _set_callbacks(model, optimizer, lazy, heuristic)
+function _set_callbacks(optimizer, lazy, heuristic)
     error("The model $(typeof(optimizer)) does not support callbacks.")
 end
 
@@ -78,6 +78,10 @@ Add a lazy constraint `func`-in-`set` to `model`.
 
 This can be called only from a lazy callback set by `set_callbacks`.
 """
+function add_lazy_constraint(model::JuMP.Model, cb_data, func, set)
+    add_lazy_constraint(JuMP.backend(model), cb_data, func, set)
+end
+
 function add_lazy_constraint(model, cb_data, func, set)
     error("add_lazy_constraint not supported by this solver.")
 end
@@ -90,6 +94,10 @@ Provide the heuristic solution given by the variable-value mapping of `sol` to
 
 This can be called only from a heuristic callback set by `set_callbacks`.
 """
+function add_heuristic_solution(model::JuMP.Model, cb_data, sol)
+    add_heuristic_solution(JuMP.backend(model), cb_data, sol)
+end
+
 function add_heuristic_solution(model, cb_data, sol)
     error("add_heuristic_solution not supported by this solver.")
 end


### PR DESCRIPTION
This PR re-introduces a limited form of solver-independent(-ish) callbacks in JuMP.

See the following PR for the API added to MOI.

MathOptInterface: https://github.com/JuliaOpt/MathOptInterface.jl/pull/670

See the following PRs for the solver-specific implementations.

GLPK: https://github.com/JuliaOpt/GLPK.jl/pull/91
Gurobi: https://github.com/JuliaOpt/Gurobi.jl/pull/194

#### What these are 

A convenient way of accessing some limited functionality of the lazy constraint and heuristic callbacks. 

These are solver-independent to the extent that

*Lazy callback*
- the lazy constraint callback *may* be called when the solver has an integer primal solution
- you can only access the primal solution through `JuMP.value`. That is, `JuMP.dual` etc will not work.
- when the solver terminates, it will provide a solution that satisfies all lazy constraints
- we make no claims about what happens to solutions during the B&B tree

*Heuristic callback*
- the heuristic callback *may* be called when the solver has a non-integer solution
- the solver may accept or reject the solution
- some solvers require a complete solution, others only partial solutions. It's up to you to provide the appropriate one. If in doubt, give a complete solution

#### What these are not

Generic solver-independent callbacks. If you want more control, use the solver-specific ones.

#### Requirements before merging

- [ ] MOI PR is merged and tagged
- [ ] GLPK PR is merged and tagged
- [ ] documentation

Closes https://github.com/JuliaOpt/JuMP.jl/issues/1553