### PR TITLE
Fix corner cases for optimizer_index

### DIFF
--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -674,6 +674,8 @@ constraint_object
 AbstractConstraint
 ScalarConstraint
 VectorConstraint
+index(::ConstraintRef)
+optimizer_index(::ConstraintRef{Model})
 ```
 
 ## Constructing constraints without adding them to the model

--- a/docs/src/solutions.md
+++ b/docs/src/solutions.md
@@ -76,8 +76,8 @@ is [`dual`](@ref). An equivalent way to check if the status is not
 `MOI.NO_SOLUTION` is by calling [`has_values`](@ref) for the primal status and
 [`has_duals`](@ref) for the dual solution.
 
-It is important to note that if [`has_values`](@ref) or [`has_duals`](@ref) 
-return false, calls to [`value`](@ref) and [`dual`](@ref) might throw an error 
+It is important to note that if [`has_values`](@ref) or [`has_duals`](@ref)
+return false, calls to [`value`](@ref) and [`dual`](@ref) might throw an error
 or return arbitrary values.
 
 The container type (e.g., scalar, vector, or matrix) of the returned solution
@@ -126,5 +126,6 @@ JuMP.value
 JuMP.dual_status
 JuMP.has_duals
 JuMP.dual
+OptimizeNotCalled
 MOI.optimize!
 ```

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -70,6 +70,7 @@ with_optimizer
 The factory can be provided either at model construction time or at
 [`optimize!`](@ref) time:
 ```@docs
+NoOptimizer
 JuMP.optimize!
 ```
 

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -631,4 +631,7 @@ is_binary
 set_binary
 unset_binary
 BinaryRef
+
+index(::VariableRef)
+optimizer_index(::VariableRef)
 ```

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -505,8 +505,8 @@ function _moi_optimizer_index(model::MOI.Bridges.LazyBridgeOptimizer,
                               index::MOI.Index)
     if index isa MOI.ConstraintIndex &&
         MOI.Bridges.is_bridged(model, typeof(index))
-        error("There is not `optimizer_index` for $(typeof(index)) constraints",
-              " as they are bridged.")
+        error("There is no `optimizer_index` for $(typeof(index)) constraints",
+              " because they are bridged.")
     else
         return _moi_optimizer_index(model.model, index)
     end
@@ -516,9 +516,9 @@ end
 """
     optimizer_index(v::VariableRef)::MOI.VariableIndex
 
-Return the index of the variable `v` for the optimizer. It throws
-[`NoOptimizer`](@ref) if no optimizer is set and throws an `ErrorException` if
-the optimizer is set but is not attached.
+Return the index of the variable that corresponds to `v` in the optimizer model.
+It throws [`NoOptimizer`](@ref) if no optimizer is set and throws an
+`ErrorException` if the optimizer is set but is not attached.
 """
 function optimizer_index(v::VariableRef)
     model = owner_model(v)
@@ -532,9 +532,10 @@ end
 """
     optimizer_index(cr::ConstraintRef{Model})::MOI.ConstraintIndex
 
-Return the index of the constraint `cr` for the optimizer. It throws
-[`NoOptimizer`](@ref) if no optimizer is set and throws an `ErrorException` if
-the optimizer is set but is not attached or if the constraint is bridged.
+Return the index of the constraint that corresponds to `cr` in the optimizer
+model. It throws [`NoOptimizer`](@ref) if no optimizer is set and throws an
+`ErrorException` if the optimizer is set but is not attached or if the
+constraint is bridged.
 """
 function optimizer_index(cr::ConstraintRef{Model})
     if mode(cr.model) == DIRECT
@@ -547,7 +548,7 @@ end
 """
     index(cr::ConstraintRef)::MOI.ConstraintIndex
 
-Return the index of the constraint `cr` for the MOI backend.
+Return the index of the constraint that corresponds to `cr` in the MOI backend.
 """
 index(cr::ConstraintRef) = cr.index
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -487,25 +487,68 @@ function Base.copy(v::AbstractArray{VariableRef}, new_model::AbstractModel)
     return (var -> VariableRef(new_model, var.index)).(v)
 end
 
+_moi_optimizer_index(model::MOI.AbstractOptimizer, index::MOI.Index) = index
+function _moi_optimizer_index(model::MOIU.CachingOptimizer, index::MOI.Index)
+    if MOIU.state(model) == MOIU.NO_OPTIMIZER
+        throw(NoOptimizer())
+    elseif MOIU.state(model) == MOIU.EMPTY_OPTIMIZER
+        error("There is no `optimizer_index` as the optimizer is not ",
+              "synchronized with the cached model. Call ",
+              "`MOIU.attach_optimizer(model)` to synchronize it.")
+    else
+        @assert MOIU.state(model) == MOIU.ATTACHED_OPTIMIZER
+        return _moi_optimizer_index(model.optimizer,
+                                    model.model_to_optimizer_map[index])
+    end
+end
+function _moi_optimizer_index(model::MOI.Bridges.LazyBridgeOptimizer,
+                              index::MOI.Index)
+    if index isa MOI.ConstraintIndex &&
+        MOI.Bridges.is_bridged(model, typeof(index))
+        error("There is not `optimizer_index` for $(typeof(index)) constraints",
+              " as they are bridged.")
+    else
+        return _moi_optimizer_index(model.model, index)
+    end
+end
+
+
+"""
+    optimizer_index(v::VariableRef)::MOI.VariableIndex
+
+Return the index of the variable `v` for the optimizer. It throws
+[`NoOptimizer`](@ref) if no optimizer is set and throws an `ErrorException` if
+the optimizer is set but is not attached.
+"""
 function optimizer_index(v::VariableRef)
     model = owner_model(v)
     if mode(model) == DIRECT
         return index(v)
     else
-        @assert backend(model).state == MOIU.ATTACHED_OPTIMIZER
-        return backend(model).model_to_optimizer_map[index(v)]
+        return _moi_optimizer_index(backend(model), index(v))
     end
 end
 
+"""
+    optimizer_index(cr::ConstraintRef{Model})::MOI.ConstraintIndex
+
+Return the index of the constraint `cr` for the optimizer. It throws
+[`NoOptimizer`](@ref) if no optimizer is set and throws an `ErrorException` if
+the optimizer is set but is not attached or if the constraint is bridged.
+"""
 function optimizer_index(cr::ConstraintRef{Model})
     if mode(cr.model) == DIRECT
         return index(cr)
     else
-        @assert backend(cr.model).state == MOIU.ATTACHED_OPTIMIZER
-        return backend(cr.model).model_to_optimizer_map[index(cr)]
+        return _moi_optimizer_index(backend(cr.model), index(cr))
     end
 end
 
+"""
+    index(cr::ConstraintRef)::MOI.ConstraintIndex
+
+Return the index of the constraint `cr` for the MOI backend.
+"""
 index(cr::ConstraintRef) = cr.index
 
 """
@@ -515,8 +558,16 @@ A result attribute cannot be queried before [`optimize!`](@ref) is called.
 """
 struct OptimizeNotCalled <: Exception end
 
+"""
+    struct NoOptimizer <: Exception end
+
+No optimizer is set. The optimizer can be provided at the [`Model`](@ref)
+constructor or at the [`optimize!`](@ref) call with [`with_optimizer`](@ref).
+"""
+struct NoOptimizer <: Exception end
+
 # Throws an error if `optimize!` has not been called, i.e., if there is no
-# optimizer attached or if the termination statis is `MOI.OPTIMIZE_NOT_CALLED`.
+# optimizer attached or if the termination status is `MOI.OPTIMIZE_NOT_CALLED`.
 function _moi_get_result(model::MOI.ModelLike, args...)
     if MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
         throw(OptimizeNotCalled())
@@ -524,8 +575,9 @@ function _moi_get_result(model::MOI.ModelLike, args...)
     return MOI.get(model, args...)
 end
 function _moi_get_result(model::MOIU.CachingOptimizer, args...)
-    if MOIU.state(model) == MOIU.NO_OPTIMIZER ||
-       MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
+    if MOIU.state(model) == MOIU.NO_OPTIMIZER
+        throw(NoOptimizer())
+    elseif MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
         throw(OptimizeNotCalled())
     end
     return MOI.get(model, args...)

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -125,7 +125,7 @@ function optimize!(model::Model,
         return model.optimize_hook(model)
     end
 
-    if MOIU.state(backend(model)) == MOIU.NO_OPTIMIZER
+    if model(model) != DIRECT && MOIU.state(backend(model)) == MOIU.NO_OPTIMIZER
         throw(NoOptimizer())
     end
 

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -74,7 +74,9 @@ end
 
 Optimize the model. If `optimizer_factory` is not `nothing`, it first sets the
 optimizer to a new one created using the optimizer factory. The factory can be
-created using the [`with_optimizer`](@ref) function.
+created using the [`with_optimizer`](@ref) function. If `optimizer_factor` is
+`nothing` and no optimizer was set to `model` before calling this function, a
+[`NoOptimizer`](@ref) error is thrown.
 
 ## Examples
 

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -74,7 +74,7 @@ end
 
 Optimize the model. If `optimizer_factory` is not `nothing`, it first sets the
 optimizer to a new one created using the optimizer factory. The factory can be
-created using the [`with_optimizer`](@ref) function. If `optimizer_factor` is
+created using the [`with_optimizer`](@ref) function. If `optimizer_factory` is
 `nothing` and no optimizer was set to `model` before calling this function, a
 [`NoOptimizer`](@ref) error is thrown.
 

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -125,7 +125,7 @@ function optimize!(model::Model,
         return model.optimize_hook(model)
     end
 
-    if model(model) != DIRECT && MOIU.state(backend(model)) == MOIU.NO_OPTIMIZER
+    if mode(model) != DIRECT && MOIU.state(backend(model)) == MOIU.NO_OPTIMIZER
         throw(NoOptimizer())
     end
 

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -67,7 +67,6 @@ function solve(::Model)
           "and `dual_status`.")
 end
 
-
 """
     optimize!(model::Model,
               optimizer_factory::Union{Nothing, OptimizerFactory}=nothing;
@@ -122,6 +121,10 @@ function optimize!(model::Model,
     # that instead of solving the model ourselves
     if !ignore_optimize_hook
         return model.optimize_hook(model)
+    end
+
+    if MOIU.state(backend(model)) == MOIU.NO_OPTIMIZER
+        throw(NoOptimizer())
     end
 
     MOI.optimize!(backend(model))

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -189,6 +189,11 @@ function Base.isequal(v1::VariableRef, v2::VariableRef)
     return owner_model(v1) === owner_model(v2) && v1.index == v2.index
 end
 
+"""
+    index(v::VariableRef)::MOI.VariableIndex
+
+Return the index of the variable `v` for the MOI backend.
+"""
 index(v::VariableRef) = v.index
 
 function VariableRef(m::Model)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -192,7 +192,7 @@ end
 """
     index(v::VariableRef)::MOI.VariableIndex
 
-Return the index of the variable `v` for the MOI backend.
+Return the index of the variable that corresponds to `v` in the MOI backend.
 """
 index(v::VariableRef) = v.index
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -42,9 +42,23 @@ end
 include("nonnegative_bridge.jl")
 
 function test_model()
+    @testset "NoOptimizer" begin
+        err = NoOptimizer()
+        model = Model()
+        @variable(model, x)
+        @test_throws err optimizer_index(x)
+        cref = @constraint(model, x == 1)
+        @test_throws err JuMP.optimizer_index(cref)
+        @test_throws err JuMP.optimize!(model)
+        @test_throws err JuMP.value(x)
+        @test_throws err JuMP.value(cref)
+        @test_throws err JuMP.dual(cref)
+    end
+
     @testset "Result attributes" begin
         err = JuMP.OptimizeNotCalled()
-        model = Model()
+        model = Model(with_optimizer(MOIU.MockOptimizer,
+                                     SimpleLPModel{Float64}()))
         @variable(model, x)
         c = @constraint(model, x ≤ 0)
         @objective(model, Max, x)
@@ -172,9 +186,20 @@ function test_model()
             @test JuMP.backend(model).optimizer.model isa MOIU.CachingOptimizer
             @test JuMP.backend(model).optimizer.model.optimizer isa MOIU.MockOptimizer
             @variable model x
+            err = ErrorException(
+                "There is no `optimizer_index` as the optimizer is not " *
+                "synchronized with the cached model. Call " *
+                "`MOIU.attach_optimizer(model)` to synchronize it.")
+            @test_throws err optimizer_index(x)
             cref = @constraint model 0 <= x + 1 <= 1
             @test cref isa JuMP.ConstraintRef{JuMP.Model,MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.Interval{Float64}}}
+            @test_throws err optimizer_index(cref)
             JuMP.optimize!(model)
+            @test optimizer_index(x) === MOI.get(JuMP.backend(model).optimizer.model.optimizer, MOI.ListOfVariableIndices())[1]
+            err = ErrorException(
+                "There is not `optimizer_index` for $(typeof(index(cref))) " *
+                "constraints as they are bridged.")
+            @test_throws err optimizer_index(cref)
         end
         @testset "Automatic bridging disabled with `bridge_constraints` keyword" begin
             model = Model(with_optimizer(MOIU.MockOptimizer,

--- a/test/model.jl
+++ b/test/model.jl
@@ -197,8 +197,8 @@ function test_model()
             JuMP.optimize!(model)
             @test optimizer_index(x) === MOI.get(JuMP.backend(model).optimizer.model.optimizer, MOI.ListOfVariableIndices())[1]
             err = ErrorException(
-                "There is not `optimizer_index` for $(typeof(index(cref))) " *
-                "constraints as they are bridged.")
+                "There is no `optimizer_index` for $(typeof(index(cref))) " *
+                "constraints because they are bridged.")
             @test_throws err optimizer_index(cref)
         end
         @testset "Automatic bridging disabled with `bridge_constraints` keyword" begin


### PR DESCRIPTION
The PR also adds the `NoSolution` error which is thrown in `optimize!` if not optimizer is attached (instead of an AssertionError because the state is not `MOIU.ATTACHED_OPTIMIZER`)