### PR TITLE
Minor documentation fixes

### DIFF
--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -380,7 +380,7 @@ JuMP also supports modeling semi-continuous variables, whose domain is ``\{0\} �
 julia> @constraint(model, x in MOI.Semicontinuous(1.5, 3.5))
 x in MathOptInterface.Semicontinuous{Float64}(1.5, 3.5)
 ```
-as well as semi-integer variables, whose domain is ``{0} ∪ {l, l+1, \dots, u}``,
+as well as semi-integer variables, whose domain is ``\{0\} ∪ \{l, l+1, \dots, u\}``,
 using the `MOI.Semiinteger` set:
 ```jldoctest; setup = :(model = Model(); @variable(model, x))
 julia> @constraint(model, x in MOI.Semiinteger(1.0, 3.0))

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -602,7 +602,7 @@ You can query the types of constraints currently present in the model by calling
 [`all_constraints`](@ref) to access a list of their references. Then use
 [`constraint_object`](@ref) to get an instance of an
 [`AbstractConstraint`](@ref) object, either [`ScalarConstraint`](@ref) or
-[`VectorConstraint`](@ref) that stores the constraint data.
+[`VectorConstraint`](@ref), that stores the constraint data.
 
 ```jldoctest
 julia> model = Model();

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -363,7 +363,7 @@ constraints in the
 In [Variables](@ref), we saw how to modify the variable bounds, as well as add
 binary and integer restrictions to the domain of each variable. This can also be
 achieved using the [`@constraint`](@ref) macro. For example, `MOI.ZeroOne()`
-restricts the domain to ``\{0, 1\}:
+restricts the domain to ``\{0, 1\}``:
 ```jldoctest; setup = :(model = Model(); @variable(model, x))
 julia> @constraint(model, x in MOI.ZeroOne())
 x binary

--- a/docs/src/containers.md
+++ b/docs/src/containers.md
@@ -28,7 +28,7 @@ JuMP.Containers.generate_container
 ```
 
 In the [`@variable`](@ref) (resp. [`@constraint`](@ref)) macro, containers of
-variables (resp. constraints) can be created the following syntax
+variables (resp. constraints) can be created with the following syntax:
 
 * `name[index_set_1, index_set_2, ..., index_set_n]` creating an `n`-dimensional
   container of name `name`; or

--- a/docs/src/expressions.md
+++ b/docs/src/expressions.md
@@ -48,7 +48,7 @@ example
 ```jldoctest
 model = Model()
 @variable(model, x[i = 1:3])
-@expression(model, expr[i=1:3], i * sum(x[j] for j in i:3))
+@expression(model, expr[i = 1:3], i * sum(x[j] for j in i:3))
 expr
 
 # output

--- a/docs/src/expressions.md
+++ b/docs/src/expressions.md
@@ -191,10 +191,10 @@ x² + 2 x*y + y² + x + y - 1
 ## Nonlinear expressions
 
 Nonlinear expressions can be constructed only using the [`@NLexpression`](@ref)
-macro, and nonlinear expressions can be used only in [`@NLobjective`](@ref),
-[`@NLconstraint`](@ref), and other [`@NLexpression`](@ref)s. Moreover, quadratic
-and affine expressions cannot be used in the nonlinear macros. For more details,
-see the [Nonlinear Modeling](@ref) section.
+macro and can be used only in [`@NLobjective`](@ref), [`@NLconstraint`](@ref),
+and other [`@NLexpression`](@ref)s. Moreover, quadratic and affine expressions
+cannot be used in the nonlinear macros. For more details, see the [Nonlinear
+Modeling](@ref) section. 
 
 ## Reference
 

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -5,16 +5,22 @@ CurrentModule = JuMP
 Extending JuMP
 ==============
 
+```@meta
 TODO: How to extend JuMP: discussion on different ways to build on top of JuMP.
 How to extend JuMP's macros and how to avoid doing this.
+```
 
 ## Extending MOI
 
+```@meta
 TODO: Create new MOI function/sets, how to use it in JuMP
+```
 
 ### Adding a bridge
 
+```@meta
 TODO: create new bridge
+```
 
 See the [bridge section in the MOI manual](http://www.juliaopt.org/MathOptInterface.jl/v0.8/apimanual/#Constraint-bridges-1).
 
@@ -35,7 +41,9 @@ provide a more consistent interface to the user.
 
 ## Extending the `@variable` macro
 
+```@meta
 TODO: parse/build/add
+```
 
 ## Extending the `@constraint` macro
 

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -13,7 +13,7 @@ Extending JuMP
 ## Extending MOI
 
 ```@meta
-TODO: Create new MOI function/sets, how to use it in JuMP
+# TODO: Create new MOI function/sets, how to use it in JuMP
 ```
 
 ### Adding a bridge

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -6,8 +6,8 @@ Extending JuMP
 ==============
 
 ```@meta
-TODO: How to extend JuMP: discussion on different ways to build on top of JuMP.
-How to extend JuMP's macros and how to avoid doing this.
+# TODO: How to extend JuMP: discussion on different ways to build on top of JuMP.
+# How to extend JuMP's macros and how to avoid doing this.
 ```
 
 ## Extending MOI
@@ -19,7 +19,7 @@ TODO: Create new MOI function/sets, how to use it in JuMP
 ### Adding a bridge
 
 ```@meta
-TODO: create new bridge
+# TODO: create new bridge
 ```
 
 See the [bridge section in the MOI manual](http://www.juliaopt.org/MathOptInterface.jl/v0.8/apimanual/#Constraint-bridges-1).
@@ -42,7 +42,7 @@ provide a more consistent interface to the user.
 ## Extending the `@variable` macro
 
 ```@meta
-TODO: parse/build/add
+# TODO: parse/build/add
 ```
 
 ## Extending the `@constraint` macro

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -78,7 +78,9 @@ Most packages follow the `ModuleName.Optimizer` naming convention, but
 exceptions may exist. See the corresponding Julia package README for more
 details on how to use the solver.
 
+```@meta
 TODO: Discuss setting solver options.
+```
 
 The following solvers were compatible with JuMP up to release 0.18 but are
 not yet compatible with the latest version because they do not implement the

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -79,7 +79,7 @@ exceptions may exist. See the corresponding Julia package README for more
 details on how to use the solver.
 
 ```@meta
-TODO: Discuss setting solver options.
+# TODO: Discuss setting solver options.
 ```
 
 The following solvers were compatible with JuMP up to release 0.18 but are

--- a/docs/src/nlp.md
+++ b/docs/src/nlp.md
@@ -213,7 +213,7 @@ register(model, :my_square, 1, my_square, autodiff=true)
 ```
 
 The above code creates a JuMP model with the objective function
-`(x[1] - 1)^2 + (x[2]^2 - 2)^2`. The first argument to `register` the
+`(x[1] - 1)^2 + (x[2]^2 - 2)^2`. The first argument to `register` is the
 model for which the functions are registered. The second argument is a Julia
 symbol object which serves as the name of the user-defined function in JuMP
 expressions; the JuMP name need not be the same as the name of the corresponding

--- a/docs/src/nlp.md
+++ b/docs/src/nlp.md
@@ -383,8 +383,10 @@ julia> index(cons2)
 NonlinearConstraintIndex(2)
 ```
 
+```@meta
 TODO: Provide a link for how to access the linear and quadratic parts of the
 model.
+```
 
 Note that for one-sided nonlinear constraints, JuMP subtracts any values on the
 right-hand side when computing expressions. In other words, one-sided nonlinear

--- a/docs/src/nlp.md
+++ b/docs/src/nlp.md
@@ -235,15 +235,15 @@ JuMP.register(model::Model, s::Symbol, dimension::Integer, f::Function,
               ∇f::Function, ∇²f::Function)
 ```
 
-The input differs for functions which take a single input argument and functions
-which take more than one. For univariate functions, the derivative evaluation
-routines should return a number which represents the first and second-order
-derivatives respectively. For multivariate functions, the derivative evaluation
-routines will be passed a gradient vector which they must explicitly fill.
-Second-order derivatives of multivariate functions are not currently supported;
-this argument should be omitted. The following example sets up the same
-optimization problem as before, but now we explicitly provide evaluation
-routines for the user-defined functions:
+The input differs between functions which take a single input argument and
+functions which take more than one. For univariate functions, the derivative
+evaluation routines should return a number which represents the first and
+second-order derivatives respectively. For multivariate functions, the
+derivative evaluation routines will be passed a gradient vector which they must
+explicitly fill. Second-order derivatives of multivariate functions are not
+currently supported; this argument should be omitted. The following example sets
+up the same optimization problem as before, but now we explicitly provide
+evaluation routines for the user-defined functions:
 
 ```julia
 my_square(x) = x^2

--- a/docs/src/nlp.md
+++ b/docs/src/nlp.md
@@ -384,8 +384,8 @@ NonlinearConstraintIndex(2)
 ```
 
 ```@meta
-TODO: Provide a link for how to access the linear and quadratic parts of the
-model.
+# TODO: Provide a link for how to access the linear and quadratic parts of the
+# model.
 ```
 
 Note that for one-sided nonlinear constraints, JuMP subtracts any values on the

--- a/docs/src/objective.md
+++ b/docs/src/objective.md
@@ -1,13 +1,17 @@
 Objective
 =========
 
+```@meta
 TODO: Describe how the objective is represented (link to MOI docs)
+```
 
 Objective functions
 -------------------
 
+```@meta
 TODO: Describe how JuMP expressions relate to MOI functions. How to set, query,
 and modify an objective function.
+```
 
 Setting the objective function and objective sense:
 ```@docs

--- a/docs/src/objective.md
+++ b/docs/src/objective.md
@@ -2,15 +2,15 @@ Objective
 =========
 
 ```@meta
-TODO: Describe how the objective is represented (link to MOI docs)
+# TODO: Describe how the objective is represented (link to MOI docs)
 ```
 
 Objective functions
 -------------------
 
 ```@meta
-TODO: Describe how JuMP expressions relate to MOI functions. How to set, query,
-and modify an objective function.
+# TODO: Describe how JuMP expressions relate to MOI functions. How to set, query,
+# and modify an objective function.
 ```
 
 Setting the objective function and objective sense:

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -122,8 +122,8 @@ end
 
 After the call to `JuMP.optimize!` has finished, we need to query what happened.
 The solve could terminate for a number of reasons. First, the solver might
-have found the optimal solution, or proved that the problem is infeasible.
-However, it might also have run into numerical difficulties, or terminated due
+have found the optimal solution or proved that the problem is infeasible.
+However, it might also have run into numerical difficulties or terminated due
 to a setting such as a time limit. We can ask the solver why it stopped using
 the `JuMP.termination_status` function:
 ```jldoctest quickstart_example

--- a/docs/src/solutions.md
+++ b/docs/src/solutions.md
@@ -10,7 +10,7 @@ end
 So far we have seen all the elements and constructs related to writing a JuMP
 optimization model. In this section we reach the point of what to do with a
 solved problem. Suppose your model is named `model`. Right after the call to
-`optimize!(model)` it's natural to ask JuMP questions about the finished
+`optimize!(model)`, it's natural to ask JuMP questions about the finished
 optimization step. Typical questions include:
  - Why has the optimization process stopped? Did it hit the time limit or run
    into numerical issues?

--- a/docs/src/solutions.md
+++ b/docs/src/solutions.md
@@ -72,9 +72,9 @@ Common status situations are described in the
 
 Provided the primal status is not `MOI.NO_SOLUTION`, the primal solution can
 be obtained by calling [`value`](@ref). For the dual solution, the function
-is [`dual`](@ref). An equivalent way to check if the status is not
-`MOI.NO_SOLUTION` is by calling [`has_values`](@ref) for the primal status and
-[`has_duals`](@ref) for the dual solution.
+is [`dual`](@ref). Calling [`has_values`](@ref) for the primal status and
+[`has_duals`](@ref) for the dual solution is an equivalent way to check whether
+the status is `MOI.NO_SOLUTION`. 
 
 It is important to note that if [`has_values`](@ref) or [`has_duals`](@ref) 
 return false, calls to [`value`](@ref) and [`dual`](@ref) might throw an error 

--- a/docs/src/solutions.md
+++ b/docs/src/solutions.md
@@ -54,7 +54,7 @@ MOI.TerminationStatusCode
 ## Solution statuses
 
 These statuses indicate what kind of result is available to be queried
-with [`value`](@ref) and [`dual`](@ref). Its possible that no result
+with [`value`](@ref) and [`dual`](@ref). It's possible that no result
 is available to be queried.
 
 We can obtain these statuses by calling [`primal_status`](@ref) for the

--- a/docs/src/solutions.md
+++ b/docs/src/solutions.md
@@ -84,7 +84,7 @@ The container type (e.g., scalar, vector, or matrix) of the returned solution
 (primal or dual) depends on the type of the variable or constraint. See
 [`AbstractShape`](@ref) and [`dual_shape`](@ref) for details.
 
-To call [`value`](@ref) or [`dual`](@ref) on container of
+To call [`value`](@ref) or [`dual`](@ref) on containers of
 [`VariableRef`](@ref) or [`ConstraintRef`](@ref), use the broadcast syntax,
 e.g., `value.(x)`.
 

--- a/docs/src/solutions.md
+++ b/docs/src/solutions.md
@@ -28,10 +28,10 @@ solver found an optimal solution, the problem was proven to be infeasible, or a
 user-provided limit such as a time limit was encountered. For more information,
 see the [Termination statuses](@ref) section below.
 
-Second, we can query the [`primal_status`](@ref) and [`dual_status`](@ref),
-which will tell us what kind of result we have for our primal and dual
-solution. This might be an optimal primal-dual pair, a primal solution without a
-corresponding dual solution, or a certificate of primal or dual infeasibility.
+Second, we can query the [`primal_status`](@ref) and the [`dual_status`](@ref),
+which will tell us what kind of results we have for our primal and dual
+solutions. This might be an optimal primal-dual pair, a primal solution without 
+a corresponding dual solution, or a certificate of primal or dual infeasibility.
 For more information, see the [Solution statuses](@ref) section below.
 
 Third, we can query [`value`](@ref) and [`dual`](@ref) to obtain the

--- a/docs/src/solutions.md
+++ b/docs/src/solutions.md
@@ -92,8 +92,8 @@ The objective value of a solved problem can be obtained via
 [`objective_value`](@ref). The best known bound on the optimal objective
 value can be obtained via [`objective_bound`](@ref).
 
-A recommended workflow for solving a model and querying the solution is the
-following:
+The following is a recommended workflow for solving a model and querying the
+solution: 
 ```julia
 using JuMP
 model = Model()

--- a/docs/src/solutions.md
+++ b/docs/src/solutions.md
@@ -70,7 +70,7 @@ Common status situations are described in the
 
 ## Obtaining solutions
 
-Provided the primal status is not (`MOI.NO_SOLUTION`), the primal solution can
+Provided the primal status is not `MOI.NO_SOLUTION`, the primal solution can
 be obtained by calling [`value`](@ref). For the dual solution, the function
 is [`dual`](@ref). An equivalent way to check if the status is not
 `MOI.NO_SOLUTION` is by calling [`has_values`](@ref) for the primal status and

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -79,7 +79,9 @@ Model()
 Model(::JuMP.OptimizerFactory)
 ```
 
+```@meta
 TODO: how to control the caching optimizer states
+```
 
 ## Direct mode
 

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -80,7 +80,7 @@ Model(::JuMP.OptimizerFactory)
 ```
 
 ```@meta
-TODO: how to control the caching optimizer states
+# TODO: how to control the caching optimizer states
 ```
 
 ## Direct mode

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -7,7 +7,7 @@ problem and acts as the optimization solver. We call it an MOI *backend* and not
 optimizer as it can also be a wrapper around an optimization file format such as
 MPS that writes the JuMP model in a file. From JuMP, the MOI
 backend can be accessed using the [`backend`](@ref) function. JuMP can be
-viewed as a lightweight user-friendly layer on top of the MOI backend, in the
+viewed as a lightweight, user-friendly layer on top of the MOI backend, in the
 sense that:
 
 * JuMP does not maintain any copy of the model outside this MOI backend.
@@ -24,7 +24,7 @@ While this allows JuMP to be a thin wrapper on top of the solver API, as
 mentioned in the last point above, this seems rather demanding on the solver.
 Indeed, while some solvers support incremental building of the model and
 modifications before and after solve, other solvers only support the model being
-copied at once before solve. Moreover it seems to require all solvers to
+copied at once before solve. Moreover, it seems to require all solvers to
 implement all possible reformulations independently which seems both very
 ambitious and might generate a lot of duplicated code.
 

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -54,13 +54,13 @@ julia> @variable(model, y, base_name="decision variable")
 decision variable
 ```
 This code does four things:
-1. it adds one *optimization* variable to `model`
-2. it creates one *JuMP* variable that acts as a reference to that optimization
-   variable
-3. it binds the JuMP variable to the Julia variable `y`
-4. it tells JuMP that the *name* attribute of this JuMP variable is "decision
 variable". JuMP uses the value of `base_name` when it has to print the variable
 as a string.
+1. It adds one *optimization* variable to `model`.
+2. It creates one *JuMP* variable that acts as a reference to that optimization
+   variable.
+3. It binds the JuMP variable to the Julia variable `y`.
+4. It tells JuMP that the *name* attribute of this JuMP variable is "decision
 
 For example, when we print `y` at the REPL we get:
 ```jldoctest variables

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -54,13 +54,13 @@ julia> @variable(model, y, base_name="decision variable")
 decision variable
 ```
 This code does four things:
-variable". JuMP uses the value of `base_name` when it has to print the variable
-as a string.
 1. It adds one *optimization* variable to `model`.
 2. It creates one *JuMP* variable that acts as a reference to that optimization
    variable.
 3. It binds the JuMP variable to the Julia variable `y`.
 4. It tells JuMP that the *name* attribute of this JuMP variable is "decision
+   variable". JuMP uses the value of `base_name` when it has to print the variable
+   as a string.
 
 For example, when we print `y` at the REPL we get:
 ```jldoctest variables

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -366,7 +366,7 @@ And data, a 2×2 Array{Float64,2}:
 
 The third container type that JuMP natively supports is `SparseAxisArray`.
 These arrays are created when the indices do not form a rectangular set.
-An example where this applies is when indices have a dependence upon previous
+For example, this applies when indices have a dependence upon previous
 indices (called *triangular indexing*). JuMP supports this as follows:
 ```jldoctest; setup=:(model=Model())
 julia> @variable(model, x[i=1:2, j=i:2])

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -264,9 +264,9 @@ variable_by_name
 In the examples above, we have mostly created scalar variables. By scalar, we
 mean that the Julia variable is bound to exactly one JuMP variable. However, it
 is often useful to create collections of JuMP variables inside more complicated
-datastructures.
+data structures.
 
-JuMP provides a mechanism for creating three types of these datastructures,
+JuMP provides a mechanism for creating three types of these data structures,
 which we refer to as *containers*. The three types are `Array`s, `DenseAxisArray`s,
 and `SparseAxisArray`s. We explain each of these in the following.
 

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -390,7 +390,7 @@ JuMP.Containers.SparseAxisArray{VariableRef,1,Tuple{Any}} with 2 entries:
 
 When creating a container of JuMP variables, JuMP will attempt to choose the
 tightest container type that can store the JuMP variables. Thus, it will prefer
-to create an Array before a DenseAxisArray, and a DenseAxisArray before a
+to create an Array before a DenseAxisArray and a DenseAxisArray before a
 SparseAxisArray. However, because this happens at compile time, it does not
 always make the best choice. To illustrate this, consider the following example:
 ```jldoctest variable_force_container; setup=:(model=Model())
@@ -417,7 +417,7 @@ julia> @variable(model, y[A], container=Array)
  y[1]
  y[2]
 ```
-JuMP now creates a vector of JuMP variables, instead of a DenseAxisArray. Note
+JuMP now creates a vector of JuMP variables instead of a DenseAxisArray. Note
 that choosing an invalid container type will throw an error.
 
 ## Integrality shortcuts

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -38,11 +38,11 @@ julia> @variable(model, x[1:2])
  x[2]
 ```
 This code does three things:
-1. it adds two *optimization* variables to `model`
-2. it creates two *JuMP* variables that act as references to those optimization
-   variables
-3. it binds those JuMP variables as a vector with two elements to the *Julia*
-   variable `x`
+1. It adds two *optimization* variables to `model`.
+2. It creates two *JuMP* variables that act as references to those optimization
+   variables.
+3. It binds those JuMP variables as a vector with two elements to the *Julia*
+   variable `x`.
 
 To reduce confusion, we will attempt, where possible, to always refer to
 variables with their corresponding prefix.

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -42,7 +42,7 @@ This code does three things:
 2. it creates two *JuMP* variables that act as references to those optimization
    variables
 3. it binds those JuMP variables as a vector with two elements to the *Julia*
-   variable `x`.
+   variable `x`
 
 To reduce confusion, we will attempt, where possible, to always refer to
 variables with their corresponding prefix.

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -428,7 +428,7 @@ JuMP supports two shortcuts for adding such constraints.
 
 #### Binary (ZeroOne) constraints
 
-Binary optimization variables are constrained to the set ``x \in {0, 1}``. (The
+Binary optimization variables are constrained to the set ``x \in \{0, 1\}``. (The
 `MOI.ZeroOne` set in MathOptInterface.) Binary optimization variables can be
 created in JuMP by passing `Bin` as an optional positional argument:
 ```jldoctest variables_binary; setup=:(model=Model())

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -229,9 +229,9 @@ outside of `backend` and no bridges are automatically applied to `backend`.
 The absence of cache reduces the memory footprint but it is important to bear
 in mind the following implications of creating models using this *direct* mode:
 
-* When `backend` does not support an operation such as adding
-  variables/constraints after solver or modifying constraints, an error is
-  thrown. With models created using the [`Model`](@ref) constructor, such
+* When `backend` does not support an operation, such as modifying
+  constraints or adding variables/constraints after solving, an error is
+  thrown. For models created using the [`Model`](@ref) constructor, such
   situations can be dealt with by storing the modifications in a cache and
   loading them into the optimizer when `optimize!` is called.
 * No constraint bridging is supported by default.

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -717,6 +717,7 @@ julia> list_of_constraint_types(model)
  (VariableRef, MathOptInterface.ZeroOne)
  (VariableRef, MathOptInterface.GreaterThan{Float64})
  (GenericAffExpr{Float64,VariableRef}, MathOptInterface.LessThan{Float64})
+```
 """
 function list_of_constraint_types(model::Model)
     list = MOI.get(

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1198,7 +1198,7 @@ The expression `varexpr` can either be
 
 * of the form `varname` creating a scalar real variable of name `varname`;
 * of the form `varname[...]` or `[...]` creating a container of variables (see
-  [Containers in macros](@ref).
+  [Containers in macros](@ref)).
 
 The recognized positional arguments in `args` are the following:
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1240,7 +1240,7 @@ x = @variable(model, base_name="x", lower_bound=0)
 ```
 
 The following are equivalent ways of creating a `DenseAxisArray` of index set
-`[:a, :b]` and with respective upper bounds 2 and 3 and names `x[a]` and `x[b].
+`[:a, :b]` and with respective upper bounds 2 and 3 and names `x[a]` and `x[b]`.
 ```julia
 ub = Dict(:a => 2, :b => 3)
 # Specify everything in `expr`

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -791,6 +791,7 @@ model = Model();
 
 # output
 ScalarConstraint{GenericAffExpr{Float64,VariableRef},MathOptInterface.GreaterThan{Float64}}(2 x, MathOptInterface.GreaterThan{Float64}(1.0))
+```
 """
 macro build_constraint(constraint_expr)
     _error(str...) = _macro_error(:build_constraint, (constraint_expr,), str...)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1273,7 +1273,7 @@ extra_kw_args...))` where
 
 ## Examples
 
-The following creates a variable `x` of name `x` with lower_bound 0 as with the first
+The following creates a variable `x` of name `x` with `lower_bound` 0 as with the first
 example above but does it without using the `@variable` macro
 ```julia
 info = VariableInfo(true, 0, false, NaN, false, NaN, false, NaN, false, false)


### PR DESCRIPTION
Thanks for JuMP! 

I've been reading through the documentation over the last few weeks and collecting commits for correcting small typos, missing commas, formatting issues, etc., along the way. Now that I've made it to the end, it's time to share!  

I also noticed that there were a few inconsistencies in the examples with respect to preferring `x[j=1:2]` or  `x[j = 1:2]`. However I didn't see a note in the style guide, so I left them alone for now. 