### PR TITLE
⚡️ Avoid creating temporary expression in matrix multiplications

### DIFF
--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -185,10 +185,10 @@ function add_to_expression! end
 
 # TODO: add deprecations for Base.push! and Base.append!
 
-# With one factor
+# With one factor.
 
 function add_to_expression!(aff::GenericAffExpr{C,V},
-                            other::Union{C, Real}) where {C,V}
+                            other::Real) where {C,V}
     aff.constant += other
     return aff
 end
@@ -206,20 +206,20 @@ function add_to_expression!(aff::GenericAffExpr{C,V},
     return aff
 end
 
-# With two factors
+# With two factors.
 
-function add_to_expression!(aff::GenericAffExpr{C,V}, new_coef::Union{C, Real},
+function add_to_expression!(aff::GenericAffExpr{C,V}, new_coef::Real,
                             new_var::V) where {C,V}
     _add_or_set!(aff.terms, new_var, convert(C, new_coef))
     return aff
 end
 
 function add_to_expression!(aff::GenericAffExpr{C,V}, new_var::V,
-                            new_coef::Union{C, Real}) where {C,V}
+                            new_coef::Real) where {C,V}
     return add_to_expression!(aff, new_coef, new_var)
 end
 
-function add_to_expression!(aff::GenericAffExpr{C,V}, coef::Union{C, Real},
+function add_to_expression!(aff::GenericAffExpr{C,V}, coef::Real,
                             other::GenericAffExpr{C,V}) where {C,V}
     sizehint!(aff, length(linear_terms(aff)) + length(linear_terms(other)))
     for (term_coef, var) in linear_terms(other)
@@ -231,7 +231,7 @@ end
 
 function add_to_expression!(aff::GenericAffExpr{C,V},
                             other::GenericAffExpr{C,V},
-                            coef::Union{C, Real}) where {C,V}
+                            coef::Real) where {C,V}
     return add_to_expression!(aff, coef, other)
 end
 

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -185,8 +185,11 @@ function add_to_expression! end
 
 # TODO: add deprecations for Base.push! and Base.append!
 
-function add_to_expression!(aff::GenericAffExpr{C,V}, new_coef::C, new_var::V) where {C,V}
-    _add_or_set!(aff.terms, new_var, new_coef)
+# With one factor
+
+function add_to_expression!(aff::GenericAffExpr{C,V},
+                            other::Union{C, Real}) where {C,V}
+    aff.constant += other
     return aff
 end
 
@@ -195,23 +198,48 @@ function add_to_expression!(aff::GenericAffExpr{C,V}, new_var::V) where {C,V}
     return aff
 end
 
-function add_to_expression!(aff::GenericAffExpr{C,V}, other::GenericAffExpr{C,V}) where {C,V}
+function add_to_expression!(aff::GenericAffExpr{C,V},
+                            other::GenericAffExpr{C,V}) where {C,V}
+    # Note: merge!() doesn't appear to call sizehint!(). Is this important?
     merge!(+, aff.terms, other.terms)
     aff.constant += other.constant
     return aff
 end
 
-function add_to_expression!(aff::GenericAffExpr{C,V}, other::C) where {C,V}
-    aff.constant += other
-    return aff
-end
-function add_to_expression!(aff::GenericAffExpr{C,V}, other::Real) where {C,V}
-    aff.constant += other
+# With two factors
+
+function add_to_expression!(aff::GenericAffExpr{C,V}, new_coef::Union{C, Real},
+                            new_var::V) where {C,V}
+    _add_or_set!(aff.terms, new_var, convert(C, new_coef))
     return aff
 end
 
-function Base.isequal(aff::GenericAffExpr{C,V},other::GenericAffExpr{C,V}) where {C,V}
-    return isequal(aff.constant, other.constant) && isequal(aff.terms, other.terms)
+function add_to_expression!(aff::GenericAffExpr{C,V}, new_var::V,
+                            new_coef::Union{C, Real}) where {C,V}
+    return add_to_expression!(aff, new_coef, new_var)
+end
+
+function add_to_expression!(aff::GenericAffExpr{C,V}, coef::Union{C, Real},
+                            other::GenericAffExpr{C,V}) where {C,V}
+    sizehint!(aff, length(linear_terms(aff)) + length(linear_terms(other)))
+    for (term_coef, var) in linear_terms(other)
+        _add_or_set!(aff.terms, var, coef * term_coef)
+    end
+    aff.constant += coef * other.constant
+    return aff
+end
+
+function add_to_expression!(aff::GenericAffExpr{C,V},
+                            other::GenericAffExpr{C,V},
+                            coef::Union{C, Real}) where {C,V}
+    return add_to_expression!(aff, coef, other)
+end
+
+
+function Base.isequal(aff::GenericAffExpr{C,V},
+                      other::GenericAffExpr{C,V}) where {C,V}
+    return isequal(aff.constant, other.constant) &&
+        isequal(aff.terms, other.terms)
 end
 
 Base.hash(aff::GenericAffExpr, h::UInt) = hash(aff.constant, hash(aff.terms, h))

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -126,55 +126,64 @@ function Base.eltype(qti::QuadTermIterator{GenericQuadExpr{C, V}}
     return Tuple{C, V, V}
 end
 
-# With one factor
+# With one factor.
 
 function add_to_expression!(quad::GenericQuadExpr{C}, other::C) where C
     return add_to_expression!(quad.aff, other)
 end
 
-function add_to_expression!(q::GenericQuadExpr{T,S}, other::GenericAffExpr{T,S}) where {T,S}
+function add_to_expression!(q::GenericQuadExpr{T,S},
+                            other::GenericAffExpr{T,S}) where {T,S}
     add_to_expression!(q.aff, other)
     return q
 end
 
-function add_to_expression!(q::GenericQuadExpr{T,S}, other::GenericQuadExpr{T,S}) where {T,S}
+function add_to_expression!(q::GenericQuadExpr{T,S},
+                            other::GenericQuadExpr{T,S}) where {T,S}
     merge!(+, q.terms, other.terms)
     add_to_expression!(q.aff, other.aff)
     return q
 end
 
-# With two factors
+# With two factors.
 
 function add_to_expression!(quad::GenericQuadExpr{C, V},
-                            new_coef::Union{C, Real},
-                            new_aff::Union{V, GenericAffExpr{C,V}}) where {C,V}
+                            new_coef::Real,
+                            new_var::V) where {C,V}
+    add_to_expression!(quad.aff, new_coef, new_var)
+    return quad
+end
+
+function add_to_expression!(quad::GenericQuadExpr{C, V},
+                            new_var::Union{V, GenericAffExpr{C, V}},
+                            new_coef::Real) where {C,V}
+    return add_to_expression!(quad, new_coef, new_var)
+end
+
+function add_to_expression!(quad::GenericQuadExpr{C},
+                            new_coef::Real,
+                            new_aff::GenericAffExpr{C}) where {C}
     add_to_expression!(quad.aff, new_coef, new_aff)
     return quad
 end
 
-function add_to_expression!(quad::GenericQuadExpr{C, V},
-                            new_aff::Union{V, GenericAffExpr{C,V}},
-                            new_coef::Union{C, Real}) where {C,V}
-    add_to_expression!(quad.aff, new_aff, new_coef)
-    return quad
-end
-
-function add_to_expression!(quad::GenericQuadExpr{C,V}, coef::Union{C, Real},
-                            other::GenericQuadExpr{C,V}) where {C,V}
+function add_to_expression!(quad::GenericQuadExpr{C, V}, coef::Real,
+                            other::GenericQuadExpr{C, V}) where {C, V}
     for (key, term_coef) in other.terms
         _add_or_set!(quad.terms, key, coef * term_coef)
     end
     return add_to_expression!(quad, coef, other.aff)
 end
 
-function add_to_expression!(quad::GenericQuadExpr{C,V},
-                            other::GenericQuadExpr{C,V},
-                            coef::Union{C, Real}) where {C,V}
+function add_to_expression!(quad::GenericQuadExpr{C, V},
+                            other::GenericQuadExpr{C, V},
+                            coef::Real) where {C, V}
     return add_to_expression!(quad, coef, other)
 end
 
-function add_to_expression!(quad::GenericQuadExpr{C,V},
-                            var_1::V, var_2::V) where {C,V}
+function add_to_expression!(quad::GenericQuadExpr{C},
+                            var_1::AbstractVariableRef,
+                            var_2::AbstractVariableRef) where {C}
     return add_to_expression!(quad, one(C), var_1, var_2)
 end
 
@@ -238,9 +247,10 @@ function add_to_expression!(quad::GenericQuadExpr{C,V},
     return quad
 end
 
-# With three factor
+# With three factors.
 
-function add_to_expression!(quad::GenericQuadExpr{C,V}, new_coef::C, new_var1::V, new_var2::V) where {C,V}
+function add_to_expression!(quad::GenericQuadExpr{C,V}, new_coef::C,
+                            new_var1::V, new_var2::V) where {C,V}
     # Node: OrderedDict updates the *key* as well. That is, if there was a
     # previous value for UnorderedPair(new_var2, new_var1), it's key will now be
     # UnorderedPair(new_var1, new_var2) (because these are defined as equal).

--- a/test/perf/matrix_product.jl
+++ b/test/perf/matrix_product.jl
@@ -1,0 +1,32 @@
+using LinearAlgebra
+using JuMP
+
+function test(n::Int, verbose::Bool)
+    model = Model()
+    a = rand(n, n)
+    @variable(model, x[1:n, 1:n])
+
+    # Compile it
+    x * a
+    a * x * a
+
+    elapsed = @elapsed x * a
+    if verbose
+        println("2D Matrix product `x * a`: $(elapsed)")
+    end
+
+    elapsed = @elapsed a * x * a
+    if verbose
+        println("2D Matrix product `a * x * a`: $(elapsed)")
+    end
+
+    return
+end
+
+# Compile the methods needed.
+test(2, false)
+
+for n in [10, 20, 50, 100]
+    println("n = $n")
+    test(n, true)
+end

--- a/test/perf/vector_speedtest.jl
+++ b/test/perf/vector_speedtest.jl
@@ -1,36 +1,37 @@
+using LinearAlgebra
 using JuMP
 
 function test(n::Int)
-    m = Model()
-    a = rand(n,n)
-    @variable(m,x[1:n,1:n])
-    b = rand(n,n,n)
-    @variable(m,y[1:n,1:n,1:n])
+    model = Model()
+    a = rand(n, n)
+    @variable(model, x[1:n, 1:n])
+    b = rand(n, n, n)
+    @variable(model, y[1:n, 1:n, 1:n])
     c = rand(n)
-    @variable(m,z[1:n])
+    @variable(model, z[1:n])
 
     #initialize
-    @constraint(m,sum(c[i]*z[i] for i=1:n)<=0)
+    @constraint(model, sum(c[i] * z[i] for i=1:n) <= 0)
 
     #Vector
-    elapsed = @elapsed @constraint(m,sum(c[i]*z[i] for i=1:n)<=1)
+    elapsed = @elapsed @constraint(model, sum(c[i] * z[i] for i=1:n) <= 1)
     println("Vector with sum(): $(elapsed)")
 
-    elapsed = @elapsed @constraint(m,dot(c,z) <= 1)
+    elapsed = @elapsed @constraint(model, dot(c, z) <= 1)
     println("Vector with vecdot() : $(elapsed)")
 
     #2D Matrix
-    elapsed = @elapsed @constraint(m,sum(a[i,j]*x[i,j] for i=1:n,j=1:n)<=1)
+    elapsed = @elapsed @constraint(model, sum(a[i, j] * x[i, j] for i=1:n, j=1:n) <= 1)
     println("2D Matrix with sum(): $(elapsed)")
 
-    elapsed = @elapsed @constraint(m,dot(a,x)<=1)
+    elapsed = @elapsed @constraint(model, dot(a, x) <= 1)
     println("2D Matrix with bigvecdot(): $(elapsed)")
 
     #3D Matrix
-    elapsed = @elapsed @constraint(m,sum(b[i,j,k]*y[i,j,k] for i=1:n,j=1:n,k=1:n)<=1)
+    elapsed = @elapsed @constraint(model, sum(b[i, j, k] * y[i, j, k] for i=1:n, j=1:n, k=1:n) <= 1)
     println("3D Matrix with sum(): $(elapsed)")
 
-    elapsed = @elapsed @constraint(m,dot(b,y)<=1)
+    elapsed = @elapsed @constraint(model, dot(b, y) <= 1)
     println("3D Matrix with vecdot(): $(elapsed)")
     return 0
 end


### PR DESCRIPTION
With the benchmark in https://github.com/JuliaOpt/JuMP.jl/issues/1403#issuecomment-463857803:
Before:
```
julia> @time x*A;
0.559247 seconds (8.21 M allocations: 668.261 MiB, 40.98% gc time)

julia> @time A*x*A;
33.784054 seconds (14.60 M allocations: 9.227 GiB, 51.83% gc time)
```
After:
```
julia> @time x*A;
0.153061 seconds (210.03 k allocations: 73.168 MiB)

julia> @time A*x*A;
16.037227 seconds (630.06 k allocations: 6.126 GiB, 14.55% gc time)
```