### PR TITLE
Added type info in NL error message

### DIFF
--- a/src/parse_nlp.jl
+++ b/src/parse_nlp.jl
@@ -199,13 +199,13 @@ end
 function _parse_NL_expr_runtime(m::Model, x::GenericQuadExpr, tape, parent, values)
     error("Unexpected quadratic expression $x in nonlinear expression. " *
           "Quadratic expressions (e.g., created using @expression) and " *
-          "nonlinear expression cannot be mixed.")
+          "nonlinear expressions cannot be mixed.")
 end
 
 function _parse_NL_expr_runtime(m::Model, x::GenericAffExpr, tape, parent, values)
     error("Unexpected affine expression $x in nonlinear expression. " *
           "Affine expressions (e.g., created using @expression) and " *
-          "nonlinear expression cannot be mixed.")
+          "nonlinear expressions cannot be mixed.")
 end
 
 function _parse_NL_expr_runtime(m::Model, x, tape, parent, values)

--- a/src/parse_nlp.jl
+++ b/src/parse_nlp.jl
@@ -202,8 +202,14 @@ function _parse_NL_expr_runtime(m::Model, x::GenericQuadExpr, tape, parent, valu
           "nonlinear expression cannot be mixed.")
 end
 
+function _parse_NL_expr_runtime(m::Model, x::GenericAffExpr, tape, parent, values)
+    error("Unexpected affine expression $x in nonlinear expression. " *
+          "Affine expressions (e.g., created using @expression) and " *
+          "nonlinear expression cannot be mixed.")
+end
+
 function _parse_NL_expr_runtime(m::Model, x, tape, parent, values)
-    error("Unexpected object $x in nonlinear expression.")
+    error("Unexpected object $x (of type $(typeof(x)) in nonlinear expression.")
 end
 
 function _expression_complexity(ex::Expr)

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -630,7 +630,7 @@
             "Affine expressions (e.g., created using @expression) and " *
             "nonlinear expressions cannot be mixed."
         )
-        @test_throws expected_exception @NLexpression(m, A)
+        @test_throws expected_exception @NLexpression(model, A)
     end
     
     @testset "Error on using QuadExpr in NLexpression" begin
@@ -643,6 +643,6 @@
             "Quadratic expressions (e.g., created using @expression) and " *
             "nonlinear expressions cannot be mixed."
         )
-        @test_throws expected_exception @NLexpression(m, A)
+        @test_throws expected_exception @NLexpression(model, A)
     end
 end

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -619,4 +619,30 @@
         evaluator = JuMP.NLPEvaluator(model)
         @test !(:Hess in MOI.features_available(evaluator))
     end
+    
+    @testset "Error on using AffExpr in NLexpression" begin
+        model = Model()
+        @variable(model, x)
+        @variable(model, y)
+        A = x + y
+        expected_exception = ErrorException(
+            "Unexpected affine expression x + y in nonlinear expression. " *
+            "Affine expressions (e.g., created using @expression) and " *
+            "nonlinear expressions cannot be mixed."
+        )
+        @test_throws expected_exception @NLexpression(m, A)
+    end
+    
+    @testset "Error on using QuadExpr in NLexpression" begin
+        model = Model()
+        @variable(model, x)
+        @variable(model, y)
+        A = x*y
+        expected_exception = ErrorException(
+            "Unexpected quadratic expression x*y in nonlinear expression. " *
+            "Quadratic expressions (e.g., created using @expression) and " *
+            "nonlinear expressions cannot be mixed."
+        )
+        @test_throws expected_exception @NLexpression(m, A)
+    end
 end


### PR DESCRIPTION
Type checking for parsing nonlinear expression was missng the GenericAffExpr case.  Also added type information to the catch-all error.