### PR TITLE
Add VectorQuadraticFunction JuMP._MOIModel

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -59,7 +59,7 @@ MOIU.@model(_MOIModel,
             (MOI.SingleVariable,),
             (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),
             (MOI.VectorOfVariables,),
-            (MOI.VectorAffineFunction,))
+            (MOI.VectorAffineFunction, MOI.VectorQuadraticFunction))
 
 """
     OptimizerFactory


### PR DESCRIPTION
It currently works thanks to the `UniversalFallback` but it is more efficient if it is handled by the `JuMP._MOIModel`