### PR TITLE
remove localvar hack

### DIFF
--- a/src/parse_expr.jl
+++ b/src/parse_expr.jl
@@ -351,11 +351,7 @@ function _parse_gen(ex, atleaf)
             push!(idxvars, idxvar)
         end
     end
-    b = Expr(:block)
-    for idxvar in idxvars
-        push!(b.args, localvar(esc(idxvar)))
-    end
-    return :(let; $b; $loop; end)
+    return loop
 end
 
 function _parse_generator(x::Expr, aff::Symbol, lcoeffs, rcoeffs, newaff=gensym())

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -47,4 +47,13 @@ JuMP.@NLobjective(model, Max, sum( y[j] for j=r if j == 4))
 
 # TODO: Add tests for the content of the model.
 
+model = JuMP.Model()
+i = 10
+j = 10
+JuMP.@expression(model, ex[j = 2:3], sum(i for i in 1:j))
+@test ex[2] == JuMP.AffExpr(3)
+@test ex[3] == JuMP.AffExpr(6)
+@test i == 10
+@test j == 10
+
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -439,6 +439,17 @@ end
          y[1] + y[3] $ge 3.0
         """
     end
+
+    @testset "Index variables don't leak out of macros" begin
+        model = Model()
+        i = 10
+        j = 10
+        @expression(model, ex[j = 2:3], sum(i for i in 1:j))
+        @test ex[2] == AffExpr(3)
+        @test ex[3] == AffExpr(6)
+        @test i == 10
+        @test j == 10
+    end
 end
 
 @testset "Macros for JuMPExtension.MyModel" begin


### PR DESCRIPTION
The desired behavior of loop variables not leaking outside their scope is now the default in Julia.