### PR TITLE
generalized sum for GenericQuadExpr

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -251,7 +251,13 @@ _sizehint_expr!(q, n) = nothing
 #############################################################################
 
 # TODO: specialize sum for DenseAxisArray and SparseAxisArray of JuMP objects?
-Base.sum(vars::AbstractArray{<:AbstractVariableRef}) = GenericAffExpr(0.0, [v => 1.0 for v in vars])
+function Base.sum(array::AbstractArray{<:AbstractVariableRef}) 
+    result_expression = zero(eltype(array)) 
+    for variable in array 
+        add_to_expression!(result_expression, variable) 
+    end 
+    return result_expression 
+end 
 # TODO: Specialize for iterables.
 function Base.sum(affs::AbstractArray{T}) where {T <: AbstractJuMPScalar}
     new_aff = zero(T)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -252,13 +252,6 @@ _sizehint_expr!(q, n) = nothing
 
 # TODO: specialize sum for DenseAxisArray and SparseAxisArray of JuMP objects?
 Base.sum(vars::AbstractArray{<:AbstractVariableRef}) = GenericAffExpr(0.0, [v => 1.0 for v in vars])
-function Base.sum(array::AbstractArray{<:AbstractVariableRef})
-    result_expression = zero(eltype(array))
-    for variable in array
-        add_to_expression!(result_expression, variable)
-    end
-    return result_expression
-end
 # TODO: Specialize for iterables.
 function Base.sum(affs::AbstractArray{T}) where {T <: AbstractJuMPScalar}
     new_aff = zero(T)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -251,7 +251,7 @@ _sizehint_expr!(q, n) = nothing
 #############################################################################
 
 # TODO: specialize sum for DenseAxisArray and SparseAxisArray of JuMP objects?
-Base.sum(vars::Array{<:AbstractVariableRef}) = GenericAffExpr(0.0, [v => 1.0 for v in vars])
+Base.sum(vars::AbstractArray{<:AbstractVariableRef}) = GenericAffExpr(0.0, [v => 1.0 for v in vars])
 function Base.sum(array::AbstractArray{<:AbstractVariableRef})
     result_expression = zero(eltype(array))
     for variable in array

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -260,7 +260,7 @@ function Base.sum(array::AbstractArray{<:AbstractVariableRef})
     return result_expression
 end
 # TODO: Specialize for iterables.
-function Base.sum(affs::AbstractArray{T}) where {T <: GenericAffExpr}
+function Base.sum(affs::AbstractArray{T}) where {T <: AbstractJuMPScalar}
     new_aff = zero(T)
     for aff in affs
         add_to_expression!(new_aff, aff)

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -255,6 +255,9 @@ function operators_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
             @testset "sum(affs::Array{AffExpr})" begin
                 @test_expression_with_string sum([2*matrix[i,j] for i in 1:3, j in 1:3]) "2 matrix[1,1] + 2 matrix[2,1] + 2 matrix[3,1] + 2 matrix[1,2] + 2 matrix[2,2] + 2 matrix[3,2] + 2 matrix[1,3] + 2 matrix[2,3] + 2 matrix[3,3]"
             end
+            @testset "sum(quads::Array{QuadExpr})" begin
+                @test_expression_with_string sum([2*matrix[i,j]^2 for i in 1:3, j in 1:3]) "2 matrix[1,1]² + 2 matrix[2,1]² + 2 matrix[3,1]² + 2 matrix[1,2]² + 2 matrix[2,2]² + 2 matrix[3,2]² + 2 matrix[1,3]² + 2 matrix[2,3]² + 2 matrix[3,3]²"
+            end
 
             S = [1,3]
             @variable(sum_m, x[S], start=1)


### PR DESCRIPTION
I'm trying to help with [#1899](https://github.com/JuliaOpt/JuMP.jl/issues/1899). One thing I didn't understand is how the first `sum` method should be defined on `AbstractVector`.

I tried `Base.sum(vars::AbstractVector{<:AbstractVariableRef}) = GenericAffExpr(0.0, [v => 1.0 for v in vars])` but this is not the same thing as `Base.sum(vars::Array{<:AbstractVariableRef}) = GenericAffExpr(0.0, [v => 1.0 for v in vars])`. 

```julia
julia> Array <: AbstractVector
false
```