### PR TITLE
MOI Silent

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -42,6 +42,7 @@ is often more complex. We list below the currently available solvers.
 | [Ipopt](https://projects.coin-or.org/Ipopt)                                    | [Ipopt.jl](https://github.com/JuliaOpt/Ipopt.jl)                                 | EPL     | LP, QP, NLP                        |
 | [MOSEK](http://www.mosek.com/)                                                 | [MosekTools.jl](https://github.com/JuliaOpt/MosekTools.jl)                       | Comm.   | LP, MILP, SOCP, MISOCP, SDP        |
 | [OSQP](https://osqp.org/)                                                      | [OSQP.jl](https://github.com/oxfordcontrol/OSQP.jl)                              | Apache  | LP, QP                             |
+| [ProxSDP](https://github.com/mariohsouto/ProxSDP.jl)                                | [ProxSDP.jl](https://github.com/mariohsouto/ProxSDP.jl)                     | MIT     | LP, SOCP, SDP                      |
 | [SCS](https://github.com/cvxgrp/scs)                                           | [SCS.jl](https://github.com/JuliaOpt/SCS.jl)                                     | MIT     | LP, SOCP, SDP                      |
 | [SDPA](http://sdpa.sourceforge.net/)                                           | [SDPA.jl](https://github.com/JuliaOpt/SDPA.jl)                                   | GPL     | LP, SDP                            |
 | [SeDuMi](http://sedumi.ie.lehigh.edu/)                                         | [SeDuMi.jl](https://github.com/JuliaOpt/SeDuMi.jl)                               | GPL     | LP, SOCP, SDP                      |
@@ -145,6 +146,13 @@ following to create a model with the Mosek solver:
 julia> using MosekTools
 julia> model = Model(with_optimizer(Mosek.Optimizer))
 ```
+
+### ProxSDP
+
+ProxSDP solves general SDP problems by means of a first order proximal algorithm
+based on the primal-dual hybrid gradient, also known as Chambolle-Pock method.
+The main advantage of ProxSDP over other state-of-the-art solvers is the ability 
+of exploit the low-rank property inherent to several SDP problems.
 
 ### SCS
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -152,7 +152,9 @@ julia> model = Model(with_optimizer(Mosek.Optimizer))
 ProxSDP solves general SDP problems by means of a first order proximal algorithm
 based on the primal-dual hybrid gradient, also known as Chambolle-Pock method.
 The main advantage of ProxSDP over other state-of-the-art solvers is the ability 
-of exploit the low-rank property inherent to several SDP problems.
+of exploit the low-rank property inherent to several SDP problems. ProxSDP is a first order
+solver and has low accuracy (``10^{−4}``) by default; see the ProxSDP.jl
+documentation for more information.
 
 ### SCS
 

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -95,3 +95,28 @@ JuMP.direct_model
 ```@docs
 JuMP.backend
 ```
+
+## Solver attributes
+
+Some solvers attributes can be queried through JuMP Models. Some solver attributes can setted through JuMP Models.
+
+```@docs
+solver_name
+```
+
+```@docs
+bridge_constraints
+```
+
+```@docs
+num_variables
+```
+
+```@docs
+set_silent
+```
+
+
+```@docs
+unset_silent
+```

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -98,25 +98,13 @@ JuMP.backend
 
 ## Solver attributes
 
-Some solvers attributes can be queried through JuMP Models. Some solver attributes can setted through JuMP Models.
+Some solver attributes can be queried and set through JuMP models.
 
 ```@docs
 solver_name
-```
 
-```@docs
 bridge_constraints
-```
 
-```@docs
-num_variables
-```
-
-```@docs
 set_silent
-```
-
-
-```@docs
 unset_silent
 ```

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -607,6 +607,7 @@ in the model. This is useful for performing operations like:
 owner_model
 VariableRef
 all_variables
+num_variables
 
 has_lower_bound
 lower_bound

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -316,6 +316,30 @@ function _try_get_solver_name(model_like)
     end
 end
 
+function _try_set_silent(model_like)
+    try
+        return MOI.set(model_like, MOI.Silent(), true)
+    catch ex
+        if isa(ex, ArgumentError)
+            return "Silent() attribute not implemented by the optimizer."
+        else
+            rethrow(ex)
+        end
+    end
+end
+
+function _try_unset_silent(model_like)
+    try
+        return MOI.set(model_like, MOI.Silent(), false)
+    catch ex
+        if isa(ex, ArgumentError)
+            return "Silent() attribute not implemented by the optimizer."
+        else
+            rethrow(ex)
+        end
+    end
+end
+
 """
     solver_name(model::Model)
 
@@ -445,7 +469,12 @@ Takes precedence over any other attribute controlling verbosity
 and requires the solver to produce no output.
 """
 function set_silent(model::Model)
-    return MOI.set(model, MOI.Silent(), true)
+    if mode(model) != DIRECT &&
+        MOIU.state(backend(model)) == MOIU.NO_OPTIMIZER
+        return "No optimizer attached."
+    else
+        return _try_set_silent(backend(model))
+    end
 end
 
 """
@@ -455,7 +484,12 @@ Neutralize the effect of the `set_silent` method and let the solver
 attributes control the verbosity.
 """
 function unset_silent(model::Model)
-    return MOI.set(model, MOI.Silent(), false)
+    if mode(model) != DIRECT &&
+        MOIU.state(backend(model)) == MOIU.NO_OPTIMIZER
+        return "No optimizer attached."
+    else
+        return _try_unset_silent(backend(model))
+    end
 end
 
 # Abstract base type for all scalar types

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -451,7 +451,7 @@ end
 """
     unset_silent(model::Model)
 
-Neutralize the effect of the `set_silent` method and let the solver
+Neutralize the effect of the `set_silent` function and let the solver
 attributes control the verbosity.
 """
 function unset_silent(model::Model)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -316,30 +316,6 @@ function _try_get_solver_name(model_like)
     end
 end
 
-function _try_set_silent(model_like)
-    try
-        return MOI.set(model_like, MOI.Silent(), true)
-    catch ex
-        if isa(ex, ArgumentError)
-            return "Silent() attribute not implemented by the optimizer."
-        else
-            rethrow(ex)
-        end
-    end
-end
-
-function _try_unset_silent(model_like)
-    try
-        return MOI.set(model_like, MOI.Silent(), false)
-    catch ex
-        if isa(ex, ArgumentError)
-            return "Silent() attribute not implemented by the optimizer."
-        else
-            rethrow(ex)
-        end
-    end
-end
-
 """
     solver_name(model::Model)
 
@@ -469,12 +445,7 @@ Takes precedence over any other attribute controlling verbosity
 and requires the solver to produce no output.
 """
 function set_silent(model::Model)
-    if mode(model) != DIRECT &&
-        MOIU.state(backend(model)) == MOIU.NO_OPTIMIZER
-        return "No optimizer attached."
-    else
-        return _try_set_silent(backend(model))
-    end
+    return MOI.set(model, MOI.Silent(), true)
 end
 
 """
@@ -484,12 +455,7 @@ Neutralize the effect of the `set_silent` method and let the solver
 attributes control the verbosity.
 """
 function unset_silent(model::Model)
-    if mode(model) != DIRECT &&
-        MOIU.state(backend(model)) == MOIU.NO_OPTIMIZER
-        return "No optimizer attached."
-    else
-        return _try_unset_silent(backend(model))
-    end
+    return MOI.set(model, MOI.Silent(), false)
 end
 
 # Abstract base type for all scalar types
@@ -674,6 +640,7 @@ function MOI.get(model::Model, attr::MOI.AbstractConstraintAttribute,
     end
 end
 
+MOI.set(m::Model, attr::MOI.AbstractOptimizerAttribute, value) = MOI.set(backend(m), attr, value)
 MOI.set(m::Model, attr::MOI.AbstractModelAttribute, value) = MOI.set(backend(m), attr, value)
 function MOI.set(model::Model, attr::MOI.AbstractVariableAttribute,
                  v::VariableRef, value)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -438,6 +438,25 @@ end
 
 set_optimize_hook(model::Model, f) = (model.optimize_hook = f)
 
+"""
+    set_silent(model::Model)
+
+Takes precedence over any other attribute controlling verbosity 
+and requires the solver to produce no output.
+"""
+function set_silent(model::Model)
+    return MOI.set(model, MOI.Silent(), true)
+end
+
+"""
+    unset_silent(model::Model)
+
+Neutralize the effect of the `set_silent` method and let the solver
+attributes control the verbosity.
+"""
+function unset_silent(model::Model)
+    return MOI.set(model, MOI.Silent(), false)
+end
 
 # Abstract base type for all scalar types
 abstract type AbstractJuMPScalar end

--- a/test/model.jl
+++ b/test/model.jl
@@ -340,6 +340,21 @@ function test_model()
             @test "Mock" == @inferred JuMP.solver_name(model)
         end
     end
+    @testset "set_silent and unset_silent" begin
+        @testset "Not attached" begin
+            model = Model()
+            @test "No optimizer attached." == JuMP.set_silent(model)
+            @test "No optimizer attached." == JuMP.unset_silent(model)
+        end
+        @testset "Mock" begin
+            mock = MOIU.UniversalFallback(JuMP._MOIModel{Float64}())
+            model = Model(with_optimizer(MOIU.MockOptimizer, mock))
+            @test JuMP.set_silent(model)
+            @test MOI.get(backend(model), MOI.Silent())
+            @test !JuMP.unset_silent(model)
+            @test !MOI.get(backend(model), MOI.Silent())
+        end
+    end
 end
 
 @testset "Model" begin

--- a/test/model.jl
+++ b/test/model.jl
@@ -341,19 +341,12 @@ function test_model()
         end
     end
     @testset "set_silent and unset_silent" begin
-        @testset "Not attached" begin
-            model = Model()
-            @test "No optimizer attached." == JuMP.set_silent(model)
-            @test "No optimizer attached." == JuMP.unset_silent(model)
-        end
-        @testset "Mock" begin
-            mock = MOIU.UniversalFallback(JuMP._MOIModel{Float64}())
-            model = Model(with_optimizer(MOIU.MockOptimizer, mock))
-            @test JuMP.set_silent(model)
-            @test MOI.get(backend(model), MOI.Silent())
-            @test !JuMP.unset_silent(model)
-            @test !MOI.get(backend(model), MOI.Silent())
-        end
+        mock = MOIU.UniversalFallback(JuMP._MOIModel{Float64}())
+        model = Model(with_optimizer(MOIU.MockOptimizer, mock))
+        @test JuMP.set_silent(model)
+        @test MOI.get(backend(model), MOI.Silent())
+        @test !JuMP.unset_silent(model)
+        @test !MOI.get(backend(model), MOI.Silent())
     end
 end
 


### PR DESCRIPTION
This is a start to solve #1920. 

I'm not sure how exactly to test this feature as JuMP doesn't depend on solvers to test it. Maybe testing an error the same way it is tested in MOI? 
```julia
attr = MOI.Silent()
exception = ErrorException(
    "Cannot query $(attr) from caching optimizer because no optimizer" *
    " is attached.")
@test_throws exception MOI.get(model, attr)
```

Also not sure where to document this feature in the manual.