### PR TITLE
Development roadmap

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,7 +28,8 @@ makedocs(
         "Query Solutions" => "solutions.md",
         "Nonlinear Modeling" => "nlp.md",
         "Style Guide" => "style.md",
-        "Extensions" => "extensions.md"
+        "Extensions" => "extensions.md",
+        "Development Roadmap" => "roadmap.md"
     ],
     assets = [
         "assets/jump-logo-with-text.svg",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -95,7 +95,8 @@ Pages = [
     "solutions.md",
     "nlp.md",
     "style.md",
-    "extensions.md"
+    "extensions.md",
+    "roadmap.md"
 ]
 Depth = 2
 ```

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -1,7 +1,7 @@
 # Development roadmap
 
-This page is not JuMP documentation *per se* but are notes for JuMP developers,
-and contributors. The JuMP developers have compiled this roadmap document to
+This page is not JuMP documentation *per se* but are notes for the JuMP
+community. The JuMP developers have compiled this roadmap document to
 share their plans and goals. Contributions to roadmap issues are especially
 invited.
 
@@ -43,7 +43,7 @@ Some but not all of these tasks are summarized in the
 ## MOI 1.0
 
 ```@meta
-# TODO: List MOI 1.0 items either here or in the MOI documentation.
+# TODO: List MOI 1.0 items here.
 ```
 
 ## Beyond JuMP 1.0

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -25,6 +25,7 @@ Some but not all of these tasks are summarized in the
   - Checking feasibility of solutions ([#693](https://github.com/JuliaOpt/JuMP.jl/issues/693))
   - Accessing IIS ([#1053](https://github.com/JuliaOpt/JuMP.jl/issues/1035))
   - Accessing multiple results from solvers
+  - Dual warm-starts (e.g., [Ipopt.jl #164](https://github.com/JuliaOpt/Ipopt.jl/issues/164))
 - Address “easy” usability issues
   - Line numbers in error messages ([#1174](https://github.com/JuliaOpt/JuMP.jl/issues/1174))
   - LP sensitivity summary ([#1332](https://github.com/JuliaOpt/JuMP.jl/issues/1332))

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -1,0 +1,54 @@
+# Development roadmap
+
+This page is not JuMP documentation *per se* but are notes for JuMP developers,
+and contributors. The JuMP developers have compiled this roadmap document to
+share their plans and goals. Contributions to roadmap issues are especially
+invited.
+
+## JuMP 1.0
+
+JuMP 1.0 will be ready to release roughly when all of these tasks are completed.
+Some but not all of these tasks are summarized in the
+[JuMP 1.0 milestone](https://github.com/JuliaOpt/JuMP.jl/milestone/12).
+
+- Create a website for JuMP.
+- Deprecate the JuliaOpt organization and move repositories to the
+  [JuMP-dev](https://github.com/JuMP-dev) organization.
+- Address major regressions from JuMP 0.18.
+  - Performance ([#1403](https://github.com/JuliaOpt/JuMP.jl/issues/1403),
+                 [#1654](https://github.com/JuliaOpt/JuMP.jl/issues/1654),
+                 [#1607](https://github.com/JuliaOpt/JuMP.jl/issues/1607))
+  - Callbacks
+  - Column generation syntax
+  - Support for second-order cones in Gurobi, CPLEX, and Xpress.
+- Fix issues that we promised MOI would fix.
+  - Checking feasibility of solutions ([#693](https://github.com/JuliaOpt/JuMP.jl/issues/693))
+  - Accessing IIS ([#1053](https://github.com/JuliaOpt/JuMP.jl/issues/1035))
+  - Accessing multiple results from solvers
+- Address “easy” usability issues
+  - Line numbers in error messages ([#1174](https://github.com/JuliaOpt/JuMP.jl/issues/1174))
+  - LP sensitivity summary ([#1332](https://github.com/JuliaOpt/JuMP.jl/issues/1332))
+  - Inferred element types for collections in macros ([#525](https://github.com/JuliaOpt/JuMP.jl/issues/525))
+  - Expose solver-independent options from JuMP
+- Improve the documentation ([#1062](https://github.com/JuliaOpt/JuMP.jl/issues/1062))
+  - Separate how-to, concept explanation, and technical reference following the
+    [Divio recommendations](https://www.divio.com/blog/documentation/)
+- Developer experience
+  - Get JuMP’s unit tests running in less than two minutes. See [#1745](https://github.com/JuliaOpt/JuMP.jl/pull/1745).
+- All solvers should complete the transition to MOI.
+- Provide packages for installing Bonmin and Couenne.
+- [MathOptFormat](https://github.com/odow/MathOptFormat.jl) 1.0
+
+## MOI 1.0
+
+```@meta
+# TODO: List MOI 1.0 items either here or in the MOI documentation.
+```
+
+## Beyond JuMP 1.0
+
+```@meta
+# TODO: Copy over list of items not tied to JuMP 1.0. These should have more
+# elaborate explanations so that potential contributors know what we mean,
+# i.e., a few sentences each or a link to a document/issue.
+```


### PR DESCRIPTION
This is a bit drafty but has been sitting on a local branch for a few weeks. I didn't copy over the MOI 1.0 points. Would we rather list them here or in MOI?

Do we want the roadmap to be in the official documentation? Another option is to have `roadmap.md`, which would make it less visible to users. Unclear if this is a good outcome.

@odow @blegat @joaquimg @juan-pablo-vielma