### PR TITLE
Add start_value to docs

### DIFF
--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -629,6 +629,13 @@ julia> start_value(y)
 2.0
 ```
 
+Prior to JuMP 0.19, the previous solution to a solve was automatically set as
+the new starting value. JuMP 0.19 no longer does this automatically. To
+reproduce the functionality, use:
+```julia
+set_start_value.(all_variables(model), value.(all_variables(model)))
+```
+
 ## Reference
 
 ```@docs

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -600,6 +600,35 @@ in the model. This is useful for performing operations like:
 - relaxing all integrality constraints in the model
 - setting the starting values for variables to the result of the last solve
 
+## Start values
+
+There are two ways to provide a primal starting solution (also called MIP-start
+or a warmstart) for each variable:
+
+ - using the `start` keyword in the [`@variable`](@ref) macro
+ - using [`set_start_value`](@ref)
+
+The starting value of a variable can be queried using [`start_value`](@ref). If
+no start value has been set, [`start_value`](@ref) will return `nothing`.
+
+```jldoctest variables_start; setup=:(model=Model())
+julia> @variable(model, x)
+x
+
+julia> start_value(x)
+
+julia> @variable(model, y, start = 1)
+y
+
+julia> start_value(y)
+1.0
+
+julia> set_start_value(y, 2)
+
+julia> start_value(y)
+2.0
+```
+
 ## Reference
 
 ```@docs
@@ -635,4 +664,7 @@ BinaryRef
 
 index(::VariableRef)
 optimizer_index(::VariableRef)
+
+set_start_value
+start_value
 ```

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -629,12 +629,13 @@ julia> start_value(y)
 2.0
 ```
 
-Prior to JuMP 0.19, the previous solution to a solve was automatically set as
-the new starting value. JuMP 0.19 no longer does this automatically. To
-reproduce the functionality, use:
-```julia
-set_start_value.(all_variables(model), value.(all_variables(model)))
-```
+!!! note
+    Prior to JuMP 0.19, the previous solution to a solve was automatically set
+    as the new starting value. JuMP 0.19 no longer does this automatically. To
+    reproduce the functionality, use:
+    ```julia
+    set_start_value.(all_variables(model), value.(all_variables(model)))
+    ```
 
 ## Reference
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -694,6 +694,8 @@ end
 
 Return the start value (MOI attribute `VariablePrimalStart`) of the variable
 `v`. See also [`set_start_value`](@ref).
+
+Note: `VariablePrimalStart`s are sometimes called "MIP-starts" or "warmstarts".
 """
 function start_value(v::VariableRef)::Union{Nothing, Float64}
     return MOI.get(owner_model(v), MOI.VariablePrimalStart(), v)
@@ -704,11 +706,14 @@ end
     set_start_value(variable::VariableRef, value::Number)
 
 Set the start value (MOI attribute `VariablePrimalStart`) of the variable `v` to
-`value`.
+`value`. See also [`start_value`](@ref).
+
+Note: `VariablePrimalStart`s are sometimes called "MIP-starts" or "warmstarts".
 """
 function set_start_value(variable::VariableRef, value::Number)
-    return MOI.set(owner_model(variable), MOI.VariablePrimalStart(), variable,
-                   convert(Float64, value))
+    MOI.set(owner_model(variable), MOI.VariablePrimalStart(), variable,
+            Float64(value))
+    return
 end
 
 """


### PR DESCRIPTION
Closes #1871.

I made one substantive change that we can debate: `set_start_value` now always returns `nothing`. Previously, it returned whatever the return of `MOI.set` was, which is solver-specific. We should standardize on return conventions.

In support of my change, `set_upper_bound`, `set_binary` et al all return `nothing`.