### PR TITLE
Fix iszero for expressions

### DIFF
--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -82,7 +82,9 @@ function GenericAffExpr{V,K}(constant, kv::Pair...) where {K,V}
     return GenericAffExpr{V,K}(convert(V, constant), _new_ordered_dict(K, V, kv...))
 end
 
-Base.iszero(a::GenericAffExpr) = isempty(a.terms) && iszero(a.constant)
+function Base.iszero(expr::GenericAffExpr)
+    return iszero(expr.constant) && all(iszero, values(expr.terms))
+end
 Base.zero(::Type{GenericAffExpr{C,V}}) where {C,V} = GenericAffExpr{C,V}(zero(C), OrderedDict{V,C}())
 Base.one(::Type{GenericAffExpr{C,V}}) where {C,V}  = GenericAffExpr{C,V}(one(C), OrderedDict{V,C}())
 Base.zero(a::GenericAffExpr) = zero(typeof(a))

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -49,7 +49,9 @@ function GenericQuadExpr{V,K}(aff::GenericAffExpr{V,K}, kv::Pair...) where {K,V}
     return GenericQuadExpr{V,K}(aff, _new_ordered_dict(UnorderedPair{K}, V, kv...))
 end
 
-Base.iszero(q::GenericQuadExpr) = isempty(q.terms) && iszero(q.aff)
+function Base.iszero(expr::GenericQuadExpr)
+    return iszero(expr.aff) && all(iszero, values(expr.terms))
+end
 function Base.zero(::Type{GenericQuadExpr{C,V}}) where {C,V}
     return GenericQuadExpr(zero(GenericAffExpr{C,V}), OrderedDict{UnorderedPair{V}, C}())
 end

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -28,6 +28,7 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
         @test !iszero(x + 1)
         @test !iszero(x + 0)
         @test iszero(0 * x + 0)
+        @test iszero(x - x)
     end
 
     @testset "isequal(::GenericQuadExpr)" begin
@@ -49,6 +50,7 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
         @test !iszero(x^2 + 0)
         @test !iszero(x^2 + 0 * x + 0)
         @test iszero(0 * x^2 + 0 * x + 0)
+        @test iszero(x^2 - x^2)
     end
 
     @testset "value for GenericAffExpr" begin

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -22,6 +22,14 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
         @test hash(x + 1) == hash(x + 1)
     end
 
+    @testset "iszero(::GenericAffExpr)" begin
+        m = ModelType()
+        @variable(m, x)
+        @test !iszero(x + 1)
+        @test !iszero(x + 0)
+        @test iszero(0 * x + 0)
+    end
+
     @testset "isequal(::GenericQuadExpr)" begin
         m = ModelType()
         @variable(m, x)
@@ -32,6 +40,15 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
         m = ModelType()
         @variable(m, x)
         @test hash(x^2 + 1) == hash(x^2 + 1)
+    end
+
+    @testset "iszero(::GenericQuadExpr)" begin
+        m = ModelType()
+        @variable(m, x)
+        @test !iszero(x^2 + 1)
+        @test !iszero(x^2 + 0)
+        @test !iszero(x^2 + 0 * x + 0)
+        @test iszero(0 * x^2 + 0 * x + 0)
     end
 
     @testset "value for GenericAffExpr" begin


### PR DESCRIPTION
Part I of #1906 

To answer the question:
> The current behavior is to check whether the terms are empty. Presumably this is for performance reasons. 

Nope. It's just legacy: https://github.com/JuliaOpt/JuMP.jl/commit/09383f2fcacb69aaccde0b7d4c34489927489c59

It's more surprising that no one has complained about this before. As a side note, it doesn't appear to be called in JuMP.jl at all, so there aren't any performance concerns on our part. Better to be correct than fast.
