### PR TITLE
Ignore terms with a zero coefficient when adding to an `OrderedDict`

### DIFF
--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -19,10 +19,11 @@
 function _add_or_set!(dict::OrderedDict{K,V}, k::K, v::V) where {K,V}
     # Adding zero terms to this dictionary leads to unacceptable performance
     # degradations. See, e.g., https://github.com/JuliaOpt/JuMP.jl/issues/1946.
-    if !iszero(v)
-        # TODO: This unnecessarily requires two lookups for k.
-        dict[k] = get!(dict, k, zero(V)) + v
+    if iszero(v)
+        return dict  # No-op.
     end
+    # TODO: This unnecessarily requires two lookups for k.
+    dict[k] = get!(dict, k, zero(V)) + v
     return dict
 end
 

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -17,10 +17,12 @@
 
 # Utilities for OrderedDict
 function _add_or_set!(dict::OrderedDict{K,V}, k::K, v::V) where {K,V}
-    # TODO: This unnecessarily requires two lookups for k.
-    # TODO: Decide if we want to drop zeros here after understanding the
-    # performance implications.
-    dict[k] = get!(dict, k, zero(V)) + v
+    # Adding zero terms to this dictionary leads to unacceptable performance
+    # degradations. See, e.g., https://github.com/JuliaOpt/JuMP.jl/issues/1946.
+    if !iszero(v)
+        # TODO: This unnecessarily requires two lookups for k.
+        dict[k] = get!(dict, k, zero(V)) + v
+    end
     return dict
 end
 

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -25,12 +25,12 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
     @testset "drop_zeros!(::GenericAffExpr)" begin
         m = ModelType()
         @variable(m, x[1:2])
-        expr = x[1] + 0.0 * x[2] + 1
+        expr = x[1] + x[2] - x[2] + 1
         @test !isequal(expr, x[1] + 1)
         JuMP.drop_zeros!(expr)
         @test isequal(expr, x[1] + 1)
     end
-  
+
     @testset "iszero(::GenericAffExpr)" begin
         m = ModelType()
         @variable(m, x)
@@ -55,12 +55,12 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
     @testset "drop_zeros!(::GenericQuadExpr)" begin
         m = ModelType()
         @variable(m, x[1:2])
-        expr = x[1]^2 + 0.0 * x[2]^2 + x[1] + 0.0 * x[2] + 1
+        expr = x[1]^2 + x[2]^2 - x[2]^2 + x[1] + x[2] - x[2] + 1
         @test !isequal(expr, x[1]^2 + x[1] + 1)
         JuMP.drop_zeros!(expr)
         @test isequal(expr, x[1]^2 + x[1] + 1)
     end
-  
+
     @testset "iszero(::GenericQuadExpr)" begin
         m = ModelType()
         @variable(m, x)


### PR DESCRIPTION
This addresses the `TODO` listed in `_add_or_set!`. 

The answer is not to call `drop_zeros`, but just to exclude terms with a zero coefficient. Thus, `x + 0y` will return `x`, but `x + y - y` will return `x + 0 y`.

Closes #1946.