### PR TITLE
Fix handling of summations with an empty range

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -393,8 +393,6 @@ function parse_one_operator_constraint(_error::Function, vectorized::Bool, sense
     # the `lhs` is a `VariableRef` and the `rhs` is a summation with no terms.
     # Without the `+0` term, `aff` would evaluate to a `VariableRef` when we
     # really want it to be a `GenericAffExpr`.
-    #
-    # See JuMP issue #1954 for more information.
     aff = :($lhs - $rhs + 0)
     set = sense_to_set(_error, sense)
     parse_one_operator_constraint(_error, vectorized, Val(:in), aff, set)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -387,8 +387,15 @@ function parse_one_operator_constraint(_error::Function, vectorized::Bool,
 end
 
 function parse_one_operator_constraint(_error::Function, vectorized::Bool, sense::Val, lhs, rhs)
-    # Simple comparison - move everything to the LHS
-    aff = :($lhs - $rhs)
+    # Simple comparison - move everything to the LHS.
+    #
+    # Note: We add the +0 to this term to account for the diabolical case that
+    # the `lhs` is a `VariableRef` and the `rhs` is a summation with no terms.
+    # Without the `+0` term, `aff` would evaluate to a `VariableRef` when we
+    # really want it to be a `GenericAffExpr`.
+    #
+    # See JuMP issue #1954 for more information.
+    aff = :($lhs - $rhs + 0)
     set = sense_to_set(_error, sense)
     parse_one_operator_constraint(_error, vectorized, Val(:in), aff, set)
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -389,7 +389,7 @@ end
 function parse_one_operator_constraint(_error::Function, vectorized::Bool, sense::Val, lhs, rhs)
     # Simple comparison - move everything to the LHS.
     #
-    # Note: We add the +0 to this term to account for the diabolical case that
+    # Note: We add the +0 to this term to account for the pathological case that
     # the `lhs` is a `VariableRef` and the `rhs` is a summation with no terms.
     # Without the `+0` term, `aff` would evaluate to a `VariableRef` when we
     # really want it to be a `GenericAffExpr`.

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -479,7 +479,7 @@ end
         model = Model()
         @variable(model, x)
         c = @NLconstraint(model, x == sum(1.0 for i in 1:0))
-        @test sprint(show, c) == "x - 0 = 0"
+        @test sprint(show, c) == "x - 0 = 0" || sprint(show, c) == "x - 0 == 0"
     end
 end
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -467,6 +467,13 @@ end
         @test_macro_throws ErrorException("Invalid syntax for @variables") @variables(model, x >= 0)
         @test_macro_throws MethodError @variables(model, x >= 0, Bin)
     end
+
+    @testset "Empty summation in @constraints" begin
+        model = Model()
+        @variable(model, x)
+        c = @constraint(model, x == sum(1.0 for i in 1:0))
+        @test isa(constraint_object(c).func, GenericAffExpr{Float64, VariableRef})
+    end
 end
 
 @testset "Macros for JuMPExtension.MyModel" begin

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -474,6 +474,13 @@ end
         c = @constraint(model, x == sum(1.0 for i in 1:0))
         @test isa(constraint_object(c).func, GenericAffExpr{Float64, VariableRef})
     end
+
+    @testset "Empty summation in @NLconstraints" begin
+        model = Model()
+        @variable(model, x)
+        c = @NLconstraint(model, x == sum(1.0 for i in 1:0))
+        @test sprint(show, c) == "x - 0 = 0"
+    end
 end
 
 @testset "Macros for JuMPExtension.MyModel" begin


### PR DESCRIPTION
Okay, so I thought of a few fixes for this, and I went for the easiest (if the most hacky).

This code should only ever get called for constraints with an (in)equality sense. So `a <= b`, `a >= b`, or `a == b`. (`a in b` goes through a different code path.) Given we have a comparison, then we always want to obtain a `GenericAffExpr`. The easiest way to do this is to just add a dummy `+ 0` term to the expression. 

I haven't benchmarked this, but it should be negligible.

The alternative is to only include this in the `parse_generator_sum` method, and maybe only if the generator has zero terms.

The other argument for doing what I've done here is that there might be other edge-cases (other than `sum` where it might occur. This approach is a panacea.

Closes #1954 