### PR TITLE
Backports for 0.19.1

### DIFF
--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -191,7 +191,7 @@ julia> shadow_price(con)
 2.0
 ```
 
-To query the dual variables associated a variable bound, first obtain a
+To query the dual variables associated with a variable bound, first obtain a
 constraint reference using one of [`UpperBoundRef`](@ref),
 [`LowerBoundRef`](@ref), or [`FixRef`](@ref), and then call [`dual`](@ref) on
 the returned constraint reference. Note that in linear programming,

--- a/docs/src/expressions.md
+++ b/docs/src/expressions.md
@@ -112,6 +112,26 @@ add_to_expression!(ex, 1.0, y)
 2 x + y - 1
 ```
 
+### Removing zero terms
+
+Use [`drop_zeros!`](@ref) to remove terms from an affine expression with a `0`
+coefficient.
+
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x)
+x
+
+julia> @expression(model, ex, 0 * x + 1)
+0 x + 1
+
+julia> drop_zeros!(ex)
+
+julia> ex
+1
+```
+
 ## Quadratic expressions
 
 Like affine expressions, there are four ways of constructing a quadratic
@@ -188,17 +208,38 @@ add_to_expression!(ex, 1.0, y, y)
 x² + 2 x*y + y² + x + y - 1
 ```
 
+### Removing zero terms
+
+Use [`drop_zeros!`](@ref) to remove terms from a quadratic expression with a `0`
+coefficient.
+
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x)
+x
+
+julia> @expression(model, ex, 0 * x^2 + x + 1)
+0 x² + x + 1
+
+julia> drop_zeros!(ex)
+
+julia> ex
+x + 1
+```
+
 ## Nonlinear expressions
 
 Nonlinear expressions can be constructed only using the [`@NLexpression`](@ref)
 macro and can be used only in [`@NLobjective`](@ref), [`@NLconstraint`](@ref),
 and other [`@NLexpression`](@ref)s. Moreover, quadratic and affine expressions
 cannot be used in the nonlinear macros. For more details, see the [Nonlinear
-Modeling](@ref) section. 
+Modeling](@ref) section.
 
 ## Reference
 
 ```@docs
 @expression
-JuMP.add_to_expression!
+add_to_expression!
+drop_zeros!
 ```

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -111,9 +111,25 @@ Base.CartesianIndices(a::DenseAxisArray) = CartesianIndices(a.data)
 # Indexing #
 ############
 
-Base.isassigned(A::DenseAxisArray{T,N}, idx...) where {T,N} = length(idx) == N && all(t -> haskey(A.lookup[t[1]], t[2]), enumerate(idx))
+function _is_assigned(A::DenseAxisArray{T, N}, idx...) where {T, N}
+    if length(idx) == N
+        keys = zeros(Int, N)
+        for (i, v) in enumerate(idx)
+            key = get(A.lookup[i], v, nothing)
+            key === nothing && return false
+            keys[i] = key
+        end
+        return isassigned(A.data, keys...)
+    end
+    return false
+end
+function Base.isassigned(A::DenseAxisArray{T, N}, idx...) where {T, N}
+    return _is_assigned(A, idx...)
+end
 # For ambiguity
-Base.isassigned(A::DenseAxisArray{T,N}, idx::Int...) where {T,N} = length(idx) == N && all(t -> haskey(A.lookup[t[1]], t[2]), enumerate(idx))
+function Base.isassigned(A::DenseAxisArray{T, N}, idx::Int...) where {T, N}
+    return _is_assigned(A, idx...)
+end
 
 Base.eachindex(A::DenseAxisArray) = CartesianIndices(size(A.data))
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -59,7 +59,7 @@ MOIU.@model(_MOIModel,
             (MOI.SingleVariable,),
             (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),
             (MOI.VectorOfVariables,),
-            (MOI.VectorAffineFunction,))
+            (MOI.VectorAffineFunction, MOI.VectorQuadraticFunction))
 
 """
     OptimizerFactory

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -36,6 +36,9 @@ Base.@deprecate(setlowerbound,     JuMP.set_lower_bound)
 Base.@deprecate(setupperbound,     JuMP.set_upper_bound)
 Base.@deprecate(linearterms,       JuMP.linear_terms)
 
+writeLP(args...; kargs...) = error("writeLP has been removed from JuMP. Use `MathOptFormat.jl` instead.")
+writeMPS(args...; kargs...) = error("writeMPS has been removed from JuMP. Use `MathOptFormat.jl` instead.")
+
 include("utils.jl")
 
 const _MOIVAR = MOI.VariableIndex

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -17,9 +17,12 @@
 
 # Utilities for OrderedDict
 function _add_or_set!(dict::OrderedDict{K,V}, k::K, v::V) where {K,V}
+    # Adding zero terms to this dictionary leads to unacceptable performance
+    # degradations. See, e.g., https://github.com/JuliaOpt/JuMP.jl/issues/1946.
+    if iszero(v)
+        return dict  # No-op.
+    end
     # TODO: This unnecessarily requires two lookups for k.
-    # TODO: Decide if we want to drop zeros here after understanding the
-    # performance implications.
     dict[k] = get!(dict, k, zero(V)) + v
     return dict
 end

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -95,6 +95,20 @@ Base.one( a::GenericAffExpr) =  one(typeof(a))
 Base.copy(a::GenericAffExpr) = GenericAffExpr(copy(a.constant), copy(a.terms))
 Base.broadcastable(a::GenericAffExpr) = Ref(a)
 
+"""
+    drop_zeros!(expr::GenericAffExpr)
+
+Remove terms in the affine expression with `0` coefficients.
+"""
+function drop_zeros!(expr::GenericAffExpr)
+    for (key, coef) in expr.terms
+        if iszero(coef)
+            delete!(expr.terms, key)
+        end
+    end
+    return
+end
+
 GenericAffExpr{C, V}() where {C, V} = zero(GenericAffExpr{C, V})
 
 function map_coefficients_inplace!(f::Function, a::GenericAffExpr)

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -82,7 +82,9 @@ function GenericAffExpr{V,K}(constant, kv::Pair...) where {K,V}
     return GenericAffExpr{V,K}(convert(V, constant), _new_ordered_dict(K, V, kv...))
 end
 
-Base.iszero(a::GenericAffExpr) = isempty(a.terms) && iszero(a.constant)
+function Base.iszero(expr::GenericAffExpr)
+    return iszero(expr.constant) && all(iszero, values(expr.terms))
+end
 Base.zero(::Type{GenericAffExpr{C,V}}) where {C,V} = GenericAffExpr{C,V}(zero(C), OrderedDict{V,C}())
 Base.one(::Type{GenericAffExpr{C,V}}) where {C,V}  = GenericAffExpr{C,V}(one(C), OrderedDict{V,C}())
 Base.zero(a::GenericAffExpr) = zero(typeof(a))

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -417,8 +417,13 @@ function parse_one_operator_constraint(_error::Function, vectorized::Bool,
 end
 
 function parse_one_operator_constraint(_error::Function, vectorized::Bool, sense::Val, lhs, rhs)
-    # Simple comparison - move everything to the LHS
-    aff = :($lhs - $rhs)
+    # Simple comparison - move everything to the LHS.
+    #
+    # Note: We add the +0 to this term to account for the pathological case that
+    # the `lhs` is a `VariableRef` and the `rhs` is a summation with no terms.
+    # Without the `+0` term, `aff` would evaluate to a `VariableRef` when we
+    # really want it to be a `GenericAffExpr`.
+    aff = :($lhs - $rhs + 0)
     set = sense_to_set(_error, sense)
     parse_one_operator_constraint(_error, vectorized, Val(:in), aff, set)
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -548,6 +548,16 @@ function build_constraint(_error::Function, expr, lb, ub)
     end
 end
 
+function build_constraint(
+        ::Function, x::Vector{<:AbstractJuMPScalar}, set::MOI.SOS1)
+    return VectorConstraint(x, MOI.SOS1{Float64}(set.weights))
+end
+
+function build_constraint(
+        ::Function, x::Vector{<:AbstractJuMPScalar}, set::MOI.SOS2)
+    return VectorConstraint(x, MOI.SOS2{Float64}(set.weights))
+end
+
 # TODO: update 3-argument @constraint macro to pass through names like @variable
 
 """

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -843,7 +843,11 @@ for (mac,sym) in [(:constraints,  Symbol("@constraint")),
                   (:NLexpressions, Symbol("@NLexpression"))]
     @eval begin
         macro $mac(m, x)
-            x.head == :block || error("Invalid syntax for @",$(string(mac)))
+            if typeof(x) != Expr || x.head != :block
+                # We do a weird string interpolation here so that it gets
+                # interpolated at compile time, not run-time.
+                error("Invalid syntax for @" * $(string(mac)))
+            end
             @assert isa(x.args[1], LineNumberNode)
             lastline = x.args[1]
             code = quote end

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -46,9 +46,9 @@ function set_objective_sense(model::Model, sense::MOI.OptimizationSense)
 end
 
 """
-    set_objective_function(model::Model,
-                           func::Union{AbstractJuMPScalar,
-                                       MathOptInterface.AbstractScalarFunction})
+    set_objective_function(
+        model::Model,
+        func::Union{AbstractJuMPScalar, MathOptInterface.AbstractScalarFunction})
 
 Sets the objective function of the model to the given function. See
 [`set_objective_sense`](@ref) to set the objective sense. These are low-level
@@ -77,8 +77,13 @@ function set_objective_function(model::Model, func::AbstractJuMPScalar)
     set_objective_function(model, moi_function(func))
 end
 
+function set_objective_function(model::Model, func::Real)
+    set_objective_function(model, MOI.ScalarAffineFunction(
+        MOI.ScalarAffineTerm{Float64}[], Float64(func)))
+end
+
 function set_objective(model::Model, sense::MOI.OptimizationSense,
-                       func::AbstractJuMPScalar)
+                       func::Union{AbstractJuMPScalar, Real})
     set_objective_sense(model, sense)
     set_objective_function(model, func)
 end

--- a/src/parse_nlp.jl
+++ b/src/parse_nlp.jl
@@ -199,11 +199,17 @@ end
 function _parse_NL_expr_runtime(m::Model, x::GenericQuadExpr, tape, parent, values)
     error("Unexpected quadratic expression $x in nonlinear expression. " *
           "Quadratic expressions (e.g., created using @expression) and " *
-          "nonlinear expression cannot be mixed.")
+          "nonlinear expressions cannot be mixed.")
+end
+
+function _parse_NL_expr_runtime(m::Model, x::GenericAffExpr, tape, parent, values)
+    error("Unexpected affine expression $x in nonlinear expression. " *
+          "Affine expressions (e.g., created using @expression) and " *
+          "nonlinear expressions cannot be mixed.")
 end
 
 function _parse_NL_expr_runtime(m::Model, x, tape, parent, values)
-    error("Unexpected object $x in nonlinear expression.")
+    error("Unexpected object $x (of type $(typeof(x)) in nonlinear expression.")
 end
 
 function _expression_complexity(ex::Expr)

--- a/src/print.jl
+++ b/src/print.jl
@@ -300,10 +300,8 @@ function function_string(mode, a::GenericAffExpr, show_constant=true)
 
     term_str = Array{String}(undef, 2 * length(linear_terms(a)))
     elm = 1
-    # For each non-zero for this model
-    for (coef, var) in linear_terms(a)
-        _is_zero_for_printing(coef) && continue  # e.g. x - x
 
+    for (coef, var) in linear_terms(a)
         pre = _is_one_for_printing(coef) ? "" : _string_round(abs(coef)) * " "
 
         term_str[2 * elm - 1] = _sign_string(coef)
@@ -339,8 +337,6 @@ function function_string(mode, q::GenericQuadExpr)
     elm = 1
     if length(term_str) > 0
         for (coef, var1, var2) in quad_terms(q)
-            _is_zero_for_printing(coef) && continue  # e.g. x - x
-
             pre = _is_one_for_printing(coef) ? "" : _string_round(abs(coef)) * " "
 
             x = function_string(mode, var1)

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -49,7 +49,9 @@ function GenericQuadExpr{V,K}(aff::GenericAffExpr{V,K}, kv::Pair...) where {K,V}
     return GenericQuadExpr{V,K}(aff, _new_ordered_dict(UnorderedPair{K}, V, kv...))
 end
 
-Base.iszero(q::GenericQuadExpr) = isempty(q.terms) && iszero(q.aff)
+function Base.iszero(expr::GenericQuadExpr)
+    return iszero(expr.aff) && all(iszero, values(expr.terms))
+end
 function Base.zero(::Type{GenericQuadExpr{C,V}}) where {C,V}
     return GenericQuadExpr(zero(GenericAffExpr{C,V}), OrderedDict{UnorderedPair{V}, C}())
 end

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -63,6 +63,21 @@ Base.one(q::GenericQuadExpr)  = one(typeof(q))
 Base.copy(q::GenericQuadExpr) = GenericQuadExpr(copy(q.aff), copy(q.terms))
 Base.broadcastable(q::GenericQuadExpr) = Ref(q)
 
+"""
+    drop_zeros!(expr::GenericQuadExpr)
+
+Remove terms in the quadratic expression with `0` coefficients.
+"""
+function drop_zeros!(expr::GenericQuadExpr)
+    drop_zeros!(expr.aff)
+    for (key, coef) in expr.terms
+        if iszero(coef)
+            delete!(expr.terms, key)
+        end
+    end
+    return
+end
+
 function map_coefficients_inplace!(f::Function, q::GenericQuadExpr)
     # The iterator remains valid if existing elements are updated.
     for (key, value) in q.terms

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -797,3 +797,8 @@ function dual(vref::VariableRef)
           "or `FixRef`, and then call `dual` on the returned constraint reference.\nFor " *
           "example, if `x <= 1`, instead of `dual(x)`, call `dual(UpperBoundRef(x))`.")
 end
+
+function value(::AbstractArray{<:AbstractJuMPScalar})
+    error("`JuMP.value` is not defined for collections of JuMP types. Use" *
+          " Julia's broadcast syntax instead: `JuMP.value.(x)`.")
+end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -790,3 +790,10 @@ function all_variables(model::Model)
         model, MOI.ListOfVariableIndices())::Vector{MOI.VariableIndex}
     return VariableRef[VariableRef(model, idx) for idx in all_indices]
 end
+
+function dual(vref::VariableRef)
+    error("To query the dual variables associated with a variable bound, first " *
+          "obtain a constraint reference using one of `UpperBoundRef`, `LowerBoundRef`, " *
+          "or `FixRef`, and then call `dual` on the returned constraint reference.\nFor " *
+          "example, if `x <= 1`, instead of `dual(x)`, call `dual(UpperBoundRef(x))`.")
+end

--- a/test/DenseAxisArray.jl
+++ b/test/DenseAxisArray.jl
@@ -1,6 +1,9 @@
 @testset "DenseAxisArray" begin
     @testset "undef constructor" begin
         A = @inferred DenseAxisArray{Int}(undef, [:a, :b], 1:2)
+        @test isassigned(A, :a, 1)  # Because the eltype is Int, isassigned=true.
+        @test !isassigned(A, :c, 1)
+        @test !isassigned(A, :c, 1, :d)
         A[:a, 1] = 1
         A[:b, 1] = 2
         A[:a, 2] = 3
@@ -9,6 +12,20 @@
         @test A[:b, 1] == 2
         @test A[:a, 2] == 3
         @test A[:b, 2] == 4
+        @test isassigned(A, :a, 1)
+        @test !isassigned(A, :c, 1)
+    end
+
+    @testset "undef constructor (ii)" begin
+        A = @inferred DenseAxisArray{String}(undef, 1:2)
+        @test !isassigned(A, 1)
+        @test !isassigned(A, 2)
+        @test !isassigned(A, 3)
+        A[1] = "abc"
+        @test isassigned(A, 1)
+        @test !isassigned(A, 2)
+        @test !isassigned(A, 3)
+        @test !isassigned(A, 2, 2)
     end
 
     @testset "Range index set" begin

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -230,6 +230,10 @@ function JuMP.set_objective(m::MyModel, sense::MOI.OptimizationSense,
     m.objectivesense = sense
     m.objective_function = f
 end
+function JuMP.set_objective(m::MyModel, sense::MOI.OptimizationSense, f::Real)
+    m.objectivesense = sense
+    m.objective_function = JuMP.GenericAffExpr{Float64, MyVariableRef}(f)
+end
 JuMP.objective_sense(model::MyModel) = model.objectivesense
 function JuMP.set_objective_sense(model::MyModel, sense)
     model.objectivesense = sense

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -22,6 +22,15 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
         @test hash(x + 1) == hash(x + 1)
     end
 
+    @testset "drop_zeros!(::GenericAffExpr)" begin
+        m = ModelType()
+        @variable(m, x[1:2])
+        expr = x[1] + x[2] - x[2] + 1
+        @test !isequal(expr, x[1] + 1)
+        JuMP.drop_zeros!(expr)
+        @test isequal(expr, x[1] + 1)
+    end
+
     @testset "iszero(::GenericAffExpr)" begin
         m = ModelType()
         @variable(m, x)
@@ -41,6 +50,15 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
         m = ModelType()
         @variable(m, x)
         @test hash(x^2 + 1) == hash(x^2 + 1)
+    end
+
+    @testset "drop_zeros!(::GenericQuadExpr)" begin
+        m = ModelType()
+        @variable(m, x[1:2])
+        expr = x[1]^2 + x[2]^2 - x[2]^2 + x[1] + x[2] - x[2] + 1
+        @test !isequal(expr, x[1]^2 + x[1] + 1)
+        JuMP.drop_zeros!(expr)
+        @test isequal(expr, x[1]^2 + x[1] + 1)
     end
 
     @testset "iszero(::GenericQuadExpr)" begin

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -22,6 +22,15 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
         @test hash(x + 1) == hash(x + 1)
     end
 
+    @testset "iszero(::GenericAffExpr)" begin
+        m = ModelType()
+        @variable(m, x)
+        @test !iszero(x + 1)
+        @test !iszero(x + 0)
+        @test iszero(0 * x + 0)
+        @test iszero(x - x)
+    end
+
     @testset "isequal(::GenericQuadExpr)" begin
         m = ModelType()
         @variable(m, x)
@@ -32,6 +41,16 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
         m = ModelType()
         @variable(m, x)
         @test hash(x^2 + 1) == hash(x^2 + 1)
+    end
+
+    @testset "iszero(::GenericQuadExpr)" begin
+        m = ModelType()
+        @variable(m, x)
+        @test !iszero(x^2 + 1)
+        @test !iszero(x^2 + 0)
+        @test !iszero(x^2 + 0 * x + 0)
+        @test iszero(0 * x^2 + 0 * x + 0)
+        @test iszero(x^2 - x^2)
     end
 
     @testset "value for GenericAffExpr" begin

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -467,6 +467,20 @@ end
         @test_macro_throws ErrorException("Invalid syntax for @variables") @variables(model, x >= 0)
         @test_macro_throws MethodError @variables(model, x >= 0, Bin)
     end
+
+    @testset "Empty summation in @constraints" begin
+        model = Model()
+        @variable(model, x)
+        c = @constraint(model, x == sum(1.0 for i in 1:0))
+        @test isa(constraint_object(c).func, GenericAffExpr{Float64, VariableRef})
+    end
+
+    @testset "Empty summation in @NLconstraints" begin
+        model = Model()
+        @variable(model, x)
+        c = @NLconstraint(model, x == sum(1.0 for i in 1:0))
+        @test sprint(show, c) == "x - 0 = 0" || sprint(show, c) == "x - 0 == 0"
+    end
 end
 
 @testset "Macros for JuMPExtension.MyModel" begin

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -448,6 +448,25 @@ end
          y[1] + y[3] $ge 3.0
         """
     end
+
+    @testset "Index variables don't leak out of macros" begin
+        model = Model()
+        i = 10
+        j = 10
+        @expression(model, ex[j = 2:3], sum(i for i in 1:j))
+        @test ex[2] == AffExpr(3)
+        @test ex[3] == AffExpr(6)
+        @test i == 10
+        @test j == 10
+    end
+
+    @testset "Plural failures" begin
+        model = Model()
+        @test_macro_throws MethodError @variables(model)
+        @test_macro_throws ErrorException("Invalid syntax for @variables") @variables(model, x)
+        @test_macro_throws ErrorException("Invalid syntax for @variables") @variables(model, x >= 0)
+        @test_macro_throws MethodError @variables(model, x >= 0, Bin)
+    end
 end
 
 @testset "Macros for JuMPExtension.MyModel" begin

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -274,6 +274,15 @@ function macros_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::Typ
         @test_macro_throws ErrorException @build_constraint(2x + 1)
     end
 
+    @testset "Promotion of SOS sets" begin
+        model = Model()
+        @variable(model, x[1:3])
+        c_sos1 = @build_constraint(x in MOI.SOS1([1, 2, 3]))
+        @test c_sos1.set == MOI.SOS1([1.0, 2.0, 3.0])
+        c_sos2 = @build_constraint(x in MOI.SOS2([6, 5, 4]))
+        @test c_sos2.set == MOI.SOS2([6.0, 5.0, 4.0])
+    end
+
     build_constraint_keyword_test(ModelType)
 end
 

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -619,4 +619,30 @@
         evaluator = JuMP.NLPEvaluator(model)
         @test !(:Hess in MOI.features_available(evaluator))
     end
+    
+    @testset "Error on using AffExpr in NLexpression" begin
+        model = Model()
+        @variable(model, x)
+        @variable(model, y)
+        A = x + y
+        expected_exception = ErrorException(
+            "Unexpected affine expression x + y in nonlinear expression. " *
+            "Affine expressions (e.g., created using @expression) and " *
+            "nonlinear expressions cannot be mixed."
+        )
+        @test_throws expected_exception @NLexpression(model, A)
+    end
+    
+    @testset "Error on using QuadExpr in NLexpression" begin
+        model = Model()
+        @variable(model, x)
+        @variable(model, y)
+        A = x*y
+        expected_exception = ErrorException(
+            "Unexpected quadratic expression x*y in nonlinear expression. " *
+            "Quadratic expressions (e.g., created using @expression) and " *
+            "nonlinear expressions cannot be mixed."
+        )
+        @test_throws expected_exception @NLexpression(model, A)
+    end
 end

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -97,8 +97,16 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
         sense = :Min
         @test_throws ErrorException @objective(m, sense, 2x)
     end
-end
 
+    @testset "Constant objective" begin
+        model = ModelType()
+        @objective(model, Min, 3)
+        @test JuMP.objective_sense(model) == MOI.MIN_SENSE
+        @test JuMP.isequal_canonical(
+            AffExprType(3.0),
+            JuMP.objective_function(model, AffExprType))
+    end
+end
 
 @testset "Objectives for JuMP.Model" begin
     objectives_test(Model, VariableRef)

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -142,17 +142,16 @@ function operators_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
             @test_expression_with_string w + x "w + x"
             @test_expression_with_string w - x "w - x"
             @test_expression_with_string w * x "w*x"
-            @test_expression_with_string x - x "0"
+            @test_expression_with_string x - x "0 x"
             @test_throws ErrorException w / x
             @test_expression_with_string y*z - x "y*z - x"
-            @test_expression_with_string x - x "0"
             # 2-3 Variable--AffExpr
             @test_expression_with_string z + aff "z + 7.1 x + 2.5"
             @test_expression_with_string z - aff "z - 7.1 x - 2.5"
             @test_expression_with_string z * aff "7.1 z*x + 2.5 z"
             @test_throws ErrorException z / aff
             @test_throws MethodError z ≤ aff
-            @test_expression_with_string 7.1 * x - aff "-2.5"
+            @test_expression_with_string 7.1 * x - aff "0 x - 2.5"
             # 2-4 Variable--QuadExpr
             @test_expression_with_string w + q "2.5 y*z + w + 7.1 x + 2.5"
             @test_expression_with_string w - q "-2.5 y*z + w - 7.1 x - 2.5"
@@ -189,14 +188,14 @@ function operators_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
             @test_expression_with_string aff - z "7.1 x - z + 2.5"
             @test_expression_with_string aff * z "7.1 x*z + 2.5 z"
             @test_throws ErrorException aff/z
-            @test_expression_with_string aff - 7.1 * x "2.5"
+            @test_expression_with_string aff - 7.1 * x "0 x + 2.5"
             # 3-3 AffExpr--AffExpr
             @test_expression_with_string aff + aff2 "7.1 x + 1.2 y + 3.7"
             @test_expression_with_string aff - aff2 "7.1 x - 1.2 y + 1.3"
             @test_expression_with_string aff * aff2 "8.52 x*y + 3 y + 8.52 x + 3"
             @test string((x+x)*(x+3)) == string((x+3)*(x+x))  # Issue #288
             @test_throws ErrorException aff/aff2
-            @test_expression_with_string aff-aff "0"
+            @test_expression_with_string aff-aff "0 x"
             # 4-4 AffExpr--QuadExpr
             @test_expression_with_string aff2 + q "2.5 y*z + 1.2 y + 7.1 x + 3.7"
             @test_expression_with_string aff2 - q "-2.5 y*z + 1.2 y - 7.1 x - 1.3"

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -610,3 +610,12 @@ end
         "example, if `x <= 1`, instead of `dual(x)`, call `dual(UpperBoundRef(x))`.")
     @test_throws exception JuMP.dual(x)
 end
+
+@testset "value on containers" begin
+    model = Model()
+    @variable(model, x[1:2])
+    exception = ErrorException(
+        "`JuMP.value` is not defined for collections of JuMP types. Use " *
+        "Julia's broadcast syntax instead: `JuMP.value.(x)`.")
+    @test_throws exception JuMP.value(x)
+end

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -599,3 +599,14 @@ end
 @testset "Variables for JuMPExtension.MyModel" begin
     variables_test(JuMPExtension.MyModel, JuMPExtension.MyVariableRef)
 end
+
+@testset "Dual from Variable" begin
+    model = Model()
+    @variable(model, x == 0)
+    exception = ErrorException(
+        "To query the dual variables associated with a variable bound, first " *
+        "obtain a constraint reference using one of `UpperBoundRef`, `LowerBoundRef`, " *
+        "or `FixRef`, and then call `dual` on the returned constraint reference.\nFor " *
+        "example, if `x <= 1`, instead of `dual(x)`, call `dual(UpperBoundRef(x))`.")
+    @test_throws exception JuMP.dual(x)
+end


### PR DESCRIPTION
Included all issues currently tagged with "backport 0.19". See the commit history below.
Besides those with the tag, I also included #1934 because it seemed to be needed for one of the subsequent commits (or maybe I merged things the wrong way). As far as I can tell, this is breaking change only in how expressions are printed, so it doesn't seem that harmful to include.