### PR TITLE
add Project.toml so we can tag 0.18.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.sublime*
 *.opf
 *.cov
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ julia:
     - 0.6
     - 0.7
     - 1.0
+    - nightly
 notifications:
     email: false
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ os:
     - linux
     - osx
 julia:
-    - 0.6
+    # O.6 is nominally supported on this branch, but is too complex to test
+    # when Project.toml is present. Be cautious if it's ever necessary to
+    # tag a new 0.18 release in METADATA.
     - 0.7
     - 1.0
     - nightly
@@ -18,12 +20,9 @@ addons:
         - libglpk-dev
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'VERSION > v"0.7-" && import Pkg; Pkg.clone(pwd())'
-    - julia -e 'VERSION > v"0.7-" && import Pkg; Pkg.test("JuMP", coverage=true)'
-    - julia -e 'VERSION > v"0.7-" && import Pkg; Pkg.add("Compat")' # needed by hygiene.jl
-    - julia test/hygiene.jl
-    - julia -e 'VERSION > v"0.7-" && import Pkg; Pkg.add("Ipopt")' # needed for below tests
-    - julia test/hockschittkowski/runhs.jl
-after_success:
-    - echo $TRAVIS_JULIA_VERSION
-    - julia -e 'VERSION > v"0.7-" && import Pkg; Pkg.add("Coverage"); cd(Pkg.dir("JuMP")); import Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'
+    - julia --project=. -e 'using Pkg; Pkg.build()'
+    - julia --project=. -e 'using Pkg; Pkg.test()'
+    - julia --project=. -e 'using Pkg; Pkg.instantiate()'
+    - julia --project=. test/hygiene.jl
+    - julia --project=. -e 'using Pkg; Pkg.add("Ipopt")' # Needed for runhs.jl.
+    - julia --project=. test/hockschittkowski/runhs.jl

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ ForwardDiff = "~0.5.0, ~0.6, ~0.7, ~0.8, ~0.9, ~0.10"
 MathProgBase = "~0.6.0, ~0.7"
 OffsetArrays = "≥ 0.2.13"
 ReverseDiffSparse = "~0.8.0"
-julia = "≥ 0.6.0"
+julia = "0.6, 0.7, 1"
 
 [extras]
 ECOS = "e2685f51-7e38-5353-a97d-a921fd2c8199"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,32 @@
+name = "JuMP"
+uuid = "4076af6c-e467-56ae-b986-b466b2749572"
+repo = "https://github.com/JuliaOpt/JuMP.jl.git"
+version = "0.18.6"
+
+[deps]
+Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+MathProgBase = "fdba3010-5040-5b88-9595-932c9decdf73"
+ReverseDiffSparse = "89212889-6d3f-5f97-b412-7825138f6c9c"
+
+[compat]
+Compat = "≥ 1.0.0"
+ForwardDiff = "~0.5.0, ~0.6, ~0.7, ~0.8, ~0.9, ~0.10"
+MathProgBase = "~0.6.0, ~0.7"
+OffsetArrays = "≥ 0.2.13"
+ReverseDiffSparse = "~0.8.0"
+julia = "≥ 0.6.0"
+
+[extras]
+ECOS = "e2685f51-7e38-5353-a97d-a921fd2c8199"
+GLPKMathProgInterface = "3c7084bd-78ad-589a-b5bb-dbd673274bea"
+Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[targets]
+test = ["OffsetArrays", "Pkg", "Serialization", "GLPKMathProgInterface", "SCS", "ECOS", "Ipopt", "Libdl"]


### PR DESCRIPTION
Given that we recommend users to stick with 0.18 until callbacks are supported, we need to tag 0.18.6 to support Julia 1.2.