### PR TITLE
Error on complex values in NLP

### DIFF
--- a/src/parse_nlp.jl
+++ b/src/parse_nlp.jl
@@ -167,11 +167,7 @@ function _parse_NL_expr(m, x, tapevar, parent, values)
 
 end
 
-function _parse_NL_expr_runtime(m::Model, x::Complex, tape, parent, values)
-    error("Complex numbers are not supported in nonlinear expressions")
-end
-
-function _parse_NL_expr_runtime(m::Model, x::Number, tape, parent, values)
+function _parse_NL_expr_runtime(m::Model, x::Real, tape, parent, values)
     push!(values, x)
     push!(tape, NodeData(VALUE, length(values), parent))
     nothing

--- a/src/parse_nlp.jl
+++ b/src/parse_nlp.jl
@@ -167,6 +167,10 @@ function _parse_NL_expr(m, x, tapevar, parent, values)
 
 end
 
+function _parse_NL_expr_runtime(m::Model, x::Complex, tape, parent, values)
+    error("Complex numbers are not supported in nonlinear expressions")
+end
+
 function _parse_NL_expr_runtime(m::Model, x::Number, tape, parent, values)
     push!(values, x)
     push!(tape, NodeData(VALUE, length(values), parent))

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -619,7 +619,7 @@
         evaluator = JuMP.NLPEvaluator(model)
         @test !(:Hess in MOI.features_available(evaluator))
     end
-    
+
     @testset "Error on using AffExpr in NLexpression" begin
         model = Model()
         @variable(model, x)
@@ -632,7 +632,7 @@
         )
         @test_throws expected_exception @NLexpression(model, A)
     end
-    
+
     @testset "Error on using QuadExpr in NLexpression" begin
         model = Model()
         @variable(model, x)
@@ -644,5 +644,14 @@
             "nonlinear expressions cannot be mixed."
         )
         @test_throws expected_exception @NLexpression(model, A)
+    end
+    @testset "Error on complex values" begin
+        model = Model()
+        @variable(model, x)
+        expected_exception = ErrorException(
+            "Complex numbers are not supported in nonlinear expressions"
+        )
+        c = sqrt(Complex(-1))
+        @test_throws expected_exception @NLobjective(model, Min, c * x)
     end
 end

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -648,10 +648,10 @@
     @testset "Error on complex values" begin
         model = Model()
         @variable(model, x)
-        expected_exception = ErrorException(
-            "Complex numbers are not supported in nonlinear expressions"
-        )
         c = sqrt(Complex(-1))
+        expected_exception = ErrorException(
+            "Unexpected object $c (of type $(typeof(c)) in nonlinear expression."
+        )
         @test_throws expected_exception @NLobjective(model, Min, c * x)
     end
 end


### PR DESCRIPTION
Closes #1973

Related:
```Julia
model = Model()
@variable(model, x >= 1im)
# ERROR: InexactError: Float64(0 + 1im)
```
Probably in lots of other places as well. What do we want to do about this?