### PR TITLE
Improve NLP documentation about ForwardDiff

### DIFF
--- a/docs/src/nlp.md
+++ b/docs/src/nlp.md
@@ -196,11 +196,13 @@ for a description of how to write a function suitable for automatic
 differentiation.
 
 !!! note
-    The general guideline for writing ForwardDiff-compatible code is is to write
-    code that is generic with respect to the number type; don't assume that the 
-    input to the function is `Float64`.
+    If you see method errors with `ForwardDiff.Duals`, see the guidelines at 
+    [ForwardDiff.jl](http://www.juliadiff.org/ForwardDiff.jl/release-0.10/user/limitations.html).
+    The most common error is that your user-defined function is not generic with
+    respect to the number type, i.e., don't assume that the input to the function 
+    is `Float64`.
     ```julia
-    f(x::Float64) = 2 * x  # Don't do this.
+    f(x::Float64) = 2 * x  # This will not work.
     f(x::Real)    = 2 * x  # This is good.
     f(x)          = 2 * x  # This is also good.
     ```

--- a/docs/src/nlp.md
+++ b/docs/src/nlp.md
@@ -193,9 +193,19 @@ JuMP uses [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) to
 perform automatic differentiation; see the ForwardDiff.jl
 [documentation](http://www.juliadiff.org/ForwardDiff.jl/v0.10.2/user/limitations.html)
 for a description of how to write a function suitable for automatic
-differentiation. The general guideline is to write code that is generic with
-respect to the number type; don't assume that the input to the function is
-`Float64`. To register a user-defined function with derivatives computed by
+differentiation.
+
+!!! note
+    The general guideline for writing ForwardDiff-compatible code is is to write
+    code that is generic with respect to the number type; don't assume that the 
+    input to the function is `Float64`.
+    ```julia
+    f(x::Float64) = 2 * x  # Don't do this.
+    f(x::Real)    = 2 * x  # This is good.
+    f(x)          = 2 * x  # This is also good.
+    ```
+    
+To register a user-defined function with derivatives computed by
 automatic differentiation, use the `register` method as in the following
 example:
 


### PR DESCRIPTION
Addresses this Discourse post: https://discourse.julialang.org/t/dual-forwarddiff-type-error-when-jump-tries-autodiff-user-defined-function/25639