### PR TITLE
DNMY: Update to MOI v0.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ForwardDiff = "~0.5.0, ~0.6, ~0.7, ~0.8, ~0.9, ~0.10"
-MathOptInterface = "~0.8.1"
+MathOptInterface = "~0.9"
 NaNMath = "≥ 0.2.1"
 OffsetArrays = "≥ 0.2.13"
 julia = "1"

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -672,9 +672,9 @@ julia> @constraint(model, x[1] + x[2] <= 1);
 
 julia> list_of_constraint_types(model)
 3-element Array{Tuple{DataType,DataType},1}:
- (VariableRef, MathOptInterface.Integer)
- (VariableRef, MathOptInterface.GreaterThan{Float64})
  (GenericAffExpr{Float64,VariableRef}, MathOptInterface.LessThan{Float64})
+ (VariableRef, MathOptInterface.GreaterThan{Float64})
+ (VariableRef, MathOptInterface.Integer)
 
 julia> num_constraints(model, VariableRef, MOI.Integer)
 2

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -141,7 +141,7 @@ DocTestSetup = quote
     model = Model(
         with_optimizer(
             MOI.Utilities.MockOptimizer,
-            JuMP._MOIModel{Float64}(),
+            MOIU.Model{Float64}(),
             eval_objective_value = false,
             eval_variable_constraint_dual = false));
     @variable(model, x);

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -46,7 +46,7 @@ DocTestSetup = quote
     # building the documentation.
     const MOI = JuMP.MathOptInterface
     model = Model(with_optimizer(MOI.Utilities.MockOptimizer,
-                                 JuMP._MOIModel{Float64}(),
+                                 MOIU.Model{Float64}(),
                                  eval_objective_value = false,
                                  eval_variable_constraint_dual = false))
 end

--- a/docs/src/solutions.md
+++ b/docs/src/solutions.md
@@ -164,7 +164,7 @@ julia> @objective(model, Max, x[1]);
 ```@meta
 DocTestSetup = quote
     using JuMP
-    model = Model(with_optimizer(MOIU.MockOptimizer, JuMP._MOIModel{Float64}(),
+    model = Model(with_optimizer(MOIU.MockOptimizer, MOIU.Model{Float64}(),
                   eval_variable_constraint_dual=true));
     @variable(model, x[1:2]);
     @constraint(model, c1, x[1] + x[2] <= 1);

--- a/examples/diet.jl
+++ b/examples/diet.jl
@@ -95,7 +95,7 @@ function example_diet(; verbose = true)
     @constraint(model, buy["milk"] + buy["ice cream"] <= 6)
     verbose && println("Solving dairy-limited problem...")
     JuMP.optimize!(model)
-    @test JuMP.termination_status(model) == MOI.INFEASIBLE_OR_UNBOUNDED
+    @test JuMP.termination_status(model) == MOI.INFEASIBLE
     @test JuMP.primal_status(model) == MOI.NO_SOLUTION
     verbose && print_solution(false, foods, buy)
 end

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -524,7 +524,7 @@ end
 function _moi_optimizer_index(model::MOI.Bridges.LazyBridgeOptimizer,
                               index::MOI.Index)
     if index isa MOI.ConstraintIndex &&
-        MOI.Bridges.is_bridged(model, typeof(index))
+        MOI.Bridges.is_bridged(model, index)
         error("There is no `optimizer_index` for $(typeof(index)) constraints",
               " because they are bridged.")
     else

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -50,21 +50,6 @@ const _MOIFIX = _MOICON{MOI.SingleVariable,MOI.EqualTo{Float64}}
 const _MOIINT = _MOICON{MOI.SingleVariable,MOI.Integer}
 const _MOIBIN = _MOICON{MOI.SingleVariable,MOI.ZeroOne}
 
-MOIU.@model(_MOIModel,
-            (MOI.ZeroOne, MOI.Integer),
-            (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval),
-            (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone,
-             MOI.RotatedSecondOrderCone, MOI.GeometricMeanCone,
-             MOI.PositiveSemidefiniteConeTriangle,
-             MOI.PositiveSemidefiniteConeSquare,
-             MOI.RootDetConeTriangle, MOI.RootDetConeSquare,
-             MOI.LogDetConeTriangle, MOI.LogDetConeSquare),
-            (),
-            (),
-            (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),
-            (MOI.VectorOfVariables,),
-            (MOI.VectorAffineFunction, MOI.VectorQuadraticFunction))
-
 """
     OptimizerFactory
 
@@ -193,7 +178,7 @@ function Model(; caching_mode::MOIU.CachingOptimizerMode=MOIU.AUTOMATIC,
               "later. See the JuMP documentation " *
               "(http://www.juliaopt.org/JuMP.jl/latest/) for latest syntax.")
     end
-    universal_fallback = MOIU.UniversalFallback(_MOIModel{Float64}())
+    universal_fallback = MOIU.UniversalFallback(MOIU.Model{Float64}())
     caching_opt = MOIU.CachingOptimizer(universal_fallback,
                                         caching_mode)
     return direct_model(caching_opt)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -60,7 +60,7 @@ MOIU.@model(_MOIModel,
              MOI.RootDetConeTriangle, MOI.RootDetConeSquare,
              MOI.LogDetConeTriangle, MOI.LogDetConeSquare),
             (),
-            (MOI.SingleVariable,),
+            (),
             (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),
             (MOI.VectorOfVariables,),
             (MOI.VectorAffineFunction, MOI.VectorQuadraticFunction))

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -16,6 +16,7 @@ using SparseArrays
 import MathOptInterface
 const MOI = MathOptInterface
 const MOIU = MOI.Utilities
+const MOIBC = MOI.Bridges.Constraint
 
 import Calculus
 import DataStructures.OrderedDict
@@ -350,36 +351,36 @@ function bridge_constraints(model::Model)
 end
 
 function _moi_add_bridge(model::Nothing,
-                        BridgeType::Type{<:MOI.Bridges.AbstractBridge})
+                        BridgeType::Type{<:MOIBC.AbstractBridge})
     # No optimizer is attached, the bridge will be added when one is attached
     return
 end
 function _moi_add_bridge(model::MOI.ModelLike,
-                        BridgeType::Type{<:MOI.Bridges.AbstractBridge})
+                        BridgeType::Type{<:MOIBC.AbstractBridge})
     error("Cannot add bridge if `bridge_constraints` was set to `false` in the",
           " `Model` constructor.")
 end
 function _moi_add_bridge(bridge_opt::MOI.Bridges.LazyBridgeOptimizer,
-                        BridgeType::Type{<:MOI.Bridges.AbstractBridge})
+                        BridgeType::Type{<:MOIBC.AbstractBridge})
     MOI.Bridges.add_bridge(bridge_opt, BridgeType{Float64})
     return
 end
 function _moi_add_bridge(caching_opt::MOIU.CachingOptimizer,
-                        BridgeType::Type{<:MOI.Bridges.AbstractBridge})
+                        BridgeType::Type{<:MOIBC.AbstractBridge})
     _moi_add_bridge(caching_opt.optimizer, BridgeType)
     return
 end
 
 """
      add_bridge(model::Model,
-                BridgeType::Type{<:MOI.Bridges.AbstractBridge})
+                BridgeType::Type{<:MOIBC.AbstractBridge})
 
 Add `BridgeType` to the list of bridges that can be used to transform
 unsupported constraints into an equivalent formulation using only constraints
 supported by the optimizer.
 """
 function add_bridge(model::Model,
-                    BridgeType::Type{<:MOI.Bridges.AbstractBridge})
+                    BridgeType::Type{<:MOIBC.AbstractBridge})
     push!(model.bridge_types, BridgeType)
     # The type of `backend(model)` is not type-stable, so we use a function
     # barrier (`_moi_add_bridge`) to improve performance.

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -480,7 +480,7 @@ function standard_form_rhs(
         S <: Union{MOI.LessThan{T}, MOI.GreaterThan{T}, MOI.EqualTo{T}},
         F <: Union{MOI.ScalarAffineFunction{T}, MOI.ScalarQuadraticFunction{T}}}
     con = constraint_object(con_ref)
-    return MOIU.getconstant(con.set)
+    return MOI.constant(con.set)
 end
 
 """

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -774,9 +774,9 @@ julia> @constraint(model, 2x <= 1);
 
 julia> list_of_constraint_types(model)
 3-element Array{Tuple{DataType,DataType},1}:
- (VariableRef, MathOptInterface.ZeroOne)
- (VariableRef, MathOptInterface.GreaterThan{Float64})
  (GenericAffExpr{Float64,VariableRef}, MathOptInterface.LessThan{Float64})
+ (VariableRef, MathOptInterface.GreaterThan{Float64})
+ (VariableRef, MathOptInterface.ZeroOne)
 ```
 """
 function list_of_constraint_types(model::Model)

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -140,9 +140,10 @@ as it is convertible to a quadratic function, it can be queried as a quadratic
 function and the result is quadratic.
 
 However, it is not convertible to a variable.
-```jldoctest objective_function; filter = r"Stacktrace:.*"s
+```jldoctest objective_function; filter = r"MathOptInterface\\."s
 julia> objective_function(model, VariableRef)
-ERROR: InexactError: convert(MathOptInterface.SingleVariable,MathOptInterface.ScalarAffineFunction{Float64}(MathOptInterface.ScalarAffineTerm{Float64}[MathOptInterface.ScalarAffineTerm{Float64}(2.0, MathOptInterface.VariableIndex(1))], 1.0))
+ERROR: InexactError: convert(MathOptInterface.SingleVariable, MathOptInterface.ScalarAffineFunction{Float64}(MathOptInterface.ScalarAffineTerm{Float64}[MathOptInterface.ScalarAffineTerm{Float64}(2.0, MathOptInterface.VariableIndex(1))], 1.0))
+[...]
 ```
 """
 function objective_function(model::Model,

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -145,10 +145,10 @@ julia> objective_function(model, VariableRef)
 ERROR: InexactError: convert(MathOptInterface.SingleVariable, MathOptInterface.ScalarAffineFunction{Float64}(MathOptInterface.ScalarAffineTerm{Float64}[ScalarAffineTerm{Float64}(2.0, VariableIndex(1))], 1.0))
 Stacktrace:
  [1] convert at /home/blegat/.julia/dev/MathOptInterface/src/functions.jl:398 [inlined]
- [2] get(::JuMP.JuMPMOIModel{Float64}, ::MathOptInterface.ObjectiveFunction{MathOptInterface.SingleVariable}) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/model.jl:290
+ [2] get(::MOIU.Model{Float64}, ::MathOptInterface.ObjectiveFunction{MathOptInterface.SingleVariable}) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/model.jl:290
  [3] get at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/universalfallback.jl:114 [inlined]
  [4] get at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:439 [inlined]
- [5] get(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer,MathOptInterface.Utilities.UniversalFallback{JuMP.JuMPMOIModel{Float64}}},MathOptInterface.Bridges.AllBridgedConstraints{Float64}}, ::MathOptInterface.ObjectiveFunction{MathOptInterface.SingleVariable}) at /home/blegat/.julia/dev/MathOptInterface/src/Bridges/bridgeoptimizer.jl:172
+ [5] get(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer,MathOptInterface.Utilities.UniversalFallback{MOIU.Model{Float64}}},MathOptInterface.Bridges.AllBridgedConstraints{Float64}}, ::MathOptInterface.ObjectiveFunction{MathOptInterface.SingleVariable}) at /home/blegat/.julia/dev/MathOptInterface/src/Bridges/bridgeoptimizer.jl:172
  [6] objective_function(::Model, ::Type{VariableRef}) at /home/blegat/.julia/dev/JuMP/src/objective.jl:129
  [7] top-level scope at none:0
 ```

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -142,15 +142,7 @@ function and the result is quadratic.
 However, it is not convertible to a variable.
 ```jldoctest objective_function; filter = r"Stacktrace:.*"s
 julia> objective_function(model, VariableRef)
-ERROR: InexactError: convert(MathOptInterface.SingleVariable, MathOptInterface.ScalarAffineFunction{Float64}(MathOptInterface.ScalarAffineTerm{Float64}[ScalarAffineTerm{Float64}(2.0, VariableIndex(1))], 1.0))
-Stacktrace:
- [1] convert at /home/blegat/.julia/dev/MathOptInterface/src/functions.jl:398 [inlined]
- [2] get(::MOIU.Model{Float64}, ::MathOptInterface.ObjectiveFunction{MathOptInterface.SingleVariable}) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/model.jl:290
- [3] get at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/universalfallback.jl:114 [inlined]
- [4] get at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:439 [inlined]
- [5] get(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer,MathOptInterface.Utilities.UniversalFallback{MOIU.Model{Float64}}},MathOptInterface.Bridges.AllBridgedConstraints{Float64}}, ::MathOptInterface.ObjectiveFunction{MathOptInterface.SingleVariable}) at /home/blegat/.julia/dev/MathOptInterface/src/Bridges/bridgeoptimizer.jl:172
- [6] objective_function(::Model, ::Type{VariableRef}) at /home/blegat/.julia/dev/JuMP/src/objective.jl:129
- [7] top-level scope at none:0
+ERROR: InexactError: convert(MathOptInterface.SingleVariable,MathOptInterface.ScalarAffineFunction{Float64}(MathOptInterface.ScalarAffineTerm{Float64}[MathOptInterface.ScalarAffineTerm{Float64}(2.0, MathOptInterface.VariableIndex(1))], 1.0))
 ```
 """
 function objective_function(model::Model,

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -46,7 +46,7 @@ function set_optimizer(model::Model, optimizer_factory::OptimizerFactory;
                 error("Bridges in `MANUAL` mode with an optimizer not ",
                       "supporting `default_copy_to` is not supported yet")
             end
-            universal_fallback = MOIU.UniversalFallback(_MOIModel{Float64}())
+            universal_fallback = MOIU.UniversalFallback(MOIU.Model{Float64}())
             optimizer = MOIU.CachingOptimizer(universal_fallback, optimizer)
         end
         optimizer = MOI.Bridges.full_bridge_optimizer(optimizer, Float64)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -249,9 +249,9 @@ julia> variable_by_name(model, "x")
 ERROR: Multiple variables have the name x.
 Stacktrace:
  [1] error(::String) at ./error.jl:33
- [2] get(::JuMP._MOIModel{Float64}, ::Type{MathOptInterface.VariableIndex}, ::String) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/model.jl:222
+ [2] get(::MOIU.Model{Float64}, ::Type{MathOptInterface.VariableIndex}, ::String) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/model.jl:222
  [3] get at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/universalfallback.jl:201 [inlined]
- [4] get(::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}}, ::Type{MathOptInterface.VariableIndex}, ::String) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:490
+ [4] get(::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer,MathOptInterface.Utilities.UniversalFallback{MOIU.Model{Float64}}}, ::Type{MathOptInterface.VariableIndex}, ::String) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:490
  [5] variable_by_name(::Model, ::String) at /home/blegat/.julia/dev/JuMP/src/variables.jl:268
  [6] top-level scope at none:0
 

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -501,7 +501,7 @@ function test_shadow_price(model_string, constraint_dual, constraint_shadow)
     model = JuMP.Model()
     MOIU.loadfromstring!(JuMP.backend(model), model_string)
     JuMP.optimize!(model, with_optimizer(MOIU.MockOptimizer,
-                                         JuMP._MOIModel{Float64}(),
+                                         MOIU.Model{Float64}(),
                                          eval_objective_value=false,
                                          eval_variable_constraint_dual=false))
     mock_optimizer = JuMP.backend(model).optimizer.model

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -38,12 +38,12 @@ using JuMP
         c: x + y <= 1.0
         """
 
-        model = JuMP._MOIModel{Float64}()
+        model = MOIU.Model{Float64}()
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.backend(m).model_cache, model, ["x","y"], ["c", "xub", "ylb"])
 
         JuMP.optimize!(m, with_optimizer(MOIU.MockOptimizer,
-                                         JuMP._MOIModel{Float64}(),
+                                         MOIU.Model{Float64}(),
                                          eval_objective_value=false))
 
         mockoptimizer = JuMP.backend(m).optimizer.model
@@ -77,7 +77,7 @@ using JuMP
     end
 
     @testset "LP (Direct mode)" begin
-        mockoptimizer = MOIU.MockOptimizer(JuMP._MOIModel{Float64}(),
+        mockoptimizer = MOIU.MockOptimizer(MOIU.Model{Float64}(),
                                            eval_objective_value=false)
 
         m = JuMP.direct_model(mockoptimizer)
@@ -121,7 +121,7 @@ using JuMP
     @testset "IP" begin
         # Tests the solver= keyword.
         m = Model(with_optimizer(MOIU.MockOptimizer,
-                                 JuMP._MOIModel{Float64}(),
+                                 MOIU.Model{Float64}(),
                                  eval_objective_value=false),
                   caching_mode = MOIU.AUTOMATIC)
         @variable(m, x == 1.0, Int)
@@ -140,7 +140,7 @@ using JuMP
         ybin: y in ZeroOne()
         """
 
-        model = JuMP._MOIModel{Float64}()
+        model = MOIU.Model{Float64}()
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.backend(m).model_cache, model, ["x","y"], ["xfix", "xint", "ybin"])
 
@@ -188,12 +188,12 @@ using JuMP
         c3: 2x + 3*y*x >= 2.0
         """
 
-        model = JuMP._MOIModel{Float64}()
+        model = MOIU.Model{Float64}()
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.backend(m).model_cache, model, ["x","y"], ["c1", "c2", "c3"])
 
         JuMP.optimize!(m, with_optimizer(MOIU.MockOptimizer,
-                                         JuMP._MOIModel{Float64}(),
+                                         MOIU.Model{Float64}(),
                                          eval_objective_value=false))
 
         mockoptimizer = JuMP.backend(m).optimizer.model
@@ -247,11 +247,11 @@ using JuMP
         rotsoc: [x+1,y,z] in RotatedSecondOrderCone(3)
         """
 
-        model = JuMP._MOIModel{Float64}()
+        model = MOIU.Model{Float64}()
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.backend(m).model_cache, model, ["x","y","z"], ["varsoc", "affsoc", "rotsoc"])
 
-        mockoptimizer = MOIU.MockOptimizer(JuMP._MOIModel{Float64}(),
+        mockoptimizer = MOIU.MockOptimizer(MOIU.Model{Float64}(),
                                            eval_objective_value=false,
                                            eval_variable_constraint_dual=false)
         MOIU.reset_optimizer(m, mockoptimizer)
@@ -306,13 +306,13 @@ using JuMP
         con_psd: [x11 + -1.0,x12,x12,x22 + -1.0] in PositiveSemidefiniteConeSquare(2)
         """
 
-        model = JuMP._MOIModel{Float64}()
+        model = MOIU.Model{Float64}()
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.backend(m).model_cache, model,
                                ["x11","x12","x22"],
                                ["var_psd", "sym_psd", "con_psd"])
 
-        mockoptimizer = MOIU.MockOptimizer(JuMP._MOIModel{Float64}(),
+        mockoptimizer = MOIU.MockOptimizer(MOIU.Model{Float64}(),
                                            eval_objective_value=false,
                                            eval_variable_constraint_dual=false)
         MOIU.reset_optimizer(m, mockoptimizer)
@@ -357,19 +357,19 @@ using JuMP
     end
 
     @testset "Provide factory in `optimize` in Direct mode" begin
-        mockoptimizer = MOIU.MockOptimizer(JuMP._MOIModel{Float64}())
+        mockoptimizer = MOIU.MockOptimizer(MOIU.Model{Float64}())
         model = JuMP.direct_model(mockoptimizer)
-        @test_throws ErrorException JuMP.optimize!(model, with_optimizer(MOIU.MockOptimizer, JuMP._MOIModel{Float64}()))
+        @test_throws ErrorException JuMP.optimize!(model, with_optimizer(MOIU.MockOptimizer, MOIU.Model{Float64}()))
     end
 
     @testset "Provide factory both in `Model` and `optimize`" begin
-        model = Model(with_optimizer(MOIU.MockOptimizer, JuMP._MOIModel{Float64}()))
-        @test_throws ErrorException JuMP.optimize!(model, with_optimizer(MOIU.MockOptimizer, JuMP._MOIModel{Float64}()))
+        model = Model(with_optimizer(MOIU.MockOptimizer, MOIU.Model{Float64}()))
+        @test_throws ErrorException JuMP.optimize!(model, with_optimizer(MOIU.MockOptimizer, MOIU.Model{Float64}()))
     end
 
     @testset "Solver doesn't support nonlinear constraints" begin
         model = Model(with_optimizer(MOIU.MockOptimizer,
-                                     JuMP._MOIModel{Float64}()))
+                                     MOIU.Model{Float64}()))
         @variable(model, x)
         @NLobjective(model, Min, sin(x))
         err = ErrorException("The solver does not support nonlinear problems " *

--- a/test/lp_sensitivity.jl
+++ b/test/lp_sensitivity.jl
@@ -11,7 +11,7 @@ function test_lp_rhs_perturbation_range(model_string, primal_solution, basis_sta
     model = JuMP.Model()
     MOIU.loadfromstring!(JuMP.backend(model), model_string)
     JuMP.optimize!(model, with_optimizer(MOIU.MockOptimizer,
-                                         JuMP._MOIModel{Float64}(),
+                                         MOIU.Model{Float64}(),
                                          eval_variable_constraint_dual=false))
     mock_optimizer = JuMP.backend(model).optimizer.model
     MOI.set(mock_optimizer, MOI.TerminationStatus(), MOI.OPTIMAL)
@@ -107,7 +107,7 @@ function test_lp_objective_perturbation_range(model_string, dual_solution, basis
     model = JuMP.Model()
     MOIU.loadfromstring!(JuMP.backend(model), model_string)
     JuMP.optimize!(model, with_optimizer(MOIU.MockOptimizer,
-                                         JuMP._MOIModel{Float64}(),
+                                         MOIU.Model{Float64}(),
                                          eval_variable_constraint_dual=true))
     mock_optimizer = JuMP.backend(model).optimizer.model
     MOI.set(mock_optimizer, MOI.TerminationStatus(), MOI.OPTIMAL)

--- a/test/model.jl
+++ b/test/model.jl
@@ -230,7 +230,7 @@ function test_model()
 
         @testset "Add bridge" begin
             function mock()
-                mock = MOIU.MockOptimizer(JuMP._MOIModel{Float64}(),
+                mock = MOIU.MockOptimizer(MOIU.Model{Float64}(),
                                           eval_variable_constraint_dual=false)
                 optimize!(mock) = MOIU.mock_optimize!(mock, [1.0],
                         (MOI.SingleVariable, MOI.GreaterThan{Float64}) => [2.0])
@@ -367,7 +367,7 @@ function test_model()
         end
     end
     @testset "set_silent and unset_silent" begin
-        mock = MOIU.UniversalFallback(JuMP._MOIModel{Float64}())
+        mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
         model = Model(with_optimizer(MOIU.MockOptimizer, mock))
         @test JuMP.set_silent(model)
         @test MOI.get(backend(model), MOI.Silent())
@@ -445,7 +445,7 @@ function dummy_optimizer_hook(::JuMP.AbstractModel) end
         end
     end
     @testset "In Direct mode" begin
-        mock = MOIU.MockOptimizer(JuMP._MOIModel{Float64}())
+        mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
         model = JuMP.direct_model(mock)
         @test_throws ErrorException JuMP.copy(model)
     end

--- a/test/model.jl
+++ b/test/model.jl
@@ -25,7 +25,7 @@ const MOIU = MOI.Utilities
             (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan),
             (),
             (),
-            (MOI.SingleVariable,),
+            (),
             (MOI.ScalarAffineFunction,),
             (),
             ())

--- a/test/nonnegative_bridge.jl
+++ b/test/nonnegative_bridge.jl
@@ -12,6 +12,7 @@
 
 using MathOptInterface
 const MOI = MathOptInterface
+const MOIB = MOI.Bridges
 const MOIBC = MOI.Bridges.Constraint
 
 """
@@ -44,7 +45,7 @@ function MOI.supports_constraint(::Type{NonnegativeBridge{T}},
                                  ::Type{Nonnegative}) where T
     return true
 end
-function MOIBC.added_constraint_types(::Type{NonnegativeBridge{T, F}}) where {T, F}
+function MOIB.added_constraint_types(::Type{NonnegativeBridge{T, F}}) where {T, F}
     return [(F, MOI.GreaterThan{T})]
 end
 function MOIBC.concrete_bridge_type(::Type{NonnegativeBridge{T}},

--- a/test/nonnegative_bridge.jl
+++ b/test/nonnegative_bridge.jl
@@ -30,7 +30,11 @@ The `NonnegativeBridge` replaces a constraint `func`-in-`Nonnegative` into
 struct NonnegativeBridge{T, F<:MOI.AbstractScalarFunction} <: MOIBC.AbstractBridge
     constraint_index::MOI.ConstraintIndex{F, MOI.GreaterThan{T}}
 end
-function NonnegativeBridge{T, F}(model, f::F, s::Nonnegative) where {T, F}
+
+function MOIBC.bridge_constraint(::Type{NonnegativeBridge{T, F}},
+                                 model,
+                                 f::F,
+                                 s::Nonnegative) where {T, F}
     ci = MOIU.add_scalar_constraint(model, f, MOI.GreaterThan(zero(T)))
     return NonnegativeBridge{T, F}(ci)
 end

--- a/test/nonnegative_bridge.jl
+++ b/test/nonnegative_bridge.jl
@@ -12,7 +12,7 @@
 
 using MathOptInterface
 const MOI = MathOptInterface
-const MOIB = MOI.Bridges
+const MOIBC = MOI.Bridges.Constraint
 
 """
     Nonnegative <: MOI.AbstractScalarSet
@@ -27,7 +27,7 @@ struct Nonnegative <: MOI.AbstractScalarSet end
 The `NonnegativeBridge` replaces a constraint `func`-in-`Nonnegative` into
 `func`-in-`GreaterThan{T}`.
 """
-struct NonnegativeBridge{T, F<:MOI.AbstractScalarFunction} <: MOIB.AbstractBridge
+struct NonnegativeBridge{T, F<:MOI.AbstractScalarFunction} <: MOIBC.AbstractBridge
     constraint_index::MOI.ConstraintIndex{F, MOI.GreaterThan{T}}
 end
 function NonnegativeBridge{T, F}(model, f::F, s::Nonnegative) where {T, F}
@@ -40,12 +40,12 @@ function MOI.supports_constraint(::Type{NonnegativeBridge{T}},
                                  ::Type{Nonnegative}) where T
     return true
 end
-function MOIB.added_constraint_types(::Type{NonnegativeBridge{T, F}}) where {T, F}
+function MOIBC.added_constraint_types(::Type{NonnegativeBridge{T, F}}) where {T, F}
     return [(F, MOI.GreaterThan{T})]
 end
-function MOIB.concrete_bridge_type(::Type{NonnegativeBridge{T}},
-                                   F::Type{<:MOI.AbstractScalarFunction},
-                                   ::Type{Nonnegative}) where T
+function MOIBC.concrete_bridge_type(::Type{NonnegativeBridge{T}},
+                                    F::Type{<:MOI.AbstractScalarFunction},
+                                    ::Type{Nonnegative}) where T
     # In the constructor, the function `f` of type `F` is passed to
     # `MOIU.add_scalar_constraint` which removes the constrant from `f` but
     # does not change its type so the type of the function in `MOI.GreaterThan`

--- a/test/nonnegative_bridge.jl
+++ b/test/nonnegative_bridge.jl
@@ -36,7 +36,7 @@ function MOIBC.bridge_constraint(::Type{NonnegativeBridge{T, F}},
                                  model,
                                  f::F,
                                  s::Nonnegative) where {T, F}
-    ci = MOIU.add_scalar_constraint(model, f, MOI.GreaterThan(zero(T)))
+    ci = MOIU.normalize_and_add_constraint(model, f, MOI.GreaterThan(zero(T)))
     return NonnegativeBridge{T, F}(ci)
 end
 
@@ -45,6 +45,10 @@ function MOI.supports_constraint(::Type{NonnegativeBridge{T}},
                                  ::Type{Nonnegative}) where T
     return true
 end
+
+function MOIB.added_constrained_variable_types(::Type{NonnegativeBridge{T, F}}) where {T, F}
+    return []
+end
 function MOIB.added_constraint_types(::Type{NonnegativeBridge{T, F}}) where {T, F}
     return [(F, MOI.GreaterThan{T})]
 end
@@ -52,7 +56,7 @@ function MOIBC.concrete_bridge_type(::Type{NonnegativeBridge{T}},
                                     F::Type{<:MOI.AbstractScalarFunction},
                                     ::Type{Nonnegative}) where T
     # In the constructor, the function `f` of type `F` is passed to
-    # `MOIU.add_scalar_constraint` which removes the constrant from `f` but
+    # `MOIU.normalize_and_add_constraint` which removes the constrant from `f` but
     # does not change its type so the type of the function in `MOI.GreaterThan`
     # will also be `F`.
     return NonnegativeBridge{T, F}

--- a/test/print.jl
+++ b/test/print.jl
@@ -385,23 +385,6 @@ function model_printing_test(ModelType::Type{<:JuMP.AbstractModel})
         io_test(REPLMode, model_1, """
     Max a - b + 2 a1 - 10 x
     Subject to
-     x binary
-     u[1] binary
-     u[2] binary
-     u[3] binary
-     a1 integer
-     b1 integer
-     c1 integer
-     z integer
-     fi $eq 9.0
-     a $ge 1.0
-     c $ge -1.0
-     a1 $ge 1.0
-     c1 $ge -1.0
-     b $le 1.0
-     c $le 1.0
-     b1 $le 1.0
-     c1 $le 1.0
      a + b - 10 c - 2 x + c1 $le 1.0
      a*b $le 2.0
      [a  b;
@@ -411,6 +394,23 @@ function model_printing_test(ModelType::Type{<:JuMP.AbstractModel})
       c  x] $inset PSDCone()
      [a, b, c, x] $inset MathOptInterface.PositiveSemidefiniteConeSquare(2)
      [-a + 1, u[1], u[2], u[3]] $inset MathOptInterface.SecondOrderCone(4)
+     fi $eq 9.0
+     a $ge 1.0
+     c $ge -1.0
+     a1 $ge 1.0
+     c1 $ge -1.0
+     b $le 1.0
+     c $le 1.0
+     b1 $le 1.0
+     c1 $le 1.0
+     a1 integer
+     b1 integer
+     c1 integer
+     z integer
+     x binary
+     u[1] binary
+     u[2] binary
+     u[3] binary
     """, repl=:print)
 
         io_test(REPLMode, model_1, """
@@ -418,16 +418,16 @@ function model_printing_test(ModelType::Type{<:JuMP.AbstractModel})
     Maximization problem with:
     Variables: 13
     Objective function type: GenericAffExpr{Float64,$VariableType}
-    `$VariableType`-in-`MathOptInterface.ZeroOne`: 4 constraints
-    `$VariableType`-in-`MathOptInterface.Integer`: 4 constraints
-    `$VariableType`-in-`MathOptInterface.EqualTo{Float64}`: 1 constraint
-    `$VariableType`-in-`MathOptInterface.GreaterThan{Float64}`: 4 constraints
-    `$VariableType`-in-`MathOptInterface.LessThan{Float64}`: 4 constraints
     `GenericAffExpr{Float64,$VariableType}`-in-`MathOptInterface.LessThan{Float64}`: 1 constraint
     `GenericQuadExpr{Float64,$VariableType}`-in-`MathOptInterface.LessThan{Float64}`: 1 constraint
     `Array{$VariableType,1}`-in-`MathOptInterface.PositiveSemidefiniteConeTriangle`: 2 constraints
     `Array{$VariableType,1}`-in-`MathOptInterface.PositiveSemidefiniteConeSquare`: 2 constraints
     `Array{GenericAffExpr{Float64,$VariableType},1}`-in-`MathOptInterface.SecondOrderCone`: 1 constraint
+    `$VariableType`-in-`MathOptInterface.EqualTo{Float64}`: 1 constraint
+    `$VariableType`-in-`MathOptInterface.GreaterThan{Float64}`: 4 constraints
+    `$VariableType`-in-`MathOptInterface.LessThan{Float64}`: 4 constraints
+    `$VariableType`-in-`MathOptInterface.Integer`: 4 constraints
+    `$VariableType`-in-`MathOptInterface.ZeroOne`: 4 constraints
     Model mode: AUTOMATIC
     CachingOptimizer state: NO_OPTIMIZER
     Solver name: No optimizer attached.
@@ -435,24 +435,7 @@ function model_printing_test(ModelType::Type{<:JuMP.AbstractModel})
 
         io_test(IJuliaMode, model_1, """
     \\begin{alignat*}{1}\\max\\quad & a - b + 2 a1 - 10 x\\\\
-    \\text{Subject to} \\quad & x binary\\\\
-     & u_{1} binary\\\\
-     & u_{2} binary\\\\
-     & u_{3} binary\\\\
-     & a1 integer\\\\
-     & b1 integer\\\\
-     & c1 integer\\\\
-     & z integer\\\\
-     & fi = 9.0\\\\
-     & a \\geq 1.0\\\\
-     & c \\geq -1.0\\\\
-     & a1 \\geq 1.0\\\\
-     & c1 \\geq -1.0\\\\
-     & b \\leq 1.0\\\\
-     & c \\leq 1.0\\\\
-     & b1 \\leq 1.0\\\\
-     & c1 \\leq 1.0\\\\
-     & a + b - 10 c - 2 x + c1 \\leq 1.0\\\\
+    \\text{Subject to} \\quad & a + b - 10 c - 2 x + c1 \\leq 1.0\\\\
      & a\\times b \\leq 2.0\\\\
      & \\begin{bmatrix}
     a & b\\\\
@@ -465,6 +448,23 @@ function model_printing_test(ModelType::Type{<:JuMP.AbstractModel})
     \\end{bmatrix} \\in PSDCone()\\\\
      & [a, b, c, x] \\in MathOptInterface.PositiveSemidefiniteConeSquare(2)\\\\
      & [-a + 1, u_{1}, u_{2}, u_{3}] \\in MathOptInterface.SecondOrderCone(4)\\\\
+     & fi = 9.0\\\\
+     & a \\geq 1.0\\\\
+     & c \\geq -1.0\\\\
+     & a1 \\geq 1.0\\\\
+     & c1 \\geq -1.0\\\\
+     & b \\leq 1.0\\\\
+     & c \\leq 1.0\\\\
+     & b1 \\leq 1.0\\\\
+     & c1 \\leq 1.0\\\\
+     & a1 integer\\\\
+     & b1 integer\\\\
+     & c1 integer\\\\
+     & z integer\\\\
+     & x binary\\\\
+     & u_{1} binary\\\\
+     & u_{2} binary\\\\
+     & u_{3} binary\\\\
     \\end{alignat*}
     """)
 
@@ -479,9 +479,9 @@ function model_printing_test(ModelType::Type{<:JuMP.AbstractModel})
     A JuMP Model
     Feasibility problem with:
     Variables: 2
-    `$VariableType`-in-`MathOptInterface.ZeroOne`: 1 constraint
-    `$VariableType`-in-`MathOptInterface.Integer`: 1 constraint
     `GenericQuadExpr{Float64,$VariableType}`-in-`MathOptInterface.LessThan{Float64}`: 1 constraint
+    `$VariableType`-in-`MathOptInterface.Integer`: 1 constraint
+    `$VariableType`-in-`MathOptInterface.ZeroOne`: 1 constraint
     Model mode: AUTOMATIC
     CachingOptimizer state: NO_OPTIMIZER
     Solver name: No optimizer attached.


### PR DESCRIPTION
Might be a bit premature, since not all solvers have been updated (see https://github.com/JuliaOpt/MathOptInterface.jl/issues/736), but I wanted to play with https://github.com/JuliaOpt/Gurobi.jl/pull/216 .

All tests pass. ~~, except for https://github.com/coroa/JuMP.jl/blob/c8784cf3e9fe5936e652139a5ae73caa48d6cfb4/test/print.jl#L351-L509 , where constraints appear with a different order; and I do not know, whether that is meant to stay!?~~ . 

All doc-tests pass as well.

All examples run fine.

## Next steps
- [x] Wait for MOI and solvers to tag compatible versions, then
- [x] Remove `Manifest.toml` from top-level, `docs` and `examples`
- [x] Remove MOI from `Project.toml` files
- [x] Rebased on `master`