### PR TITLE
Implement set_objective_coefficient

### DIFF
--- a/docs/src/objective.md
+++ b/docs/src/objective.md
@@ -9,6 +9,9 @@ Use the [`@objective`](@ref) macro to set linear and quadratic objective
 functions in a JuMP model. The functions [`set_objective_sense`](@ref) and
 [`set_objective_function`](@ref) provide an equivalent lower-level interface.
 
+To update a term in the objective function, see
+[`set_objective_coefficient`](@ref). 
+
 To query the objective function from a model, see [`objective_sense`](@ref),
 [`objective_function`](@ref), and [`objective_function_type`](@ref).
 
@@ -23,6 +26,7 @@ apply to nonlinear objectives also.
 @objective
 JuMP.set_objective_sense
 JuMP.set_objective_function
+JuMP.set_objective_coefficient
 
 JuMP.objective_sense
 JuMP.objective_function

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -184,7 +184,7 @@ function set_objective_coefficient(model::Model, variable::VariableRef, coeff::R
         end
     elseif obj_fct_type == AffExpr || obj_fct_type == QuadExpr
         MOI.modify(backend(model),
-            MOI.ObjectiveFunction{moi_function_type(objective_function_type(model))}(),
+            MOI.ObjectiveFunction{moi_function_type(obj_fct_type)}(),
             MOI.ScalarCoefficientChange(index(variable), coeff)
         )
     else

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -172,14 +172,13 @@ coefficient of a quadratic term where there is only a linear objective.
 function set_objective_coefficient end
 
 function set_objective_coefficient(model::Model, variable::VariableRef, coeff)
+    if model.nlp_data !== nothing && model.nlp_data.nlobj !== nothing
+        error("A nonlinear objective is already set in the model")
+    end
+
     MOI.modify(backend(model),
             MOI.ObjectiveFunction{moi_function_type(objective_function_type(model))}(),
             MOI.ScalarCoefficientChange(index(variable), coeff)
     )
-    # Nonlinear objectives override regular objectives, so if there was a
-    # nonlinear objective set, we must clear it.
-    if model.nlp_data !== nothing
-        model.nlp_data.nlobj = nothing
-    end
     return
 end

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -169,7 +169,7 @@ Set the linear objective coefficient associated with `Variable` to `coefficient`
 Note: this function will throw an error if a nonlinear objective is set.
 """
 function set_objective_coefficient(model::Model, variable::VariableRef, coeff::Real)
-    if model.nlp_data !== nothing && model.nlp_data.nlobj !== nothing
+    if model.nlp_data !== nothing && _nlp_objective_function(model) !== nothing
         error("A nonlinear objective is already set in the model")
     end
 

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -180,13 +180,12 @@ function set_objective_coefficient(model::Model, variable::VariableRef, coeff::R
         if index(current_obj) == index(variable)
             set_objective_function(model, coeff * variable)
         else
-            obj_expr = objective_function(model)
-            add_to_expression!(coeff * variable, obj_expr)
+            set_objective_function(model, add_to_expression!(coeff * variable, current_obj))
         end
     elseif obj_fct_type == MOI.ScalarAffineFunction{Float64} || obj_fct_type == MOI.ScalarQuadraticFunction{Float64}
         MOI.modify(backend(model),
-                MOI.ObjectiveFunction{moi_function_type(objective_function_type(model))}(),
-                MOI.ScalarCoefficientChange(index(variable), coeff)
+            MOI.ObjectiveFunction{moi_function_type(objective_function_type(model))}(),
+            MOI.ScalarCoefficientChange(index(variable), coeff)
         )
     else
         error("Objective function type not supported: $(obj_fct_type)")

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -176,7 +176,12 @@ function set_objective_coefficient(model::Model, variable::VariableRef, coeff::R
     obj_fct_type = moi_function_type(objective_function_type(model))
     if obj_fct_type == MOI.SingleVariable
         # Promote the objective function to be an affine expression.
-        set_objective_function(model, coeff * variable)
+        current_obj = objective_function(model)
+        if index(current_obj) == index(variable)
+            set_objective_function(model, coeff * variable)
+        else
+            set_objective_function(model, current_obj + coeff * variable)
+        end
     elseif obj_fct_type == MOI.ScalarAffineFunction{Float64} || obj_fct_type == MOI.ScalarQuadraticFunction{Float64}
         MOI.modify(backend(model),
                 MOI.ObjectiveFunction{moi_function_type(objective_function_type(model))}(),

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -162,16 +162,13 @@ function objective_function(model::Model,
 end
 
 """
-    set_objective_coefficient(model::Model, term, coeff)
+    set_objective_coefficient(model::Model, variable::VariableRef, coefficient::Real)
 
-Updates the objective function to change the coefficient of the given term.
-If the objective does not have the right type, an error will be thrown:
-changing a variable coefficient for a constant objective, changing the
-coefficient of a quadratic term where there is only a linear objective.
+Set the linear objective coefficient associated with `Variable` to `coefficient`.
+
+Note: this function will throw an error if a nonlinear objective is set.
 """
-function set_objective_coefficient end
-
-function set_objective_coefficient(model::Model, variable::VariableRef, coeff)
+function set_objective_coefficient(model::Model, variable::VariableRef, coeff::Real)
     if model.nlp_data !== nothing && model.nlp_data.nlobj !== nothing
         error("A nonlinear objective is already set in the model")
     end

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -173,8 +173,8 @@ function set_objective_coefficient(model::Model, variable::VariableRef, coeff::R
         error("A nonlinear objective is already set in the model")
     end
 
-    obj_fct_type = moi_function_type(objective_function_type(model))
-    if obj_fct_type == MOI.SingleVariable
+    obj_fct_type = objective_function_type(model)
+    if obj_fct_type == VariableRef
         # Promote the objective function to be an affine expression.
         current_obj = objective_function(model)
         if index(current_obj) == index(variable)
@@ -182,7 +182,7 @@ function set_objective_coefficient(model::Model, variable::VariableRef, coeff::R
         else
             set_objective_function(model, add_to_expression!(coeff * variable, current_obj))
         end
-    elseif obj_fct_type == MOI.ScalarAffineFunction{Float64} || obj_fct_type == MOI.ScalarQuadraticFunction{Float64}
+    elseif obj_fct_type == AffExpr || obj_fct_type == QuadExpr
         MOI.modify(backend(model),
             MOI.ObjectiveFunction{moi_function_type(objective_function_type(model))}(),
             MOI.ScalarCoefficientChange(index(variable), coeff)

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -180,7 +180,8 @@ function set_objective_coefficient(model::Model, variable::VariableRef, coeff::R
         if index(current_obj) == index(variable)
             set_objective_function(model, coeff * variable)
         else
-            set_objective_function(model, current_obj + coeff * variable)
+            obj_expr = objective_function(model)
+            add_to_expression!(coeff * variable, obj_expr)
         end
     elseif obj_fct_type == MOI.ScalarAffineFunction{Float64} || obj_fct_type == MOI.ScalarQuadraticFunction{Float64}
         MOI.modify(backend(model),

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -160,3 +160,26 @@ function objective_function(model::Model,
                    MOI.ObjectiveFunction{MOIFunType}())::MOIFunType
     return jump_function(model, func)
 end
+
+"""
+    set_objective_coefficient(model::Model, term, coeff)
+
+Updates the objective function to change the coefficient of the given term.
+If the objective does not have the right type, an error will be thrown:
+changing a variable coefficient for a constant objective, changing the
+coefficient of a quadratic term where there is only a linear objective.
+"""
+function set_objective_coefficient end
+
+function set_objective_coefficient(model::Model, variable::VariableRef, coeff)
+    MOI.modify(backend(model),
+            MOI.ObjectiveFunction{moi_function_type(objective_function_type(model))}(),
+            MOI.ScalarCoefficientChange(index(variable), coeff)
+    )
+    # Nonlinear objectives override regular objectives, so if there was a
+    # nonlinear objective set, we must clear it.
+    if model.nlp_data !== nothing
+        model.nlp_data.nlobj = nothing
+    end
+    return
+end

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -76,6 +76,10 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
         @objective(m, Max, x + y)
         set_objective_coefficient(m, x, 4.0)
         @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x + y)
+
+        @objective(m, Min, x)
+        set_objective_coefficient(m, y, 2.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), x + 2.0 * y)
     end
 
     @testset "Quadratic objectives" begin

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -64,6 +64,20 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
             4x + 1, @inferred JuMP.objective_function(m, AffExprType))
     end
 
+    @testset "Linear objective changes" begin
+        m = ModelType()
+        @variable(m, x)
+
+        # No change possible for a single variable.
+        @objective(m, Max, x)
+        @test_throws MethodError set_objective_coefficient(m, x, 4.0)
+
+        @variable(m, y)
+        @objective(m, Max, x + y)
+        set_objective_coefficient(m, x, 4.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x + y)
+    end
+
     @testset "Quadratic objectives" begin
         m = ModelType()
         @variable(m, x)

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -64,24 +64,6 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
             4x + 1, @inferred JuMP.objective_function(m, AffExprType))
     end
 
-    @testset "Linear objective changes" begin
-        m = ModelType()
-        @variable(m, x)
-
-        @objective(m, Max, x)
-        set_objective_coefficient(m, x, 4.0)
-        @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x)
-
-        @variable(m, y)
-        @objective(m, Max, x + y)
-        set_objective_coefficient(m, x, 4.0)
-        @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x + y)
-
-        @objective(m, Min, x)
-        set_objective_coefficient(m, y, 2.0)
-        @test JuMP.isequal_canonical(JuMP.objective_function(m), x + 2.0 * y)
-    end
-
     @testset "Quadratic objectives" begin
         m = ModelType()
         @variable(m, x)
@@ -93,15 +75,6 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
         @test JuMP.isequal_canonical(
             x^2 + 2x, @inferred JuMP.objective_function(m, QuadExprType))
         @test_throws InexactError JuMP.objective_function(m, AffExprType)
-    end
-
-    @testset "Quadratic objective changes" begin
-        m = ModelType()
-        @variable(m, x)
-
-        @objective(m, Max, x^2 + x)
-        set_objective_coefficient(m, x, 4.0)
-        @test JuMP.isequal_canonical(JuMP.objective_function(m), x^2 + 4x)
     end
 
     @testset "Sense as symbol" begin
@@ -135,8 +108,38 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
     end
 end
 
+function objective_coeff_update_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::Type{<:JuMP.AbstractVariableRef})
+    @testset "Linear objective changes" begin
+        m = ModelType()
+        @variable(m, x)
+
+        @objective(m, Max, x)
+        set_objective_coefficient(m, x, 4.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x)
+
+        @variable(m, y)
+        @objective(m, Max, x + y)
+        set_objective_coefficient(m, x, 4.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x + y)
+
+        @objective(m, Min, x)
+        set_objective_coefficient(m, y, 2.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), x + 2.0 * y)
+    end
+
+    @testset "Quadratic objective changes" begin
+        m = ModelType()
+        @variable(m, x)
+
+        @objective(m, Max, x^2 + x)
+        set_objective_coefficient(m, x, 4.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), x^2 + 4x)
+    end
+end
+
 @testset "Objectives for JuMP.Model" begin
     objectives_test(Model, VariableRef)
+    objective_coeff_update_test(Model, VariableRef)
 end
 
 @testset "Objectives for JuMPExtension.MyModel" begin

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -65,23 +65,22 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
     end
 
     @testset "Linear objective changes" begin
-        m = ModelType()
+        # Only works with JuMP model, not extensions.
+        m = Model()
         @variable(m, x)
 
-        if JuMP.objective_function_type(m) == VariableRef
-            @objective(m, Max, x)
-            set_objective_coefficient(m, x, 4.0)
-            @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x)
+        @objective(m, Max, x)
+        set_objective_coefficient(m, x, 4.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x)
 
-            @variable(m, y)
-            @objective(m, Max, x + y)
-            set_objective_coefficient(m, x, 4.0)
-            @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x + y)
+        @variable(m, y)
+        @objective(m, Max, x + y)
+        set_objective_coefficient(m, x, 4.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x + y)
 
-            @objective(m, Min, x)
-            set_objective_coefficient(m, y, 2.0)
-            @test JuMP.isequal_canonical(JuMP.objective_function(m), x + 2.0 * y)
-        end
+        @objective(m, Min, x)
+        set_objective_coefficient(m, y, 2.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), x + 2.0 * y)
     end
 
     @testset "Quadratic objectives" begin
@@ -98,14 +97,13 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
     end
 
     @testset "Quadratic objective changes" begin
-        m = ModelType()
+        # Only works with JuMP model, not extensions.
+        m = Model()
         @variable(m, x)
 
-        if JuMP.objective_function_type(m) == VariableRef
-            @objective(m, Max, x^2 + x)
-            set_objective_coefficient(m, x, 4.0)
-            @test JuMP.isequal_canonical(JuMP.objective_function(m), x^2 + 4x)
-        end
+        @objective(m, Max, x^2 + x)
+        set_objective_coefficient(m, x, 4.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), x^2 + 4x)
     end
 
     @testset "Sense as symbol" begin

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -68,9 +68,9 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
         m = ModelType()
         @variable(m, x)
 
-        # No change possible for a single variable.
         @objective(m, Max, x)
-        @test_throws MethodError set_objective_coefficient(m, x, 4.0)
+        set_objective_coefficient(m, x, 4.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x)
 
         @variable(m, y)
         @objective(m, Max, x + y)
@@ -89,6 +89,15 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
         @test JuMP.isequal_canonical(
             x^2 + 2x, @inferred JuMP.objective_function(m, QuadExprType))
         @test_throws InexactError JuMP.objective_function(m, AffExprType)
+    end
+
+    @testset "Quadratic objective changes" begin
+        m = ModelType()
+        @variable(m, x)
+
+        @objective(m, Max, x^2 + x)
+        set_objective_coefficient(m, x, 4.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), x^2 + 4x)
     end
 
     @testset "Sense as symbol" begin

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -64,25 +64,6 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
             4x + 1, @inferred JuMP.objective_function(m, AffExprType))
     end
 
-    @testset "Linear objective changes" begin
-        # Only works with JuMP model, not extensions.
-        m = Model()
-        @variable(m, x)
-
-        @objective(m, Max, x)
-        set_objective_coefficient(m, x, 4.0)
-        @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x)
-
-        @variable(m, y)
-        @objective(m, Max, x + y)
-        set_objective_coefficient(m, x, 4.0)
-        @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x + y)
-
-        @objective(m, Min, x)
-        set_objective_coefficient(m, y, 2.0)
-        @test JuMP.isequal_canonical(JuMP.objective_function(m), x + 2.0 * y)
-    end
-
     @testset "Quadratic objectives" begin
         m = ModelType()
         @variable(m, x)
@@ -94,16 +75,6 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
         @test JuMP.isequal_canonical(
             x^2 + 2x, @inferred JuMP.objective_function(m, QuadExprType))
         @test_throws InexactError JuMP.objective_function(m, AffExprType)
-    end
-
-    @testset "Quadratic objective changes" begin
-        # Only works with JuMP model, not extensions.
-        m = Model()
-        @variable(m, x)
-
-        @objective(m, Max, x^2 + x)
-        set_objective_coefficient(m, x, 4.0)
-        @test JuMP.isequal_canonical(JuMP.objective_function(m), x^2 + 4x)
     end
 
     @testset "Sense as symbol" begin
@@ -137,8 +108,38 @@ function objectives_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType:
     end
 end
 
+function objective_coeff_update_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::Type{<:JuMP.AbstractVariableRef})
+    @testset "Linear objective changes" begin
+        m = ModelType()
+        @variable(m, x)
+
+        @objective(m, Max, x)
+        set_objective_coefficient(m, x, 4.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x)
+
+        @variable(m, y)
+        @objective(m, Max, x + y)
+        set_objective_coefficient(m, x, 4.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), 4x + y)
+
+        @objective(m, Min, x)
+        set_objective_coefficient(m, y, 2.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), x + 2.0 * y)
+    end
+
+    @testset "Quadratic objective changes" begin
+        m = ModelType()
+        @variable(m, x)
+
+        @objective(m, Max, x^2 + x)
+        set_objective_coefficient(m, x, 4.0)
+        @test JuMP.isequal_canonical(JuMP.objective_function(m), x^2 + 4x)
+    end
+end
+
 @testset "Objectives for JuMP.Model" begin
     objectives_test(Model, VariableRef)
+    objective_coeff_update_test(Model, VariableRef)
 end
 
 @testset "Objectives for JuMPExtension.MyModel" begin


### PR DESCRIPTION
Currently, only works for affine objectives: I could not find the relevant functions to call for quadratic objectives, and looking at https://github.com/JuliaOpt/CPLEX.jl/blob/d837d8fc090f223f7467e65fd175a14958e41b9e/src/MOI_wrapper.jl or https://github.com/JuliaOpt/LinQuadOptInterface.jl/blob/a81b31235bac72e180ca7586746b2e5b5e910bee/src/objective.jl doesn't show like anything like this is implemented… 