### PR TITLE
Improved error message for x.f(y) in NL expressions

### DIFF
--- a/src/parse_nlp.jl
+++ b/src/parse_nlp.jl
@@ -37,6 +37,13 @@ function _parse_NL_expr(m, x, tapevar, parent, values)
     end
 
     if isexpr(x, :call)
+        if isexpr(x.args[1], :.)
+            # Functions like foo.bar cannot possibly be registered, because you
+            # can register only with a symbol name.
+            errorstring = "Unexpected function $(x.args[1]). See the " *
+            "documentation on how to register a function."
+            return :(error($errorstring))
+        end
         if _is_sum(x.args[1]) || _is_prod(x.args[1])
             opname = x.args[1]
             errorstring = "$opname() can appear in nonlinear expressions " *

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -154,6 +154,13 @@
         @test_macro_throws ErrorException @NLexpression(model, x...)
     end
 
+    @testset "Error on x.f(y) in NL expression" begin
+        model = Model()
+        @variable(model, x[1:2])
+        @test_macro_throws(ErrorException,
+            @NLexpression(model, sum(foo.bar(i) * x[i] for i = 1:2)))
+    end
+
     @testset "Error on sum(x)" begin
         m = Model()
         x = [1,2,3]


### PR DESCRIPTION
Fixes #2016