### PR TITLE
added documentation for categories

### DIFF
--- a/src/sets.jl
+++ b/src/sets.jl
@@ -67,3 +67,18 @@ function LinearAlgebra.norm(::AbstractVector{<:AbstractJuMPScalar})
           "`@constraint(model, norm(x) <= t)` should now be written as ",
           "`@constraint(model, [t; x] in SecondOrderCone())`")
 end
+
+"""
+    Bin
+
+Binary variable category, used in the `@variable` macro.
+"""
+Bin
+
+"""
+    PSD
+
+Postitive semi-definite variable category, used in the `@variable` macro,
+only valid for square matrix variables.
+"""
+PSD


### PR DESCRIPTION
JuMP `@variable` can be odd for newcomers because there seems to be bindings that don't exist:

```julia
@variable(m, x[1:10], Bin)

JuMP.Bin # not found
?JuMP.Bin # not found either
```

This allows having a short docstring for these categories
