### PR TITLE
Remove dictionaries tracking SingleVariable constraints

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -44,11 +44,6 @@ include("utils.jl")
 
 const _MOIVAR = MOI.VariableIndex
 const _MOICON{F,S} = MOI.ConstraintIndex{F,S}
-const _MOILB = _MOICON{MOI.SingleVariable,MOI.GreaterThan{Float64}}
-const _MOIUB = _MOICON{MOI.SingleVariable,MOI.LessThan{Float64}}
-const _MOIFIX = _MOICON{MOI.SingleVariable,MOI.EqualTo{Float64}}
-const _MOIINT = _MOICON{MOI.SingleVariable,MOI.Integer}
-const _MOIBIN = _MOICON{MOI.SingleVariable,MOI.ZeroOne}
 
 """
     OptimizerFactory
@@ -127,13 +122,6 @@ abstract type AbstractModel end
 A mathematical model of an optimization problem.
 """
 mutable struct Model <: AbstractModel
-    # Special variablewise properties that we keep track of:
-    # lower bound, upper bound, fixed, integrality, binary
-    variable_to_lower_bound::Dict{_MOIVAR, _MOILB}
-    variable_to_upper_bound::Dict{_MOIVAR, _MOIUB}
-    variable_to_fix::Dict{_MOIVAR, _MOIFIX}
-    variable_to_integrality::Dict{_MOIVAR, _MOIINT}
-    variable_to_zero_one::Dict{_MOIVAR, _MOIBIN}
     # In MANUAL and AUTOMATIC modes, CachingOptimizer.
     # In DIRECT mode, will hold an AbstractOptimizer.
     moi_backend::MOI.AbstractOptimizer
@@ -229,12 +217,7 @@ in mind the following implications of creating models using this *direct* mode:
 """
 function direct_model(backend::MOI.ModelLike)
     @assert MOI.is_empty(backend)
-    return Model(Dict{_MOIVAR, _MOILB}(),
-                 Dict{_MOIVAR, _MOIUB}(),
-                 Dict{_MOIVAR, _MOIFIX}(),
-                 Dict{_MOIVAR, _MOIINT}(),
-                 Dict{_MOIVAR, _MOIBIN}(),
-                 backend,
+    return Model(backend,
                  Dict{_MOICON, AbstractShape}(),
                  Set{Any}(),
                  nothing,
@@ -439,7 +422,7 @@ end
 """
     set_silent(model::Model)
 
-Takes precedence over any other attribute controlling verbosity 
+Takes precedence over any other attribute controlling verbosity
 and requires the solver to produce no output.
 """
 function set_silent(model::Model)

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -13,24 +13,6 @@ extension storing data in the `ext` field.
 function copy_extension_data end
 
 """
-    _copy_single_variable_constraints(
-        dest::Dict{MOI.VariableIndex, _MOICON{MOI.SingleVariable, S}},
-        src::Dict{MOI.VariableIndex, _MOICON{MOI.SingleVariable, S}},
-        index_map) where S
-
-Copy the single variable constraint indices of `src` into `dest` mapping
-variable and constraint indices using `index_map`.
-"""
-function _copy_single_variable_constraints(
-    dest::Dict{MOI.VariableIndex, _MOICON{MOI.SingleVariable, S}},
-    src::Dict{MOI.VariableIndex, _MOICON{MOI.SingleVariable, S}},
-    index_map) where S
-    for (variable_index, constraint_index) in src
-        dest[index_map[variable_index]] = index_map[constraint_index]
-    end
-end
-
-"""
     ReferenceMap
 
 Mapping between variable and constraint reference of a model and its copy. The
@@ -99,20 +81,6 @@ function copy_model(model::Model)
     # `backend(model` and the indices of `backend(new_model)`.
     index_map = MOI.copy_to(backend(new_model), backend(model),
                             copy_names = true)
-
-    _copy_single_variable_constraints(
-        new_model.variable_to_lower_bound, model.variable_to_lower_bound,
-        index_map)
-    _copy_single_variable_constraints(
-        new_model.variable_to_upper_bound, model.variable_to_upper_bound,
-        index_map)
-    _copy_single_variable_constraints(
-        new_model.variable_to_fix, model.variable_to_fix, index_map)
-    _copy_single_variable_constraints(
-        new_model.variable_to_integrality, model.variable_to_integrality,
-        index_map)
-    _copy_single_variable_constraints(
-        new_model.variable_to_zero_one, model.variable_to_zero_one, index_map)
 
     new_model.optimize_hook = model.optimize_hook
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -328,18 +328,20 @@ Return `true` if `v` has a lower bound. If `true`, the lower bound can be
 queried with [`lower_bound`](@ref). See also [`LowerBoundRef`](@ref).
 """
 function has_lower_bound(v::VariableRef)
-    return haskey(owner_model(v).variable_to_lower_bound, index(v))
+    return _moi_has_lower_bound(backend(owner_model(v)), v)
 end
 
-function lower_bound_index(v::VariableRef)
-    if !has_lower_bound(v)
-        error("Variable $(v) does not have a lower bound.")
-    end
-    return owner_model(v).variable_to_lower_bound[index(v)]
+# _moi_* methods allow us to work around the type instability of the backend of
+# a model.
+function _moi_has_lower_bound(backend, v::VariableRef)
+    return MOI.is_valid(backend, _lower_bound_index(v))
 end
-function set_lower_bound_index(v::VariableRef, cindex::_MOILB)
-    owner_model(v).variable_to_lower_bound[index(v)] = cindex
+
+function _lower_bound_index(v::VariableRef)
+    return _MOICON{MOI.SingleVariable, MOI.GreaterThan{Float64}}(index(v).value)
 end
+
+
 
 """
     set_lower_bound(v::VariableRef, lower::Number)
@@ -348,16 +350,17 @@ Set the lower bound of a variable. If one does not exist, create a new lower
 bound constraint. See also [`delete_lower_bound`](@ref).
 """
 function set_lower_bound(v::VariableRef, lower::Number)
-    newset = MOI.GreaterThan(convert(Float64, lower))
-    # do we have a lower bound already?
-    if has_lower_bound(v)
-        cindex = lower_bound_index(v)
-        MOI.set(backend(owner_model(v)), MOI.ConstraintSet(), cindex, newset)
+    return _moi_set_lower_bound(backend(owner_model(v)), v, lower)
+end
+
+function _moi_set_lower_bound(backend, v::VariableRef, lower::Number)
+    new_set = MOI.GreaterThan(convert(Float64, lower))
+    if _moi_has_lower_bound(backend, v)
+        cindex = _lower_bound_index(v)
+        MOI.set(backend, MOI.ConstraintSet(), cindex, new_set)
     else
-        @assert !is_fixed(v)
-        cindex = MOI.add_constraint(
-            backend(owner_model(v)), MOI.SingleVariable(index(v)), newset)
-        set_lower_bound_index(v, cindex)
+        @assert !_moi_is_fixed(backend, v)
+        MOI.add_constraint(backend, MOI.SingleVariable(index(v)), new_set)
     end
     return
 end
@@ -369,8 +372,9 @@ Return a constraint reference to the lower bound constraint of `v`. Errors if
 one does not exist.
 """
 function LowerBoundRef(v::VariableRef)
-    return ConstraintRef{Model, _MOILB, ScalarShape}(owner_model(v),
-                                                     lower_bound_index(v),
+    moi_lb = _MOICON{MOI.SingleVariable, MOI.GreaterThan{Float64}}
+    return ConstraintRef{Model, moi_lb, ScalarShape}(owner_model(v),
+                                                     _lower_bound_index(v),
                                                      ScalarShape())
 end
 
@@ -381,8 +385,6 @@ Delete the lower bound constraint of a variable.
 """
 function delete_lower_bound(variable_ref::VariableRef)
     JuMP.delete(owner_model(variable_ref), LowerBoundRef(variable_ref))
-    delete!(owner_model(variable_ref).variable_to_lower_bound,
-            index(variable_ref))
     return
 end
 
@@ -393,6 +395,9 @@ Return the lower bound of a variable. Error if one does not exist. See also
 [`has_lower_bound`](@ref).
 """
 function lower_bound(v::VariableRef)
+    if !has_lower_bound(v)
+        error("Variable $(v) does not have a lower bound.")
+    end
     cset = MOI.get(owner_model(v), MOI.ConstraintSet(),
                    LowerBoundRef(v))::MOI.GreaterThan{Float64}
     return cset.lower
@@ -407,17 +412,15 @@ Return `true` if `v` has a upper bound. If `true`, the upper bound can be
 queried with [`upper_bound`](@ref). See also [`UpperBoundRef`](@ref).
 """
 function has_upper_bound(v::VariableRef)
-    return haskey(owner_model(v).variable_to_upper_bound, index(v))
+    return _moi_has_upper_bound(backend(owner_model(v)), v)
 end
 
-function upper_bound_index(v::VariableRef)
-    if !has_upper_bound(v)
-        error("Variable $(v) does not have an upper bound.")
-    end
-    return owner_model(v).variable_to_upper_bound[index(v)]
+function _moi_has_upper_bound(backend, v::VariableRef)
+    return MOI.is_valid(backend, _upper_bound_index(v))
 end
-function set_upper_bound_index(v::VariableRef, cindex::_MOIUB)
-    owner_model(v).variable_to_upper_bound[index(v)] = cindex
+
+function _upper_bound_index(v::VariableRef)
+    return _MOICON{MOI.SingleVariable, MOI.LessThan{Float64}}(index(v).value)
 end
 
 """
@@ -427,16 +430,17 @@ Set the upper bound of a variable. If one does not exist, create an upper bound
 constraint. See also [`delete_upper_bound`](@ref).
 """
 function set_upper_bound(v::VariableRef, upper::Number)
-    newset = MOI.LessThan(convert(Float64,upper))
-    # do we have an upper bound already?
-    if has_upper_bound(v)
-        cindex = upper_bound_index(v)
-        MOI.set(backend(owner_model(v)), MOI.ConstraintSet(), cindex, newset)
+    return _moi_set_upper_bound(backend(owner_model(v)), v, upper)
+end
+
+function _moi_set_upper_bound(backend, v::VariableRef, upper::Number)
+    new_set = MOI.LessThan(convert(Float64,upper))
+    if _moi_has_upper_bound(backend, v)
+        cindex = _upper_bound_index(v)
+        MOI.set(backend, MOI.ConstraintSet(), cindex, new_set)
     else
-        @assert !is_fixed(v)
-        cindex = MOI.add_constraint(backend(owner_model(v)),
-                                    MOI.SingleVariable(index(v)), newset)
-        set_upper_bound_index(v, cindex)
+        @assert !_moi_is_fixed(backend, v)
+        MOI.add_constraint(backend, MOI.SingleVariable(index(v)), new_set)
     end
     return
 end
@@ -448,8 +452,9 @@ Return a constraint reference to the upper bound constraint of `v`. Errors if
 one does not exist.
 """
 function UpperBoundRef(v::VariableRef)
-    return ConstraintRef{Model, _MOIUB, ScalarShape}(owner_model(v),
-                                                     upper_bound_index(v),
+    moi_ub = _MOICON{MOI.SingleVariable, MOI.LessThan{Float64}}
+    return ConstraintRef{Model, moi_ub, ScalarShape}(owner_model(v),
+                                                     _upper_bound_index(v),
                                                      ScalarShape())
 end
 
@@ -460,8 +465,6 @@ Delete the upper bound constraint of a variable.
 """
 function delete_upper_bound(variable_ref::VariableRef)
     JuMP.delete(owner_model(variable_ref), UpperBoundRef(variable_ref))
-    delete!(owner_model(variable_ref).variable_to_upper_bound,
-            index(variable_ref))
     return
 end
 
@@ -472,6 +475,9 @@ Return the upper bound of a variable. Error if one does not exist. See also
 [`has_upper_bound`](@ref).
 """
 function upper_bound(v::VariableRef)
+    if !has_upper_bound(v)
+        error("Variable $(v) does not have an upper bound.")
+    end
     cset = MOI.get(owner_model(v), MOI.ConstraintSet(),
                    UpperBoundRef(v))::MOI.LessThan{Float64}
     return cset.upper
@@ -485,14 +491,16 @@ end
 Return `true` if `v` is a fixed variable. If `true`, the fixed value can be
 queried with [`fix_value`](@ref). See also [`FixRef`](@ref).
 """
-is_fixed(v::VariableRef) = haskey(owner_model(v).variable_to_fix, index(v))
-
-function fix_index(v::VariableRef)
-    @assert is_fixed(v) # TODO error message
-    return owner_model(v).variable_to_fix[index(v)]
+function is_fixed(v::VariableRef)
+    return _moi_is_fixed(backend(owner_model(v)), v)
 end
-function set_fix_index(v::VariableRef, cindex::_MOIFIX)
-    owner_model(v).variable_to_fix[index(v)] = cindex
+
+function _moi_is_fixed(backend, v::VariableRef)
+    return MOI.is_valid(backend, _fix_index(v))
+end
+
+function _fix_index(v::VariableRef)
+    return _MOICON{MOI.SingleVariable, MOI.EqualTo{Float64}}(index(v).value)
 end
 
 """
@@ -507,29 +515,32 @@ and the fixing constraint will be added. Note a variable will have no bounds
 after a call to [`unfix`](@ref).
 """
 function fix(variable::VariableRef, value::Number; force::Bool = false)
+    return _moi_fix(backend(owner_model(variable)), variable, value, force)
+end
+
+function _moi_fix(backend, variable::VariableRef, value::Number, force::Bool)
     new_set = MOI.EqualTo(convert(Float64, value))
-    model = backend(owner_model(variable))
-    if is_fixed(variable)  # Update existing fixing constraint.
-        c_index = fix_index(variable)
-        MOI.set(model, MOI.ConstraintSet(), c_index, new_set)
+    if _moi_is_fixed(backend, variable)  # Update existing fixing constraint.
+        c_index = _fix_index(variable)
+        MOI.set(backend, MOI.ConstraintSet(), c_index, new_set)
     else  # Add a new fixing constraint.
-        if has_upper_bound(variable) || has_lower_bound(variable)
+        if _moi_has_upper_bound(backend, variable) ||
+            _moi_has_lower_bound(backend, variable)
             if !force
                 error("Unable to fix $(variable) to $(value) because it has " *
                       "existing variable bounds. Consider calling " *
                       "`JuMP.fix(variable, value; force=true)` which will " *
                       "delete existing bounds before fixing the variable.")
             end
-            if has_upper_bound(variable)
+            if _moi_has_upper_bound(backend, variable)
                 delete_upper_bound(variable)
             end
-            if has_lower_bound(variable)
+            if _moi_has_lower_bound(backend, variable)
                 delete_lower_bound(variable)
             end
         end
-        c_index = MOI.add_constraint(
-            model, MOI.SingleVariable(index(variable)), new_set)
-        set_fix_index(variable, c_index)
+        MOI.add_constraint(backend, MOI.SingleVariable(index(variable)),
+                           new_set)
     end
     return
 end
@@ -541,7 +552,6 @@ Delete the fixing constraint of a variable.
 """
 function unfix(variable_ref::VariableRef)
     JuMP.delete(owner_model(variable_ref), FixRef(variable_ref))
-    delete!(owner_model(variable_ref).variable_to_fix, index(variable_ref))
     return
 end
 
@@ -564,8 +574,9 @@ Return a constraint reference to the constraint fixing the value of `v`. Errors
 if one does not exist.
 """
 function FixRef(v::VariableRef)
-    return ConstraintRef{Model, _MOIFIX, ScalarShape}(owner_model(v),
-                                                      fix_index(v),
+    moi_fix = _MOICON{MOI.SingleVariable, MOI.EqualTo{Float64}}
+    return ConstraintRef{Model, moi_fix, ScalarShape}(owner_model(v),
+                                                      _fix_index(v),
                                                       ScalarShape())
 end
 
@@ -576,15 +587,15 @@ Return `true` if `v` is constrained to be integer. See also
 [`IntegerRef`](@ref).
 """
 function is_integer(v::VariableRef)
-    return haskey(owner_model(v).variable_to_integrality, index(v))
+    return _moi_is_integer(backend(owner_model(v)), v)
 end
 
-function integer_index(v::VariableRef)
-    @assert is_integer(v) # TODO error message
-    return owner_model(v).variable_to_integrality[index(v)]
+function _moi_is_integer(backend, v::VariableRef)
+    return MOI.is_valid(backend, _integer_index(v))
 end
-function set_integer_index(v::VariableRef, cindex::_MOIINT)
-    owner_model(v).variable_to_integrality[index(v)] = cindex
+
+function _integer_index(v::VariableRef)
+    return _MOICON{MOI.SingleVariable, MOI.Integer}(index(v).value)
 end
 
 """
@@ -594,16 +605,18 @@ Add an integrality constraint on the variable `variable_ref`. See also
 [`unset_integer`](@ref).
 """
 function set_integer(variable_ref::VariableRef)
-    if is_integer(variable_ref)
+    return _moi_set_integer(backend(owner_model(variable_ref)), variable_ref)
+end
+
+function _moi_set_integer(backend, variable_ref::VariableRef)
+    if _moi_is_integer(backend, variable_ref)
         return
-    elseif is_binary(variable_ref)
+    elseif _moi_is_binary(backend, variable_ref)
         error("Cannot set the variable_ref $(variable_ref) to integer as it " *
               "is already binary.")
     end
-    constraint_ref = MOI.add_constraint(backend(owner_model(variable_ref)),
-                                        MOI.SingleVariable(index(variable_ref)),
-                                        MOI.Integer())
-    set_integer_index(variable_ref, constraint_ref)
+    MOI.add_constraint(backend, MOI.SingleVariable(index(variable_ref)),
+                       MOI.Integer())
     return
 end
 
@@ -614,8 +627,6 @@ Remove the integrality constraint on the variable `variable_ref`.
 """
 function unset_integer(variable_ref::VariableRef)
     JuMP.delete(owner_model(variable_ref), IntegerRef(variable_ref))
-    delete!(owner_model(variable_ref).variable_to_integrality,
-            index(variable_ref))
     return
 end
 
@@ -626,8 +637,9 @@ Return a constraint reference to the constraint constrainting `v` to be integer.
 Errors if one does not exist.
 """
 function IntegerRef(v::VariableRef)
-    return ConstraintRef{Model, _MOIINT, ScalarShape}(
-        owner_model(v), integer_index(v), ScalarShape())
+    moi_int = _MOICON{MOI.SingleVariable, MOI.Integer}
+    return ConstraintRef{Model, moi_int, ScalarShape}(
+        owner_model(v), _integer_index(v), ScalarShape())
 end
 
 """
@@ -636,15 +648,15 @@ end
 Return `true` if `v` is constrained to be binary. See also [`BinaryRef`](@ref).
 """
 function is_binary(v::VariableRef)
-    return haskey(owner_model(v).variable_to_zero_one, index(v))
+    return _moi_is_binary(backend(owner_model(v)), v)
 end
 
-function binary_index(v::VariableRef)
-    @assert is_binary(v) # TODO error message
-    return owner_model(v).variable_to_zero_one[index(v)]
+function _moi_is_binary(backend, v::VariableRef)
+    return MOI.is_valid(backend, _binary_index(v))
 end
-function set_binary_index(v::VariableRef, cindex::_MOIBIN)
-    owner_model(v).variable_to_zero_one[index(v)] = cindex
+
+function _binary_index(v::VariableRef)
+    return _MOICON{MOI.SingleVariable, MOI.ZeroOne}(index(v).value)
 end
 
 """
@@ -654,16 +666,18 @@ Add a constraint on the variable `v` that it must take values in the set
 ``\\{0,1\\}``. See also [`unset_binary`](@ref).
 """
 function set_binary(variable_ref::VariableRef)
-    if is_binary(variable_ref)
+    return _moi_set_binary(backend(owner_model(variable_ref)), variable_ref)
+end
+
+function _moi_set_binary(backend, variable_ref)
+    if _moi_is_binary(backend, variable_ref)
         return
-    elseif is_integer(variable_ref)
+    elseif _moi_is_integer(backend, variable_ref)
         error("Cannot set the variable_ref $(variable_ref) to binary as it " *
               "is already integer.")
     end
-    constraint_ref = MOI.add_constraint(backend(owner_model(variable_ref)),
-                                        MOI.SingleVariable(index(variable_ref)),
-                                        MOI.ZeroOne())
-    set_binary_index(variable_ref, constraint_ref)
+    MOI.add_constraint(backend, MOI.SingleVariable(index(variable_ref)),
+                       MOI.ZeroOne())
     return
 end
 
@@ -674,7 +688,6 @@ Remove the binary constraint on the variable `variable_ref`.
 """
 function unset_binary(variable_ref::VariableRef)
     JuMP.delete(owner_model(variable_ref), BinaryRef(variable_ref))
-    delete!(owner_model(variable_ref).variable_to_zero_one, index(variable_ref))
     return
 end
 
@@ -685,8 +698,9 @@ Return a constraint reference to the constraint constrainting `v` to be binary.
 Errors if one does not exist.
 """
 function BinaryRef(v::VariableRef)
-    return ConstraintRef{Model, _MOIBIN, ScalarShape}(
-        owner_model(v), binary_index(v), ScalarShape())
+    moi_bin = _MOICON{MOI.SingleVariable, MOI.ZeroOne}
+    return ConstraintRef{Model, moi_bin, ScalarShape}(
+        owner_model(v), _binary_index(v), ScalarShape())
 end
 
 """
@@ -743,31 +757,42 @@ Add a variable `v` to `Model m` and sets its name.
 """
 function add_variable end
 
-function add_variable(m::Model, v::ScalarVariable, name::String="")
+function add_variable(model::Model, v::ScalarVariable, name::String="")
+    return _moi_add_variable(backend(model), model, v, name)
+end
+
+function _moi_add_variable(backend, model, v::ScalarVariable, name::String)
+    index = MOI.add_variable(backend)
+    var_ref = VariableRef(model, index)
     info = v.info
-    vref = VariableRef(m)
+    # We don't call the _moi* versions (e.g., _moi_set_lower_bound) because they
+    # have extra checks that are not necessary for newly created variables.
     if info.has_lb
-        set_lower_bound(vref, info.lower_bound)
+        MOI.add_constraint(backend, MOI.SingleVariable(index),
+                           MOI.GreaterThan{Float64}(info.lower_bound))
     end
     if info.has_ub
-        set_upper_bound(vref, info.upper_bound)
+        MOI.add_constraint(backend, MOI.SingleVariable(index),
+                           MOI.LessThan{Float64}(info.upper_bound))
     end
     if info.has_fix
-        fix(vref, info.fixed_value)
+        MOI.add_constraint(backend, MOI.SingleVariable(index),
+                           MOI.EqualTo{Float64}(info.fixed_value))
     end
     if info.binary
-        set_binary(vref)
+        MOI.add_constraint(backend, MOI.SingleVariable(index),
+                           MOI.ZeroOne())
     end
     if info.integer
-        set_integer(vref)
+        MOI.add_constraint(backend, MOI.SingleVariable(index), MOI.Integer())
     end
     if info.has_start
-        set_start_value(vref, info.start)
+        set_start_value(var_ref, info.start)
     end
     if !isempty(name)
-        set_name(vref, name)
+        set_name(var_ref, name)
     end
-    return vref
+    return var_ref
 end
 
 """


### PR DESCRIPTION
This follows from https://github.com/JuliaOpt/MathOptInterface.jl/issues/570.

Unfortunately the performance issue in https://github.com/JuliaOpt/JuMP.jl/issues/1607 is not resolved:
```julia
using JuMP
using BenchmarkTools

function plain(N)
    model = Model()
    x = @variable(model, [1:N])
    return x
end
@btime plain(1_000_000)

function with_int_and_bounds(N)
    model = Model()
    x = @variable(model, [1:N], Int, lower_bound=-1, upper_bound=1)
    return x
end
@btime with_int_and_bounds(1_000_000)
```
yields
```
  67.775 ms (2000220 allocations: 73.43 MiB)
  674.142 ms (18000220 allocations: 305.57 MiB)
```
So it's still about 10x slower to create variables with bounds than without them. I haven't started looking into the reasons for this.