### PR TITLE
Fill NEWS entry for v0.20.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,19 +5,21 @@ Version 0.20.0 (Aug 24, 2019)
 -----------------------------
 
 - Documentation updates.
-- Lots of bug fixes.
-- Better error messages (#2017).
-- Performance improvements (#2032).
+- Numerous bug fixes.
+- Better error messages (#1977, #1978, #1997, #2017).
+- Performance improvements (#1947, #2032).
 - Added LP sensitivity summary functions `lp_objective_perturbation_range`
   and `lp_rhs_perturbation_range` (#1917).
 - Added functions `dual_objective_value`, `raw_status` and `set_parameter`.
 - Added function `set_objective_coefficient` to modify the coefficient of
-  a linear terms coefficient of the objective (#2008).
-- Added functions `set_normalized_rhs`, `normalized_rhs`,
-  `set_normalized_coefficient`, `normalized_coefficient`, and
-  `add_to_function_constant` to modify the constant part
-  of constraints (#1935, #1960).
-- Lots of other improvements in MOI 0.9, see the `NEWS.md` file of MOI for more
+  a linear term of the objective (#2008).
+- Added functions `set_normalized_rhs`, `normalized_rhs`, and
+  `add_to_function_constant` to modify and get the constant part
+  of a constraint (#1935, #1960).
+- Added functions `set_normalized_coefficient` and `normalized_coefficient`
+  to modify and get the coefficient of a linear term of a constraint
+  (#1935, #1960).
+- Numerous other improvements in MOI 0.9, see the `NEWS.md` file of MOI for more
   details.
 
 Version 0.19.2 (June 8, 2019)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,25 @@
 JuMP release notes
 ==================
 
+Version 0.20.0 (Aug 24, 2019)
+-----------------------------
+
+- Documentation updates.
+- Lots of bug fixes.
+- Better error messages (#2017).
+- Performance improvements (#2032).
+- Added LP sensitivity summary functions `lp_objective_perturbation_range`
+  and `lp_rhs_perturbation_range` (#1917).
+- Added functions `dual_objective_value`, `raw_status` and `set_parameter`.
+- Added function `set_objective_coefficient` to modify the coefficient of
+  a linear terms coefficient of the objective (#2008).
+- Added functions `set_normalized_rhs`, `normalized_rhs`,
+  `set_normalized_coefficient`, `normalized_coefficient`, and
+  `add_to_function_constant` to modify the constant part
+  of constraints (#1935, #1960).
+- Lots of other improvements in MOI 0.9, see the `NEWS.md` file of MOI for more
+  details.
+
 Version 0.19.2 (June 8, 2019)
 -----------------------------
 


### PR DESCRIPTION
I'll make a separate commit without `[ci skip]` for bumping the version to avoid the problem of missing documentation mentioned in `howto_release.txt`.

Closes https://github.com/JuliaOpt/JuMP.jl/issues/2036