### PR TITLE
[[un]set_]time_limit_sec

### DIFF
--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -110,6 +110,7 @@ unset_silent
 
 set_parameter
 
-set_time_limit
-time_limit
+set_time_limit_sec
+unset_time_limit_sec
+time_limit_sec
 ```

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -109,4 +109,7 @@ set_silent
 unset_silent
 
 set_parameter
+
+set_time_limit
+time_limit
 ```

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -460,7 +460,8 @@ end
 """
     set_time_limit_sec(model::Model, limit)
 
-Sets the time limit (in seconds) of the solver. Can be unset using `unset_time_limit_sec`.
+Sets the time limit (in seconds) of the solver. 
+Can be unset using `unset_time_limit_sec` or with `limit` set to `nothing`.
 """
 function set_time_limit_sec(model::Model, limit)
     return MOI.set(model, MOI.TimeLimitSec(), limit)
@@ -478,7 +479,7 @@ end
 """
     time_limit_sec(model::Model)
 
-Gets the time limit (in seconds) of the model (`nothing` if undefined). Can be set using `set_time_limit_sec`.
+Gets the time limit (in seconds) of the model (`nothing` if unset). Can be set using `set_time_limit_sec`.
 """
 function time_limit_sec(model::Model)
     return MOI.get(model, MOI.TimeLimitSec())

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -457,6 +457,24 @@ function unset_silent(model::Model)
     return MOI.set(model, MOI.Silent(), false)
 end
 
+"""
+    set_time_limit(model::Model, limit)
+
+Sets the time limit (in seconds) of the solver.
+"""
+function set_time_limit(model::Model, limit)
+    return MOI.set(model, MOI.TimeLimitSec(), limit)
+end
+
+"""
+    time_limit(model::Model)
+
+Gets the time limit (in seconds) of the model (`nothing` if undefined).
+"""
+function time_limit(model::Model)
+    return MOI.get(model, MOI.TimeLimitSec())
+end
+
 # Abstract base type for all scalar types
 abstract type AbstractJuMPScalar end
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -458,29 +458,29 @@ function unset_silent(model::Model)
 end
 
 """
-    set_time_limit(model::Model, limit)
+    set_time_limit_sec(model::Model, limit)
 
-Sets the time limit (in seconds) of the solver. Can be unset using `unset_time_limit`.
+Sets the time limit (in seconds) of the solver. Can be unset using `unset_time_limit_sec`.
 """
-function set_time_limit(model::Model, limit)
+function set_time_limit_sec(model::Model, limit)
     return MOI.set(model, MOI.TimeLimitSec(), limit)
 end
 
 """
-    unset_time_limit(model::Model)
+    unset_time_limit_sec(model::Model)
 
-Unsets the time limit of the solver. Can be set using `set_time_limit`.
+Unsets the time limit of the solver. Can be set using `set_time_limit_sec`.
 """
-function unset_time_limit(model::Model)
+function unset_time_limit_sec(model::Model)
     return MOI.set(model, MOI.TimeLimitSec(), nothing)
 end
 
 """
-    time_limit(model::Model)
+    time_limit_sec(model::Model)
 
-Gets the time limit (in seconds) of the model (`nothing` if undefined).
+Gets the time limit (in seconds) of the model (`nothing` if undefined). Can be set using `set_time_limit_sec`.
 """
-function time_limit(model::Model)
+function time_limit_sec(model::Model)
     return MOI.get(model, MOI.TimeLimitSec())
 end
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -460,10 +460,19 @@ end
 """
     set_time_limit(model::Model, limit)
 
-Sets the time limit (in seconds) of the solver.
+Sets the time limit (in seconds) of the solver. Can be unset using `unset_time_limit`.
 """
 function set_time_limit(model::Model, limit)
     return MOI.set(model, MOI.TimeLimitSec(), limit)
+end
+
+"""
+    unset_time_limit(model::Model)
+
+Unsets the time limit of the solver. Can be set using `set_time_limit`.
+"""
+function unset_time_limit(model::Model)
+    return MOI.set(model, MOI.TimeLimitSec(), nothing)
 end
 
 """

--- a/test/model.jl
+++ b/test/model.jl
@@ -382,6 +382,11 @@ function test_model()
         model = Model(with_optimizer(MOIU.MockOptimizer, mock))
         JuMP.set_time_limit(model, 12.0)
         @test JuMP.time_limit(model) == 12.0
+        JuMP.set_time_limit(model, nothing)
+        @test JuMP.time_limit(model) === nothing
+        JuMP.set_time_limit(model, 12.0)
+        JuMP.unset_time_limit(model)
+        @test JuMP.time_limit(model) === nothing
     end
 end
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -380,13 +380,13 @@ function test_model()
     @testset "set and retrieve time limit" begin
         mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
         model = Model(with_optimizer(MOIU.MockOptimizer, mock))
-        JuMP.set_time_limit(model, 12.0)
-        @test JuMP.time_limit(model) == 12.0
-        JuMP.set_time_limit(model, nothing)
-        @test JuMP.time_limit(model) === nothing
-        JuMP.set_time_limit(model, 12.0)
-        JuMP.unset_time_limit(model)
-        @test JuMP.time_limit(model) === nothing
+        JuMP.set_time_limit_sec(model, 12.0)
+        @test JuMP.time_limit_sec(model) == 12.0
+        JuMP.set_time_limit_sec(model, nothing)
+        @test JuMP.time_limit_sec(model) === nothing
+        JuMP.set_time_limit_sec(model, 12.0)
+        JuMP.unset_time_limit_sec(model)
+        @test JuMP.time_limit_sec(model) === nothing
     end
 end
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -376,6 +376,13 @@ function test_model()
         @test MOI.get(backend(model), MOI.RawParameter("aaa")) == "bbb"
         @test MOI.get(model, MOI.RawParameter("aaa")) == "bbb"
     end
+
+    @testset "set and retrieve time limit" begin
+        mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
+        model = Model(with_optimizer(MOIU.MockOptimizer, mock))
+        JuMP.set_time_limit(model, 12.0)
+        @test JuMP.time_limit(model) == 12.0
+    end
 end
 
 @testset "Model" begin


### PR DESCRIPTION
Using `set_time_limit` to set the time limit of the solver
and `time_limit` to retrieve it.
Implements #2031 