### PR TITLE
Now deepcopy(::AbstractModel) calls error

### DIFF
--- a/src/copy.jl
+++ b/src/copy.jl
@@ -138,14 +138,10 @@ function Base.copy(model::AbstractModel)
     return new_model
 end
 
-"""
-    deepcopy(_::AbstractModel)
-
-Calls error. Calling `deepcopy` over a JuMP model is not supported, nor
-planned to be supported, because it would involve making a deep copy of
-the underlying solver (behind a C pointer). Check [`copy`](@ref) instead.
-"""
-function Base.deepcopy(_::AbstractModel)
-    error("JuMP.AbstractModel does not support deepcopy, see documentation")
+# Calling `deepcopy` over a JuMP model is not supported, nor planned to be
+# supported, because it would involve making a deep copy of the underlying
+# solver (behind a C pointer).
+function Base.deepcopy(_::Model)
+    error("JuMP.AbstractModel does not support deepcopy as the reference to the underlying solver cannot be deep copied, use copy instead.")
 end
 

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -141,7 +141,6 @@ end
 # Calling `deepcopy` over a JuMP model is not supported, nor planned to be
 # supported, because it would involve making a deep copy of the underlying
 # solver (behind a C pointer).
-function Base.deepcopy(_::Model)
+function Base.deepcopy(::Model)
     error("JuMP.AbstractModel does not support deepcopy as the reference to the underlying solver cannot be deep copied, use copy instead.")
 end
-

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -142,5 +142,5 @@ end
 # supported, because it would involve making a deep copy of the underlying
 # solver (behind a C pointer).
 function Base.deepcopy(::Model)
-    error("`JuMP.AbstractModel` does not support `deepcopy` as the reference to the underlying solver cannot be deep copied, use `copy` instead.")
+    error("`JuMP.Model` does not support `deepcopy` as the reference to the underlying solver cannot be deep copied, use `copy` instead.")
 end

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -142,5 +142,5 @@ end
 # supported, because it would involve making a deep copy of the underlying
 # solver (behind a C pointer).
 function Base.deepcopy(::Model)
-    error("JuMP.AbstractModel does not support deepcopy as the reference to the underlying solver cannot be deep copied, use copy instead.")
+    error("`JuMP.AbstractModel` does not support `deepcopy` as the reference to the underlying solver cannot be deep copied, use `copy` instead.")
 end

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -137,3 +137,15 @@ function Base.copy(model::AbstractModel)
     new_model, _ = copy_model(model)
     return new_model
 end
+
+"""
+    deepcopy(_::AbstractModel)
+
+Calls error. Calling `deepcopy` over a JuMP model is not supported, nor
+planned to be supported, because it would involve making a deep copy of
+the underlying solver (behind a C pointer). Check [`copy`](@ref) instead.
+"""
+function Base.deepcopy(_::AbstractModel)
+    error("JuMP.AbstractModel does not support deepcopy, see documentation")
+end
+


### PR DESCRIPTION
There is no plan to support copying the underlying solver and, if this is not done, then the object returned by deepcopy does not behave as would be expected (both copy and original edit the same underlying model).
This has been a source of frustration before:
https://discourse.julialang.org/t/jump-gurobi-bug-value-of-variable-in-solved-model-changes-after-deleting-another-variable/29619/7
https://discourse.julialang.org/t/strange-behavior-with-deepcopy/23342/3
https://discourse.julialang.org/t/workaround-for-modifying-coefficients-in-constraints-in-jump/27123/9