### PR TITLE
Add bounds on Calculus and DataStructures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,8 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+Calculus = "0.5"
+DataStructures = "0.17"
 ForwardDiff = "~0.5.0, ~0.6, ~0.7, ~0.8, ~0.9, ~0.10"
 MathOptInterface = "~0.9.1"
 NaNMath = "≥ 0.2.1"


### PR DESCRIPTION
PR to JuliaRegistries/General are not automatically merged if the package does not have bounds to all its dependencies.