### PR TITLE
Deprecate with_optimizer

### DIFF
--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -155,12 +155,10 @@ false
 ```@meta
 DocTestSetup = quote
     using JuMP
-    model = Model(
-        with_optimizer(
-            MOI.Utilities.MockOptimizer,
-            MOIU.Model{Float64}(),
-            eval_objective_value = false,
-            eval_variable_constraint_dual = false));
+    model = Model(() -> MOIU.MockOptimizer(
+                            MOIU.Model{Float64}(),
+                            eval_objective_value = false,
+                            eval_variable_constraint_dual = false));
     @variable(model, x);
     @constraint(model, con, x <= 1);
     @objective(model, Max, -2x);

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -85,12 +85,16 @@ Most packages follow the `ModuleName.Optimizer` naming convention, but
 exceptions may exist. See the corresponding Julia package README for more
 details on how to use the solver.
 
-Use [`set_parameter`](@ref) to set solver-specific options. Continuing the
+Use [`set_parameters`](@ref) to set solver-specific options. Continuing the
 example from above,
 ```julia
-set_parameter(model, "Presolve", 0)
+set_parameters(model, "Presolve" => 0, "Heuristics" => 0.01)
 ```
-sets Gurobi's `Presolve` parameter to zero.
+sets Gurobi's
+[`Presolve`](https://www.gurobi.com/documentation/8.1/refman/presolve.html#parameter:Presolve)
+parameter to zero and
+[`Heuristics`](https://www.gurobi.com/documentation/8.1/refman/heuristics.html#parameter:Heuristics)
+to 0.01.
 
 The following solvers were compatible with JuMP up to release 0.18 but are
 not yet compatible with the latest version because they do not implement the

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -78,16 +78,19 @@ import Pkg
 Pkg.add("Gurobi")
 using JuMP
 using Gurobi
-model = Model(with_optimizer(Gurobi.Optimizer))
+model = Model(Gurobi.Optimizer)
 ```
 
 Most packages follow the `ModuleName.Optimizer` naming convention, but
 exceptions may exist. See the corresponding Julia package README for more
 details on how to use the solver.
 
-```@meta
-# TODO: Discuss setting solver options.
+Use [`set_parameter`](@ref) to set solver-specific options. Continuing the
+example from above,
+```julia
+set_parameter(model, "Presolve", 0)
 ```
+sets Gurobi's `Presolve` parameter to zero.
 
 The following solvers were compatible with JuMP up to release 0.18 but are
 not yet compatible with the latest version because they do not implement the
@@ -165,7 +168,7 @@ for consistency the MOI optimizer is called `Mosek.Optimizer` so do the
 following to create a model with the Mosek solver:
 ```julia
 julia> using MosekTools
-julia> model = Model(with_optimizer(Mosek.Optimizer))
+julia> model = Model(Mosek.Optimizer)
 ```
 
 ### ProxSDP

--- a/docs/src/nlp.md
+++ b/docs/src/nlp.md
@@ -26,7 +26,7 @@ follows:
 
 ```julia
 using Ipopt
-model = Model(with_optimizer(Ipopt.Optimizer))
+model = Model(Ipopt.Optimizer)
 @variable(model, x, start = 0.0)
 @variable(model, y, start = 0.0)
 
@@ -154,7 +154,7 @@ Nonlinear parameters are useful when solving nonlinear models in a sequence:
 
 ```julia
 using Ipopt
-model = Model(with_optimizer(Ipopt.Optimizer))
+model = Model(Ipopt.Optimizer)
 @variable(model, z)
 @NLparameter(model, x == 1.0)
 @NLobjective(model, Min, (z - x)^2)
@@ -196,17 +196,17 @@ for a description of how to write a function suitable for automatic
 differentiation.
 
 !!! note
-    If you see method errors with `ForwardDiff.Duals`, see the guidelines at 
+    If you see method errors with `ForwardDiff.Duals`, see the guidelines at
     [ForwardDiff.jl](http://www.juliadiff.org/ForwardDiff.jl/release-0.10/user/limitations.html).
     The most common error is that your user-defined function is not generic with
-    respect to the number type, i.e., don't assume that the input to the function 
+    respect to the number type, i.e., don't assume that the input to the function
     is `Float64`.
     ```julia
     f(x::Float64) = 2 * x  # This will not work.
     f(x::Real)    = 2 * x  # This is good.
     f(x)          = 2 * x  # This is also good.
     ```
-    
+
 To register a user-defined function with derivatives computed by
 automatic differentiation, use the `register` method as in the following
 example:

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -23,32 +23,43 @@ julia> using GLPK
 ```
 See [Installation Guide](@ref) for a list of other solvers you can use.
 
-Models are created with the `Model()` function. The `with_optimizer` syntax is
-used to specify the optimizer to be used:
+Models are created with the [`Model`](@ref) function. The optimizer can be set
+either in `Model()` or by calling [`set_optimizer`](@ref):
 ```julia
-julia> model = Model(with_optimizer(GLPK.Optimizer))
+julia> model = Model(GLPK.Optimizer)
 A JuMP Model
 Feasibility problem with:
 Variables: 0
 Model mode: AUTOMATIC
 CachingOptimizer state: NO_OPTIMIZER
-Solver name: No optimizer attached.
+Solver name: GLPK
+```
+equivalently,
+```julia
+julia> model = Model();
+julia> set_optimizer(model, GLPK.Optimizer);
+julia> model
+A JuMP Model
+Feasibility problem with:
+Variables: 0
+Model mode: AUTOMATIC
+CachingOptimizer state: NO_OPTIMIZER
+Solver name: GLPK
 ```
 
 !!! note
     The term "solver" is used as a synonym for "optimizer". The convention in
-    code, however, is to always use "optimizer", e.g., `with_optimizer` and
-    `GLPK.Optimizer`.
+    code, however, is to always use "optimizer", e.g., `GLPK.Optimizer`.
 
 ```@meta
 DocTestSetup = quote
     # Using a mock optimizer removes the need to load a solver such as GLPK for
     # building the documentation.
     const MOI = JuMP.MathOptInterface
-    model = Model(with_optimizer(MOI.Utilities.MockOptimizer,
-                                 MOIU.Model{Float64}(),
-                                 eval_objective_value = false,
-                                 eval_variable_constraint_dual = false))
+    model = Model(() -> MOI.Utilities.MockOptimizer(
+                            MOIU.Model{Float64}(),
+                            eval_objective_value = false,
+                            eval_variable_constraint_dual = false))
 end
 ```
 !!! note

--- a/docs/src/solutions.md
+++ b/docs/src/solutions.md
@@ -169,8 +169,8 @@ julia> @objective(model, Max, x[1]);
 ```@meta
 DocTestSetup = quote
     using JuMP
-    model = Model(with_optimizer(MOIU.MockOptimizer, MOIU.Model{Float64}(),
-                  eval_variable_constraint_dual=true));
+    model = Model(() -> MOIU.MockOptimizer(MOIU.Model{Float64}(),
+                          eval_variable_constraint_dual=true));
     @variable(model, x[1:2]);
     @constraint(model, c1, x[1] + x[2] <= 1);
     @constraint(model, c2, x[1] - x[2] <= 1);

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -104,11 +104,10 @@ solver_name
 
 bridge_constraints
 
+set_parameter
+set_parameters
 set_silent
 unset_silent
-
-set_parameter
-
 set_time_limit_sec
 unset_time_limit_sec
 time_limit_sec

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -59,13 +59,10 @@ the optimizer:
 See the [MOI documentation](http://www.juliaopt.org/MathOptInterface.jl/v0.9.1/)
 for more details on these two MOI layers.
 
-To attach an optimizer to a JuMP model, JuMP needs to create a new empty
-optimizer instance. New optimizer instances can be obtained using an
-`OptimizerFactory` that can be created using the [`with_optimizer`](@ref)
-function:
-```@docs
-with_optimizer
-```
+To attach an optimizer to a JuMP model, JuMP needs to be able to create a new
+empty optimizer instance. For this reason, we provide JuMP with a function
+that creates a new optimizer (i.e., an optimizer factory), instead of a concrete
+optimizer object.
 
 The factory can be provided either at model construction time by calling
 [`set_optimizer`](@ref). An optimizer must be set before a call to
@@ -79,7 +76,7 @@ JuMP.optimize!
 New JuMP models are created using the [`Model`](@ref) constructor:
 ```@docs
 Model()
-Model(::JuMP.OptimizerFactory)
+Model(::Any)
 ```
 
 ```@meta

--- a/examples/basic.jl
+++ b/examples/basic.jl
@@ -22,7 +22,7 @@ Formulate and solve a simple LP:
 If `verbose = true`, print the model and the solution.
 """
 function example_basic(; verbose = true)
-    model = Model(with_optimizer(GLPK.Optimizer))
+    model = Model(GLPK.Optimizer)
 
     @variable(model, 0 <= x <= 2)
     @variable(model, 0 <= y <= 30)

--- a/examples/cannery.jl
+++ b/examples/cannery.jl
@@ -37,7 +37,7 @@ function example_cannery(; verbose = true)
     num_plants = length(plants)
     num_markets = length(markets)
 
-    cannery = Model(with_optimizer(GLPK.Optimizer))
+    cannery = Model(GLPK.Optimizer)
 
     @variable(cannery, ship[1:num_plants, 1:num_markets] >= 0)
 

--- a/examples/clnlbeam.jl
+++ b/examples/clnlbeam.jl
@@ -30,7 +30,8 @@ function example_clnlbeam()
     N = 1000
     h = 1/N
     alpha = 350
-    model = Model(with_optimizer(Ipopt.Optimizer, print_level = 0))
+    model = Model(Ipopt.Optimizer)
+    set_silent(model)
     @variables(model, begin
         -1 <= t[1:(N + 1)] <= 1
         -0.05 <= x[1:(N + 1)] <= 0.05

--- a/examples/cluster.jl
+++ b/examples/cluster.jl
@@ -33,7 +33,8 @@ function example_cluster(; verbose = true)
         end
     end
 
-    model = Model(with_optimizer(SCS.Optimizer, verbose = 0))
+    model = Model(SCS.Optimizer)
+    set_silent(model)
     # Z >= 0, PSD
     @variable(model, Z[1:m, 1:m], PSD)
     @constraint(model, Z .>= 0)

--- a/examples/corr_sdp.jl
+++ b/examples/corr_sdp.jl
@@ -25,7 +25,8 @@ We can use the following property of the correlations to determine bounds on
     | ρ_AC  ρ_BC   1   |
 """
 function example_corr_sdp()
-    model = Model(with_optimizer(SCS.Optimizer, verbose = 0))
+    model = Model(SCS.Optimizer)
+    set_silent(model)
     @variable(model, X[1:3, 1:3], PSD)
 
     # Diagonal is 1s

--- a/examples/cutting_stock_column_generation.jl
+++ b/examples/cutting_stock_column_generation.jl
@@ -24,7 +24,7 @@ function solve_pricing(dual_demand_satisfaction, maxwidth, widths, rollcost, dem
     n = length(reduced_costs)
 
     # The actual pricing model.
-    submodel = Model(with_optimizer(GLPK.Optimizer))
+    submodel = Model(GLPK.Optimizer)
     @variable(submodel, xs[1:n] >= 0, Int)
     @constraint(submodel, sum(xs .* widths) <= maxwidth)
     @objective(submodel, Max, sum(xs .* reduced_costs))
@@ -114,7 +114,7 @@ function example_cutting_stock(; max_gen_cols::Int=5000)
     # Write the master problem with this "reduced" set of patterns.
     # Not yet integer variables: otherwise, the dual values may make no sense
     # (actually, GLPK will yell at you if you're trying to get duals for integer problems)
-    m = Model(with_optimizer(GLPK.Optimizer))
+    m = Model(GLPK.Optimizer)
     @variable(m, θ[1:ncols] >= 0)
     @objective(m, Min,
         sum(θ[p] * (rollcost - sum(patterns[j, p] * prices[j] for j in 1:n)) for p in 1:ncols)

--- a/examples/diet.jl
+++ b/examples/diet.jl
@@ -65,7 +65,7 @@ function example_diet(; verbose = true)
     @test food_data["milk", "fat"] == 2.5
 
     # Build model
-    model = Model(with_optimizer(GLPK.Optimizer))
+    model = Model(GLPK.Optimizer)
 
     @variables(model, begin
         # Variables for nutrition info

--- a/examples/knapsack.jl
+++ b/examples/knapsack.jl
@@ -23,7 +23,7 @@ function example_knapsack(; verbose = true)
     profit = [5, 3, 2, 7, 4]
     weight = [2, 8, 4, 2, 5]
     capacity = 10
-    model = Model(with_optimizer(GLPK.Optimizer))
+    model = Model(GLPK.Optimizer)
     @variable(model, x[1:5], Bin)
     # Objective: maximize profit
     @objective(model, Max, profit' * x)

--- a/examples/max_cut_sdp.jl
+++ b/examples/max_cut_sdp.jl
@@ -31,7 +31,7 @@ function solve_max_cut_sdp(num_vertex, weights)
     laplacian = diagm(0 => weights * ones(num_vertex)) - weights
 
     # Solve the SDP relaxation
-    model = Model(with_optimizer(SCS.Optimizer))
+    model = Model(SCS.Optimizer)
     @variable(model, X[1:num_vertex, 1:num_vertex], PSD)
     @objective(model, Max, 1 / 4 * dot(laplacian, X))
     @constraint(model, diag(X) .== 1)

--- a/examples/min_distortion.jl
+++ b/examples/min_distortion.jl
@@ -41,7 +41,8 @@ For more detail, see "Lectures on discrete geometry" by J. Matoušek, Springer,
 2002, pp. 378-379.
 """
 function example_min_distortion()
-    model = Model(with_optimizer(SCS.Optimizer, verbose = 0))
+    model = Model(SCS.Optimizer)
+    set_silent(model)
     D = [0.0 1.0 1.0 1.0;
          1.0 0.0 2.0 2.0;
          1.0 2.0 0.0 2.0;

--- a/examples/min_ellipse.jl
+++ b/examples/min_ellipse.jl
@@ -34,7 +34,8 @@ function example_min_ellipse()
     ]
     # We change the weights to see different solutions, if they exist
     weights = [1.0 0.0; 0.0 1.0]
-    model = Model(with_optimizer(SCS.Optimizer, verbose = 0))
+    model = Model(SCS.Optimizer)
+    set_silent(model)
     @variable(model, X[i=1:2, j=1:2], PSD, start = [2.0 0.0; 0.0 3.0][i, j])
     @objective(model, Min, tr(weights * X))
     for As_i in As

--- a/examples/mle.jl
+++ b/examples/mle.jl
@@ -20,7 +20,8 @@ function example_mle(; verbose = true)
     n = 1_000
     Random.seed!(1234)
     data = randn(n)
-    model = Model(with_optimizer(Ipopt.Optimizer, print_level = 0))
+    model = Model(Ipopt.Optimizer)
+    set_silent(model)
     @variable(model, μ, start = 0.0)
     @variable(model, σ >= 0.0, start = 1.0)
     @NLobjective(model, Max, n / 2 * log(1 / (2 * π * σ^2)) -

--- a/examples/multi.jl
+++ b/examples/multi.jl
@@ -65,7 +65,7 @@ function example_multi(; verbose = true)
 
 
     #  DECLARE MODEL
-    multi = Model(with_optimizer(GLPK.Optimizer))
+    multi = Model(GLPK.Optimizer)
 
     #  VARIABLES
     @variable(multi, trans[1:numorig, 1:numdest, 1:numprod] >= 0)

--- a/examples/prod.jl
+++ b/examples/prod.jl
@@ -121,7 +121,7 @@ function example_prod(; verbose = true)
     minv = [[dem[p][t+1] * checkpro(p,t, pro, pir, rir) for t in numperiods] for p in 1:numprd]
     # Lower limit on inventory at end of period t
 
-    prod = Model(with_optimizer(GLPK.Optimizer))
+    prod = Model(GLPK.Optimizer)
 
     ###  VARIABLES  ###
     @variable(prod, Crews[0:lastperiod] >= 0)

--- a/examples/qcp.jl
+++ b/examples/qcp.jl
@@ -18,7 +18,8 @@ A simple quadratically constrained program based on
 http://www.gurobi.com/documentation/5.5/example-tour/node25
 """
 function example_qcp(; verbose = true)
-    model = Model(with_optimizer(Ipopt.Optimizer, print_level = 0))
+    model = Model(Ipopt.Optimizer)
+    set_silent(model)
     @variable(model, x)
     @variable(model, y >= 0)
     @variable(model, z >= 0)

--- a/examples/robust_uncertainty.jl
+++ b/examples/robust_uncertainty.jl
@@ -33,7 +33,8 @@ function example_robust_uncertainty()
     Γ1(𝛿, N) = R / sqrt(N) * (2 + sqrt(2 * log(1 / 𝛿)))
     Γ2(𝛿, N) = 2 * R^2 / sqrt(N) * (2 + sqrt(2 * log(2 / 𝛿)))
 
-    model = Model(with_optimizer(SCS.Optimizer, verbose = 0))
+    model = Model(SCS.Optimizer)
+    set_silent(model)
 
     @variable(model, Σ[1:d, 1:d], PSD)
     @variable(model, u[1:d])

--- a/examples/rosenbrock.jl
+++ b/examples/rosenbrock.jl
@@ -12,7 +12,8 @@ using JuMP, Ipopt, Test
 const MOI = JuMP.MathOptInterface
 
 function example_rosenbrock()
-    model = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+    model = Model(Ipopt.Optimizer)
+    set_silent(model)
     @variable(model, x)
     @variable(model, y)
     @NLobjective(model, Min, (1 - x)^2 + 100 * (y - x^2)^2)

--- a/examples/steelT3.jl
+++ b/examples/steelT3.jl
@@ -52,7 +52,7 @@ function example_steelT3(; verbose = true)
     )
 
     # Model
-    model = Model(with_optimizer(GLPK.Optimizer))
+    model = Model(GLPK.Optimizer)
 
     # Decision Variables
     @variables(model, begin

--- a/examples/sudoku.jl
+++ b/examples/sudoku.jl
@@ -33,7 +33,7 @@ function example_sudoku(filepath)
         end
     end
 
-    model = Model(with_optimizer(GLPK.Optimizer))
+    model = Model(GLPK.Optimizer)
 
     @variable(model, x[1:9, 1:9, 1:9], Bin)
 

--- a/examples/transp.jl
+++ b/examples/transp.jl
@@ -36,7 +36,7 @@ function example_transp()
 		24   14   17   13   28   99   20
 	]
 
-	model = Model(with_optimizer(GLPK.Optimizer))
+	model = Model(GLPK.Optimizer)
 
 	@variable(model, trans[1:length(ORIG), 1:length(DEST)] >= 0)
 	@objective(model, Min, sum(cost[i, j] * trans[i, j] for i in 1:length(ORIG), j in 1:length(DEST)))

--- a/examples/urban_plan.jl
+++ b/examples/urban_plan.jl
@@ -18,7 +18,7 @@ An "urban planning" problem. Based on
 http://www.puzzlor.com/2013-08_UrbanPlanning.html
 """
 function example_urban_plan()
-    model = Model(with_optimizer(GLPK.Optimizer))
+    model = Model(GLPK.Optimizer)
 
     # x is indexed by row and column
     @variable(model, 0 <= x[1:5, 1:5] <= 1, Int)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -423,13 +423,16 @@ end
     set_parameters(model::Model, pairs::Pair...)
 
 Given a list of `parameter_name => value` pairs, calls
-`set_parameters(model, parameter_name, value)` for each pair. This is a
-convenience function only. See [`set_parameter`](@ref).
+`set_parameter(model, parameter_name, value)` for each pair. See
+[`set_parameter`](@ref).
 
 ## Example
 ```julia
 model = Model(Ipopt.Optimizer)
 set_parameters(model, "tol" => 1e-4, "max_iter" => 100)
+# The above call is equivalent to:
+set_parameter(model, "tol", 1e-4)
+set_parameter(model, "max_iter", 100)
 ```
 """
 function set_parameters(model::Model, pairs::Pair...)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -46,23 +46,8 @@ include("utils.jl")
 const _MOIVAR = MOI.VariableIndex
 const _MOICON{F,S} = MOI.ConstraintIndex{F,S}
 
-"""
-    OptimizerFactory
-
-User-friendly closure that creates new MOI models. New `OptimizerFactory`s are
-created with [`with_optimizer`](@ref) and new models are created from the
-optimizer factory `optimizer_factory` with `optimizer_factory()`.
-
-## Examples
-
-The following construct an optimizer factory and then use it to create two
-independent `Ipopt.Optimizer`s:
-```julia
-optimizer_factory = with_optimizer(Ipopt.Optimizer, print_level=0)
-optimizer1 = optimizer_factory()
-optimizer2 = optimizer_factory()
-```
-"""
+# OptimizerFactory was deprecated in JuMP 0.21 and should be removed when
+# with_optimizer is removed.
 struct OptimizerFactory
     # The constructor can be
     # * `Function`: a function, or
@@ -73,22 +58,15 @@ struct OptimizerFactory
     kwargs # type changes from Julia v0.6 to v0.7 so we leave it untyped for now
 end
 
-"""
-    with_optimizer(constructor, args...; kwargs...)
-
-Return an `OptimizerFactory` that creates optimizers using the constructor
-`constructor` with positional arguments `args` and keyword arguments `kwargs`.
-
-## Examples
-
-The following returns an optimizer factory that creates `Ipopt.Optimizer`s using
-the constructor call `Ipopt.Optimizer(print_level=0)`:
-```julia
-with_optimizer(Ipopt.Optimizer, print_level=0)
-```
-"""
 function with_optimizer(constructor,
                         args...; kwargs...)
+    deprecation_message = """
+with_optimizer is deprecated. The examples below demonstrate how to update to the new syntax:
+- 'with_optimizer(Ipopt.Optimizer)' becomes 'Ipopt.Optimizer'.
+- 'set_optimizer(model, with_optimizer(Ipopt.Optimizer, print_level=1))' becomes 'set_optimizer(model, Ipopt.Optimizer); set_parameter(model, \"print_level\", 1)'. Each parameter should be set with a separate call to set_parameter.
+- In rare cases where an argument must be passed to the constructor, use an anonymous function. For example, 'env = Gurobi.Env(); set_optimizer(model, with_optimizer(Gurobi.Optimizer, env))' becomes 'env = Gurobi.Env(); set_optimizer(model, () -> Gurobi.Optimizer(env))'.
+    """
+    Base.depwarn(deprecation_message, :with_optimizer)
     if !applicable(constructor, args...)
         error("$constructor does not have any method with arguments $args.",
               "The first argument of `with_optimizer` should be callable with",
@@ -170,24 +148,29 @@ function Model(; caching_mode::MOIU.CachingOptimizerMode=MOIU.AUTOMATIC,
 end
 
 """
-    Model(optimizer_factory::OptimizerFactory;
+    Model(optimizer_factory;
           caching_mode::MOIU.CachingOptimizerMode=MOIU.AUTOMATIC,
           bridge_constraints::Bool=true)
 
-Return a new JuMP model using the optimizer factory `optimizer_factory` to
-create the optimizer. The optimizer factory can be created by the
-[`with_optimizer`](@ref) function. See [`set_optimizer`](@ref) for the
-description of the `bridge_constraints` argument.
+Return a new JuMP model with the provided optimizer and bridge settings. This
+function is equivalent to:
+```julia
+    model = Model()
+    set_optimizer(model, optimizer_factory,
+                  bridge_constraints=bridge_constraints)
+    return model
+```
+See [`set_optimizer`](@ref) for the description of the `optimizer_factory` and
+`bridge_constraints` arguments.
 
 ## Examples
 
-The following creates a model using the optimizer
-`Ipopt.Optimizer(print_level=0)`:
+The following creates a model with the optimizer set to `Ipopt`:
 ```julia
-model = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+model = Model(Ipopt.Optimizer)
 ```
 """
-function Model(optimizer_factory::OptimizerFactory;
+function Model(optimizer_factory;
                bridge_constraints::Bool=true, kwargs...)
     model = Model(; kwargs...)
     set_optimizer(model, optimizer_factory,

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -63,7 +63,7 @@ function with_optimizer(constructor,
     deprecation_message = """
 with_optimizer is deprecated. The examples below demonstrate how to update to the new syntax:
 - 'with_optimizer(Ipopt.Optimizer)' becomes 'Ipopt.Optimizer'.
-- 'set_optimizer(model, with_optimizer(Ipopt.Optimizer, print_level=1))' becomes 'set_optimizer(model, Ipopt.Optimizer); set_parameter(model, \"print_level\", 1)'. Each parameter should be set with a separate call to set_parameter.
+- 'set_optimizer(model, with_optimizer(Ipopt.Optimizer, print_level=1, tol=1e-5))' becomes 'set_optimizer(model, Ipopt.Optimizer); set_parameters(model, \"print_level\" => 1, \"tol\" => 1e-5)'.
 - In rare cases where an argument must be passed to the constructor, use an anonymous function. For example, 'env = Gurobi.Env(); set_optimizer(model, with_optimizer(Gurobi.Optimizer, env))' becomes 'env = Gurobi.Env(); set_optimizer(model, () -> Gurobi.Optimizer(env))'.
     """
     Base.depwarn(deprecation_message, :with_optimizer)
@@ -417,6 +417,25 @@ Sets solver-specific parameter identified by `name` to `value`.
 """
 function set_parameter(model::Model, name, value)
     return MOI.set(model, MOI.RawParameter(name), value)
+end
+
+"""
+    set_parameters(model::Model, pairs::Pair...)
+
+Given a list of `parameter_name => value` pairs, calls
+`set_parameters(model, parameter_name, value)` for each pair. This is a
+convenience function only. See [`set_parameter`](@ref).
+
+## Example
+```julia
+model = Model(Ipopt.Optimizer)
+set_parameters(model, "tol" => 1e-4, "max_iter" => 100)
+```
+"""
+function set_parameters(model::Model, pairs::Pair...)
+    for (name, value) in pairs
+        set_parameter(model, name, value)
+    end
 end
 
 """

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -54,7 +54,8 @@ optimizer are automatically bridged to equivalent supported constraints when
 an appropriate transformation is defined in the `MathOptInterface.Bridges`
 module or is defined in another module and is explicitly added.
 
-See [`set_parameter`](@ref) for setting parameters of the optimizer.
+See [`set_parameters`](@ref) and [`set_parameter`](@ref) for setting
+solver-specific parameters of the optimizer.
 
 ## Examples
 ```julia

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -32,28 +32,51 @@ function MOIU.attach_optimizer(model::Model)
     MOIU.attach_optimizer(backend(model))
 end
 
+const _set_optimizer_not_callable_message =
+    "The provided optimizer_factory is invalid. It must be callable with zero" *
+    "arguments. For example, \"Ipopt.Optimizer\" or" *
+    "\"() -> ECOS.Optimizer()\". It should not be an instantiated optimizer " *
+    "like \"Ipopt.Optimizer()\" or \"ECOS.Optimizer()\"." *
+    "(Note the difference in parentheses!)"
+
 """
-    set_optimizer(model::Model, optimizer_factory::OptimizerFactory;
+    set_optimizer(model::Model, optimizer_factory;
                   bridge_constraints::Bool=true)
 
-Creates a new `MathOptInterface.AbstractOptimizer` instance using the optimizer
-factory and sets it as the optimizer of `model`.
+
+Creates an empty `MathOptInterface.AbstractOptimizer` instance by calling
+`optimizer_factory()` and sets it as the optimizer of `model`. Specifically,
+`optimizer_factory` must be callable with zero arguments and return an empty
+`MathOptInterface.AbstractOptimizer`.
 
 If `bridge_constraints` is true, constraints that are not supported by the
 optimizer are automatically bridged to equivalent supported constraints when
 an appropriate transformation is defined in the `MathOptInterface.Bridges`
 module or is defined in another module and is explicitly added.
 
+See [`set_parameter`](@ref) for setting parameters of the optimizer.
+
 ## Examples
 ```julia
 model = Model()
-set_optimizer(model, with_optimizer(GLPK.Optimizer))
+set_optimizer(model, GLPK.Optimizer)
 ```
 """
-function set_optimizer(model::Model, optimizer_factory::OptimizerFactory;
+function set_optimizer(model::Model, optimizer_factory;
                        bridge_constraints::Bool=true)
     error_if_direct_mode(model, :set_optimizer)
+    if !applicable(optimizer_factory)
+        error(_set_optimizer_not_callable_message)
+    end
     optimizer = optimizer_factory()
+    if !isa(optimizer, MOI.AbstractOptimizer)
+        error("The provided optimizer_factory returned an object of type " *
+              "$(typeof(optimizer)). Expected a " *
+              "MathOptInterface.AbstractOptimizer.")
+    end
+    if !MOI.is_empty(optimizer)
+        error("The provided optimizer_factory returned a non-empty optimizer.")
+    end
     if bridge_constraints
         # The names are handled by the first caching optimizer.
         # If default_copy_to without names is supported, no need for a second

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -528,10 +528,10 @@ end
 function test_shadow_price(model_string, constraint_dual, constraint_shadow)
     model = JuMP.Model()
     MOIU.loadfromstring!(JuMP.backend(model), model_string)
-    set_optimizer(model, with_optimizer(MOIU.MockOptimizer,
-                                        MOIU.Model{Float64}(),
-                                        eval_objective_value=false,
-                                        eval_variable_constraint_dual=false))
+    set_optimizer(model, () -> MOIU.MockOptimizer(
+                                MOIU.Model{Float64}(),
+                                eval_objective_value=false,
+                                eval_variable_constraint_dual=false))
     JuMP.optimize!(model)
     mock_optimizer = JuMP.backend(model).optimizer.model
     MOI.set(mock_optimizer, MOI.TerminationStatus(), MOI.OPTIMAL)

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -42,9 +42,9 @@ using JuMP
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.backend(m).model_cache, model, ["x","y"], ["c", "xub", "ylb"])
 
-        set_optimizer(m, with_optimizer(MOIU.MockOptimizer,
-                                        MOIU.Model{Float64}(),
-                                        eval_objective_value=false))
+        set_optimizer(m, () -> MOIU.MockOptimizer(
+                                 MOIU.Model{Float64}(),
+                                 eval_objective_value=false))
         JuMP.optimize!(m)
 
         mockoptimizer = JuMP.backend(m).optimizer.model
@@ -126,9 +126,9 @@ using JuMP
 
     @testset "IP" begin
         # Tests the solver= keyword.
-        m = Model(with_optimizer(MOIU.MockOptimizer,
-                                 MOIU.Model{Float64}(),
-                                 eval_objective_value=false),
+        m = Model(() -> MOIU.MockOptimizer(
+                            MOIU.Model{Float64}(),
+                            eval_objective_value=false),
                   caching_mode = MOIU.AUTOMATIC)
         @variable(m, x == 1.0, Int)
         @variable(m, y, Bin)
@@ -200,9 +200,9 @@ using JuMP
         MOIU.loadfromstring!(model, modelstring)
         MOIU.test_models_equal(JuMP.backend(m).model_cache, model, ["x","y"], ["c1", "c2", "c3"])
 
-        set_optimizer(m, with_optimizer(MOIU.MockOptimizer,
-                                        MOIU.Model{Float64}(),
-                                        eval_objective_value=false))
+        set_optimizer(m, () -> MOIU.MockOptimizer(
+                                 MOIU.Model{Float64}(),
+                                 eval_objective_value=false))
         JuMP.optimize!(m)
 
         mockoptimizer = JuMP.backend(m).optimizer.model
@@ -373,8 +373,7 @@ using JuMP
     end
 
     @testset "Solver doesn't support nonlinear constraints" begin
-        model = Model(with_optimizer(MOIU.MockOptimizer,
-                                     MOIU.Model{Float64}()))
+        model = Model(() -> MOIU.MockOptimizer(MOIU.Model{Float64}()))
         @variable(model, x)
         @NLobjective(model, Min, sin(x))
         err = ErrorException("The solver does not support nonlinear problems " *

--- a/test/lp_sensitivity.jl
+++ b/test/lp_sensitivity.jl
@@ -10,9 +10,9 @@
 function test_lp_rhs_perturbation_range(model_string, primal_solution, basis_status, feasibility_ranges)
     model = JuMP.Model()
     MOIU.loadfromstring!(JuMP.backend(model), model_string)
-    set_optimizer(model, with_optimizer(MOIU.MockOptimizer,
-                                        MOIU.Model{Float64}(),
-                                        eval_variable_constraint_dual=false))
+    set_optimizer(model, () -> MOIU.MockOptimizer(
+                                 MOIU.Model{Float64}(),
+                                 eval_variable_constraint_dual=false))
     JuMP.optimize!(model)
     mock_optimizer = JuMP.backend(model).optimizer.model
     MOI.set(mock_optimizer, MOI.TerminationStatus(), MOI.OPTIMAL)
@@ -107,9 +107,9 @@ end
 function test_lp_objective_perturbation_range(model_string, dual_solution, basis_status, optimality_ranges)
     model = JuMP.Model()
     MOIU.loadfromstring!(JuMP.backend(model), model_string)
-    set_optimizer(model, with_optimizer(MOIU.MockOptimizer,
-                                        MOIU.Model{Float64}(),
-                                        eval_variable_constraint_dual=true))
+    set_optimizer(model, () -> MOIU.MockOptimizer(
+                                 MOIU.Model{Float64}(),
+                                 eval_variable_constraint_dual=true))
     JuMP.optimize!(model)
     mock_optimizer = JuMP.backend(model).optimizer.model
     MOI.set(mock_optimizer, MOI.TerminationStatus(), MOI.OPTIMAL)

--- a/test/model.jl
+++ b/test/model.jl
@@ -374,7 +374,7 @@ function test_model()
         err = ErrorException("The provided optimizer_factory returned an " *
             "object of type Int64. Expected a " *
             "MathOptInterface.AbstractOptimizer.")
-        @test_throws err set_optimizer(model, () -> 10)
+        @test_throws err set_optimizer(model, () -> Int64(10))
         # TODO: A factory that returns a non-empty optimizer.
     end
 end

--- a/test/model.jl
+++ b/test/model.jl
@@ -48,8 +48,7 @@ function test_model()
 
     @testset "Result attributes" begin
         err = JuMP.OptimizeNotCalled()
-        model = Model(with_optimizer(MOIU.MockOptimizer,
-                                     SimpleLPModel{Float64}()))
+        model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()))
         @variable(model, x)
         c = @constraint(model, x ≤ 0)
         @objective(model, Max, x)
@@ -163,8 +162,7 @@ function test_model()
     @testset "Bridges" begin
         @testset "Automatic bridging" begin
             # optimizer not supporting Interval
-            model = Model(with_optimizer(MOIU.MockOptimizer,
-                                         SimpleLPModel{Float64}()))
+            model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()))
             @test JuMP.bridge_constraints(model)
             @test JuMP.backend(model) isa MOIU.CachingOptimizer
             @test JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer
@@ -176,9 +174,8 @@ function test_model()
         end
         @testset "Automatic bridging with cache for bridged model" begin
             # optimizer not supporting Interval and not supporting `default_copy_to`
-            model = Model(with_optimizer(MOIU.MockOptimizer,
-                                         SimpleLPModel{Float64}(),
-                                         needs_allocate_load=true))
+            model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}(),
+                                                   needs_allocate_load=true))
             @test JuMP.bridge_constraints(model)
             @test JuMP.backend(model) isa MOIU.CachingOptimizer
             @test JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer
@@ -200,8 +197,7 @@ function test_model()
             @test_throws err optimizer_index(cref)
         end
         @testset "Automatic bridging disabled with `bridge_constraints` keyword" begin
-            model = Model(with_optimizer(MOIU.MockOptimizer,
-                                         SimpleLPModel{Float64}()),
+            model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()),
                           bridge_constraints=false)
             @test !JuMP.bridge_constraints(model)
             @test JuMP.backend(model) isa MOIU.CachingOptimizer
@@ -220,7 +216,7 @@ function test_model()
         end
 
         @testset "Add bridge" begin
-            function mock()
+            function mock_factory()
                 mock = MOIU.MockOptimizer(MOIU.Model{Float64}(),
                                           eval_variable_constraint_dual=false)
                 optimize!(mock) = MOIU.mock_optimize!(mock, [1.0],
@@ -228,10 +224,9 @@ function test_model()
                 MOIU.set_mock_optimize!(mock, optimize!)
                 return mock
             end
-            factory = with_optimizer(mock)
             @testset "before loading the constraint to the optimizer" begin
-                @testset "with_optimizer at Model" begin
-                    model = Model(factory)
+                @testset "optimizer set at Model" begin
+                    model = Model(mock_factory)
                     @variable(model, x)
                     JuMP.add_bridge(model, NonnegativeBridge)
                     c = @constraint(model, x in Nonnegative())
@@ -240,12 +235,12 @@ function test_model()
                     @test 1.0 == @inferred JuMP.value(c)
                     @test 2.0 == @inferred JuMP.dual(c)
                 end
-                @testset "with_optimizer with set_optimizer" begin
+                @testset "optimizer set with set_optimizer" begin
                     model = Model()
                     @variable(model, x)
                     c = @constraint(model, x in Nonnegative())
                     JuMP.add_bridge(model, NonnegativeBridge)
-                    set_optimizer(model, factory)
+                    set_optimizer(model, mock_factory)
                     JuMP.optimize!(model)
                     @test 1.0 == @inferred JuMP.value(x)
                     @test 1.0 == @inferred JuMP.value(c)
@@ -253,12 +248,12 @@ function test_model()
                 end
             end
             @testset "after loading the constraint to the optimizer" begin
-                @testset "with_optimizer at Model" begin
+                @testset "optimizer set at Model" begin
                     err = ErrorException(string("Constraints of type ",
                     "MathOptInterface.SingleVariable-in-Nonnegative are not ",
                     "supported by the solver and there are no bridges that ",
                     "can reformulate it into supported constraints."))
-                    model = Model(factory)
+                    model = Model(mock_factory)
                     @variable(model, x)
                     @test_throws err @constraint(model, x in Nonnegative())
                     JuMP.add_bridge(model, NonnegativeBridge)
@@ -268,13 +263,13 @@ function test_model()
                     @test 1.0 == @inferred JuMP.value(c)
                     @test 2.0 == @inferred JuMP.dual(c)
                 end
-                @testset "with_optimizer with set_optimizer" begin
+                @testset "optimizer set with set_optimizer" begin
                     err = MOI.UnsupportedConstraint{MOI.SingleVariable,
                                                     Nonnegative}()
                     model = Model()
                     @variable(model, x)
                     c = @constraint(model, x in Nonnegative())
-                    set_optimizer(model, factory)
+                    set_optimizer(model, mock_factory)
                     @test_throws err JuMP.optimize!(model)
                     JuMP.add_bridge(model, NonnegativeBridge)
                     JuMP.optimize!(model)
@@ -284,8 +279,8 @@ function test_model()
                 end
             end
             @testset "automatically with BridgeableConstraint" begin
-                @testset "with_optimizer at Model" begin
-                    model = Model(factory)
+                @testset "optimizer set at Model" begin
+                    model = Model(mock_factory)
                     @variable(model, x)
                     constraint = ScalarConstraint(x, Nonnegative())
                     bc = BridgeableConstraint(constraint, NonnegativeBridge)
@@ -295,13 +290,13 @@ function test_model()
                     @test 1.0 == @inferred JuMP.value(c)
                     @test 2.0 == @inferred JuMP.dual(c)
                 end
-                @testset "with_optimizer with set_optimizer" begin
+                @testset "optimizer set with set_optimizer" begin
                     model = Model()
                     @variable(model, x)
                     constraint = ScalarConstraint(x, Nonnegative())
                     bc = BridgeableConstraint(constraint, NonnegativeBridge)
                     c = add_constraint(model, bc)
-                    set_optimizer(model, factory)
+                    set_optimizer(model, mock_factory)
                     JuMP.optimize!(model)
                     @test 1.0 == @inferred JuMP.value(x)
                     @test 1.0 == @inferred JuMP.value(c)
@@ -309,24 +304,6 @@ function test_model()
                 end
             end
         end
-    end
-
-    @testset "Factories" begin
-        factory = with_optimizer(Optimizer, 1, 2)
-        @test factory.constructor == Optimizer
-        @test factory.args == (1, 2)
-        optimizer = factory()
-        @test optimizer isa Optimizer
-        @test optimizer.a == 1
-        @test optimizer.b == 2
-        @test_throws ErrorException factory = with_optimizer(opt_build, 1, 2)
-        factory = with_optimizer(opt_build, 1, b = 2)
-        @test factory.constructor == opt_build
-        @test factory.args == (1,)
-        optimizer = factory()
-        @test optimizer isa Optimizer
-        @test optimizer.a == 1
-        @test optimizer.b == 2
     end
 
     @testset "solve_time" begin
@@ -338,8 +315,7 @@ function test_model()
 
         @testset "OptimizeNotCalled()" begin
             err = OptimizeNotCalled()
-            model = Model(with_optimizer(MOIU.MockOptimizer,
-                                         SimpleLPModel{Float64}()))
+            model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()))
             @test_throws err solve_time(model)
         end
 
@@ -355,14 +331,13 @@ function test_model()
         end
 
         @testset "Mock" begin
-            model = Model(with_optimizer(MOIU.MockOptimizer,
-                                         SimpleLPModel{Float64}()))
+            model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()))
             @test "Mock" == @inferred JuMP.solver_name(model)
         end
     end
     @testset "set_silent and unset_silent" begin
         mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
-        model = Model(with_optimizer(MOIU.MockOptimizer, mock))
+        model = Model(() -> MOIU.MockOptimizer(mock))
         @test JuMP.set_silent(model)
         @test MOI.get(backend(model), MOI.Silent())
         @test MOI.get(model, MOI.Silent())
@@ -373,7 +348,7 @@ function test_model()
 
     @testset "set_parameter" begin
         mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
-        model = Model(with_optimizer(MOIU.MockOptimizer, mock))
+        model = Model(() -> MOIU.MockOptimizer(mock))
         @test JuMP.set_parameter(model, "aaa", "bbb") == "bbb"
         @test MOI.get(backend(model), MOI.RawParameter("aaa")) == "bbb"
         @test MOI.get(model, MOI.RawParameter("aaa")) == "bbb"
@@ -381,7 +356,7 @@ function test_model()
 
     @testset "set and retrieve time limit" begin
         mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
-        model = Model(with_optimizer(MOIU.MockOptimizer, mock))
+        model = Model(() -> MOIU.MockOptimizer(mock))
         JuMP.set_time_limit_sec(model, 12.0)
         @test JuMP.time_limit_sec(model) == 12.0
         JuMP.set_time_limit_sec(model, nothing)
@@ -389,6 +364,18 @@ function test_model()
         JuMP.set_time_limit_sec(model, 12.0)
         JuMP.unset_time_limit_sec(model)
         @test JuMP.time_limit_sec(model) === nothing
+    end
+
+    @testset "set_optimizer error cases" begin
+        model = Model()
+        @test_throws(ErrorException(JuMP._set_optimizer_not_callable_message),
+                     set_optimizer(model,
+                                   MOIU.MockOptimizer(MOIU.Model{Float64}())))
+        err = ErrorException("The provided optimizer_factory returned an " *
+            "object of type Int64. Expected a " *
+            "MathOptInterface.AbstractOptimizer.")
+        @test_throws err set_optimizer(model, () -> 10)
+        # TODO: A factory that returns a non-empty optimizer.
     end
 end
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -354,6 +354,14 @@ function test_model()
         @test MOI.get(model, MOI.RawParameter("aaa")) == "bbb"
     end
 
+    @testset "set_parameters" begin
+        mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
+        model = Model(() -> MOIU.MockOptimizer(mock))
+        JuMP.set_parameters(model, "aaa" => "bbb", "abc" => 10)
+        @test MOI.get(model, MOI.RawParameter("aaa")) == "bbb"
+        @test MOI.get(model, MOI.RawParameter("abc")) == 10
+    end
+
     @testset "set and retrieve time limit" begin
         mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
         model = Model(() -> MOIU.MockOptimizer(mock))

--- a/test/nlp_solver.jl
+++ b/test/nlp_solver.jl
@@ -37,13 +37,14 @@ const MOI = MathOptInterface
         #     1 <= x1, x2, x3, x4 <= 5
         # Start at (1,5,5,1)
         # End at (1.000..., 4.743..., 3.821..., 1.379...)
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
         initval = [1,5,5,1]
         @variable(m, 1 <= x[i=1:4] <= 5, start=initval[i])
         @NLobjective(m, Min, x[1]*x[4]*(x[1]+x[2]+x[3]) + x[3])
         @NLconstraint(m, x[1]*x[2]*x[3]*x[4] >= 25)
         @NLconstraint(m, sum(x[i]^2 for i=1:4) == 40)
 
+        set_silent(m)
         JuMP.optimize!(m)
 
         @test JuMP.has_values(m)
@@ -62,7 +63,7 @@ const MOI = MathOptInterface
         #     1 <= x1, x2, x3, x4 <= 5
         # Start at (1,5,5,1)
         # End at (1.000..., 4.743..., 3.821..., 1.379...)
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
         initval = [1,5,5,1]
         @variable(m, 1 <= x[i=1:4] <= 5, start=initval[i])
         JuMP.set_NL_objective(m, MOI.MIN_SENSE,
@@ -75,6 +76,7 @@ const MOI = MathOptInterface
         bad_expr = :(x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2 == 40)
         @test_throws ErrorException JuMP.add_NL_constraint(m, bad_expr)
 
+        set_silent(m)
         JuMP.optimize!(m)
 
         @test JuMP.has_values(m)
@@ -90,7 +92,7 @@ const MOI = MathOptInterface
         # min t
         # st  t >= x1 * x4 * (x1 + x2 + x3) + x3
         #     ...
-        model = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        model = Model(Ipopt.Optimizer)
         start = [1.0, 5.0, 5.0, 1.0]
         @variable(model, 1 <= x[i=1:4] <= 5, start = start[i])
         @variable(model, t, start = 100)
@@ -99,6 +101,7 @@ const MOI = MathOptInterface
         @NLconstraint(model, x[1] * x[2] * x[3] * x[4] >= 25)
         @NLconstraint(model, sum(x[i]^2 for i = 1:4) == 40)
 
+        set_silent(model)
         JuMP.optimize!(model)
         @test JuMP.termination_status(model) == MOI.LOCALLY_SOLVED
         @test JuMP.primal_status(model) == MOI.FEASIBLE_POINT
@@ -115,7 +118,7 @@ const MOI = MathOptInterface
         L = [0.0, 0.0, -0.55, -0.55, 196, 196, 196, -400, -400]
         U = [Inf, Inf,  0.55,  0.55, 252, 252, 252,  800,  800]
 
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
         @variable(m, L[i] <= x[i=1:9] <= U[i], start = 0.0)
 
         @NLobjective(m, Min, 3 * x[1] + 1e-6 * x[1]^3 + 2 * x[2] + .522074e-6 * x[2]^3)
@@ -145,6 +148,7 @@ const MOI = MathOptInterface
             x[5] * x[7] * cos(x[4] - .25) + x[6] * x[7] * cos(x[4] - x[3] - .25) -
             2 * c * x[7]^2 + 22.938 * a + .7533e-3 * a * x[7]^2 == 0)
 
+        set_silent(m)
         JuMP.optimize!(m)
 
         @test JuMP.has_values(m)
@@ -155,7 +159,7 @@ const MOI = MathOptInterface
     end
 
     @testset "HS110" begin
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
         @variable(m, -2.001 <= x[1:10] <= 9.999, start = 9)
 
         @NLobjective(m, Min,
@@ -163,6 +167,7 @@ const MOI = MathOptInterface
             prod(x[i] for i=1:10)^0.2
         )
 
+        set_silent(m)
         JuMP.optimize!(m)
 
         @test JuMP.has_values(m)
@@ -176,7 +181,7 @@ const MOI = MathOptInterface
     @testset "HS111" begin
         c = [-6.089, -17.164, -34.054, -5.914, -24.721, -14.986, -24.100, -10.708, -26.662, -22.179]
 
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
         @variable(m, -100 <= x[1:10] <= 100, start = -2.3)
 
         @NLobjective(m, Min,
@@ -186,6 +191,7 @@ const MOI = MathOptInterface
         @NLconstraint(m, exp(x[4]) + 2*exp(x[5]) +   exp(x[6]) +   exp(x[7])              == 1)
         @NLconstraint(m, exp(x[3]) +   exp(x[7]) +   exp(x[8]) + 2*exp(x[9]) + exp(x[10]) == 1)
 
+        set_silent(m)
         JuMP.optimize!(m)
 
         @test JuMP.has_values(m)
@@ -198,7 +204,7 @@ const MOI = MathOptInterface
     @testset "HS112" begin
         c = [-6.089, -17.164, -34.054, -5.914, -24.721, -14.986, -24.100, -10.708, -26.662, -22.179]
 
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
         @variable(m, x[1:10] >= 1e-6, start = 0.1)
 
         @NLobjective(m, Min, sum(x[j]*(c[j] + log(x[j]/sum(x[k] for k=1:10))) for j=1:10))
@@ -207,6 +213,7 @@ const MOI = MathOptInterface
         @NLconstraint(m, x[4] + 2*x[5] + x[6] + x[7] == 1)
         @NLconstraint(m, x[3] + x[7] + x[8] + 2*x[9] + x[10] == 1)
 
+        set_silent(m)
         JuMP.optimize!(m)
 
         @test JuMP.has_values(m)
@@ -225,7 +232,7 @@ const MOI = MathOptInterface
         upper = [2000, 16000, 120, 5000, 2000, 93, 95, 12, 4, 162]
         start = [1745, 12000, 110, 3048, 1974, 89.2, 92.8, 8, 3.6, 145]
 
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
         @variable(m, lower[i] <= x[i=1:n] <= upper[i], start = start[i])
 
         @NLobjective(m, Min, 5.04*x[1] + .035*x[2] + 10*x[3] + 3.36*x[5] - .063*x[4]*x[7])
@@ -242,6 +249,7 @@ const MOI = MathOptInterface
         @NLconstraint(m, 98000*x[3]/(x[4]*x[9] + 1000*x[3]) - x[6] == 0)
         @NLconstraint(m, (x[2] + x[5])/x[1] - x[8] == 0)
 
+        set_silent(m)
         JuMP.optimize!(m)
 
         @test JuMP.has_values(m)
@@ -264,7 +272,7 @@ const MOI = MathOptInterface
         upper = [1.0, 1.0, 1.0, 0.1, 0.9, 0.9, 1000, 1000, 1000, 500, 150, 150, 150, Inf, Inf, Inf]
         start = [0.5  2 0.8  3 0.9  4 0.1  5 0.14  6 0.5  7 489  8 80  9 650 0.5  2 0.8  3 0.9  4 0.1  5 0.14  6 0.5  7 489  8 80  9 650]
 
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
         @variable(m, lower[i] <= x[i=1:N] <= upper[i], start = start[i])
         @NLobjective(m, Min, x[11] + x[12] + x[13])
 
@@ -288,6 +296,7 @@ const MOI = MathOptInterface
             x[11] + x[12] + x[13] <= 250
         end
 
+        set_silent(m)
         JuMP.optimize!(m)
 
         @test JuMP.has_values(m)
@@ -299,7 +308,7 @@ const MOI = MathOptInterface
     end
 
     @testset "HS118" begin
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
 
         L = zeros(15)
         L[1] =  8.0
@@ -356,6 +365,7 @@ const MOI = MathOptInterface
         @constraint(m, x[10] + x[11] + x[12] >= 85)
         @constraint(m, x[13] + x[14] + x[15] >= 100)
 
+        set_silent(m)
         JuMP.optimize!(m)
 
         @test JuMP.has_values(m)
@@ -367,7 +377,7 @@ const MOI = MathOptInterface
     end
 
     @testset "Two-sided constraints" begin
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
         @variable(m, x)
         @NLobjective(m, Max, x)
         l = -1
@@ -381,6 +391,7 @@ const MOI = MathOptInterface
         @test JuMP.objective_value(m) ≈ u atol=1e-6
 
         @NLobjective(m, Min, x)
+        set_silent(m)
         JuMP.optimize!(m)
 
         @test JuMP.has_values(m)
@@ -390,12 +401,13 @@ const MOI = MathOptInterface
     end
 
     @testset "Two-sided constraints (no macros)" begin
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
         @variable(m, x)
         JuMP.set_NL_objective(m, MOI.MAX_SENSE, x)
         l = -1
         u = 1
         JuMP.add_NL_constraint(m, :($l <= $x <= $u))
+        set_silent(m)
         JuMP.optimize!(m)
 
         @test JuMP.has_values(m)
@@ -413,7 +425,7 @@ const MOI = MathOptInterface
     end
 
     @testset "Duals" begin
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
         @variable(m, x >= 0)
         @variable(m, y <= 5)
         @variable(m, 2 <= z <= 4)
@@ -456,6 +468,7 @@ const MOI = MathOptInterface
             @test JuMP.dual(cons3) ≈ -0.0714286 atol=1e-6
         end
 
+        set_silent(m)
         JuMP.optimize!(m)
         test_result()
         @test JuMP.objective_value(m) ≈ -5.8446115 atol=1e-6
@@ -469,11 +482,12 @@ const MOI = MathOptInterface
     end
 
     @testset "Quadratic inequality constraints, linear objective" begin
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
         @variable(m, -2 <= x <= 2)
         @variable(m, -2 <= y <= 2)
         @objective(m, Min, x - y)
         @constraint(m, x + x^2 + x*y + y^2 <= 1)
+        set_silent(m)
         JuMP.optimize!(m)
 
         @test JuMP.has_values(m)
@@ -484,11 +498,12 @@ const MOI = MathOptInterface
     end
 
     @testset "Quadratic inequality constraints, NL objective" begin
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
         @variable(m, -2 <= x <= 2)
         @variable(m, -2 <= y <= 2)
         @NLobjective(m, Min, x - y)
         @constraint(m, x + x^2 + x*y + y^2 <= 1)
+        set_silent(m)
         JuMP.optimize!(m)
 
         @test JuMP.has_values(m)
@@ -499,10 +514,11 @@ const MOI = MathOptInterface
     end
 
     @testset "Quadratic equality constraints" begin
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
         @variable(m, 0 <= x[1:2] <= 1)
         @constraint(m, x[1]^2 + x[2]^2 == 1/2)
         @NLobjective(m, Max, x[1] - x[2])
+        set_silent(m)
         JuMP.optimize!(m)
 
         @test JuMP.has_values(m)
@@ -513,7 +529,8 @@ const MOI = MathOptInterface
     end
 
     @testset "Fixed variables" begin
-        m = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        m = Model(Ipopt.Optimizer)
+        set_silent(m)
         @variable(m, x == 0)
         @variable(m, y ≥ 0)
         @objective(m, Min, y)
@@ -526,10 +543,11 @@ const MOI = MathOptInterface
     end
 
     @testset "ifelse" begin
-        model = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        model = Model(Ipopt.Optimizer)
         @variable(model, x, start = 2)
         # The minimizer is at smooth point, so solvers should be okay.
         @NLobjective(model, Min, ifelse( x <= 1, x^2, x) )
+        set_silent(model)
         JuMP.optimize!(model)
 
         @test JuMP.termination_status(model) == MOI.LOCALLY_SOLVED
@@ -539,31 +557,34 @@ const MOI = MathOptInterface
 
     @testset "infeasible problem" begin
         # (Attempt to) solve an infeasible problem
-        model = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        model = Model(Ipopt.Optimizer)
         n = 10
         @variable(model, 0 <= x[i=1:n] <= 1)
         @NLobjective(model, Max, x[n])
         for i in 1:n-1
             @NLconstraint(model, x[i+1]-x[i] == 0.15)
         end
+        set_silent(model)
         JuMP.optimize!(model)
 
         @test JuMP.termination_status(model) == MOI.LOCALLY_INFEASIBLE
     end
 
     @testset "unbounded problem" begin
-        model = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        model = Model(Ipopt.Optimizer)
         @variable(model, x >= 0)
         @NLobjective(model, Max, x)
         @NLconstraint(model, x >= 5)
+        set_silent(model)
         JuMP.optimize!(model)
         @test JuMP.termination_status(model) == MOI.NORM_LIMIT
     end
 
     @testset "Derivatives of x^4, x < 0" begin
-        model = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        model = Model(Ipopt.Optimizer)
         @variable(model, x >= -1, start = -0.5)
         @NLobjective(model, Min, x^4)
+        set_silent(model)
         JuMP.optimize!(model)
 
         @test JuMP.termination_status(model) == MOI.LOCALLY_SOLVED
@@ -573,7 +594,7 @@ const MOI = MathOptInterface
 
     # This test seems to be checking for a bug in expression handling.
     @testset "Entropy maximization" begin
-        model = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        model = Model(Ipopt.Optimizer)
         @variable(model, x[1:4] >= 0, start = 1)
         @variable(model, z[1:4], start = 0)
         @NLexpression(model, entropy[i=1:4], -x[i] * log(x[i]))
@@ -583,6 +604,7 @@ const MOI = MathOptInterface
         @NLconstraint(model, z_constr1_dup[i=2], z[i] <= entropy[i]) # duplicate expressions
         @NLconstraint(model, z_constr2[i=3:4], z[i] <= 2 * entropy[i])
         @constraint(model, sum(x) == 1)
+        set_silent(model)
         JuMP.optimize!(model)
 
         @test JuMP.termination_status(model) == MOI.LOCALLY_SOLVED
@@ -592,7 +614,7 @@ const MOI = MathOptInterface
     end
 
     @testset "Changing objectives" begin
-        model = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        model = Model(Ipopt.Optimizer)
         @variable(model, x >= 0)
         @variable(model, y >= 0)
         @objective(model, Max, x + y)
@@ -603,6 +625,7 @@ const MOI = MathOptInterface
         @test JuMP.objective_value(model) ≈ 1.0 atol=1e-4
 
         @objective(model, Max, 2x + y)
+        set_silent(model)
         JuMP.optimize!(model)
         @test JuMP.value(x) ≈ 1.0 atol=1e-4
         @test JuMP.value(y) ≈ 0.0 atol=1e-4
@@ -610,7 +633,7 @@ const MOI = MathOptInterface
     end
 
     @testset "Setting NLobjective then objective" begin
-        model = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        model = Model(Ipopt.Optimizer)
         @variable(model, x >= 0)
         @variable(model, y >= 0)
         @NLobjective(model, Max, x + y)
@@ -621,6 +644,7 @@ const MOI = MathOptInterface
         @test JuMP.objective_value(model) ≈ 1.0 atol=1e-4
 
         @objective(model, Max, 2x + y)
+        set_silent(model)
         JuMP.optimize!(model)
         @test JuMP.value(x) ≈ 1.0 atol=1e-4
         @test JuMP.value(y) ≈ 0.0 atol=1e-4
@@ -633,13 +657,14 @@ const MOI = MathOptInterface
     end
 
     @testset "User-defined functions" begin
-        model = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        model = Model(Ipopt.Optimizer)
         JuMP.register(model, :my_f, 2, my_f, autodiff=true)
         JuMP.register(model, :my_square, 1, my_square, autodiff=true)
 
         @variable(model, x[1:2] >= 0.5)
         @NLobjective(model, Min, my_f(x[1], my_square(x[2])))
 
+        set_silent(model)
         JuMP.optimize!(model)
         @test JuMP.termination_status(model) == MOI.LOCALLY_SOLVED
         @test JuMP.primal_status(model) == MOI.FEASIBLE_POINT
@@ -647,13 +672,14 @@ const MOI = MathOptInterface
     end
 
     @testset "Univariate user-defined functions" begin
-        model = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        model = Model(Ipopt.Optimizer)
         JuMP.register(model, :my_square, 1, my_square, autodiff=true)
 
         # Test just univariate functions because this is a path where hessians
         # are enabled.
         @variable(model, x[1:2] >= 0.5)
         @NLobjective(model, Min, my_square(x[1]-0.4) + my_square(x[2] - 2.0))
+        set_silent(model)
         JuMP.optimize!(model)
         @test JuMP.termination_status(model) == MOI.LOCALLY_SOLVED
         @test JuMP.primal_status(model) == MOI.FEASIBLE_POINT
@@ -661,10 +687,11 @@ const MOI = MathOptInterface
     end
 
     @testset "Issue #927" begin
-        model = Model(with_optimizer(Ipopt.Optimizer, print_level=0))
+        model = Model(Ipopt.Optimizer)
         JuMP.register(model, :my_f, 2, my_f, autodiff=true)
         @variable(model, x)
         @NLobjective(model, Min, my_f(x, x))
+        set_silent(model)
         JuMP.optimize!(model)
         @test JuMP.termination_status(model) == MOI.LOCALLY_SOLVED
         @test JuMP.primal_status(model) == MOI.FEASIBLE_POINT

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -5,7 +5,7 @@ struct DummyOptimizer <: MOI.AbstractOptimizer end
 MOI.is_empty(::DummyOptimizer) = true
 
 @testset "Unsupported objective_function" begin
-    model = Model(with_optimizer(DummyOptimizer))
+    model = Model(DummyOptimizer)
     func = MOI.SingleVariable(MOI.VariableIndex(1))
     @test_throws ErrorException JuMP.set_objective_function(model, func)
 end


### PR DESCRIPTION
`with_optimizer(Ipopt.Optimizer)` becomes simply `Ipopt.Optimizer`

`set_optimizer(model, with_optimizer(Ipopt.Optimizer, print_level=0))` becomes `set_optimizer(model, Ipopt.Optimizer); set_parameter(model, "print_level", 0)`

`set_optimizer(model, with_optimizer(Gurobi.Optimizer, gurobi_env))` becomes `set_optimizer(model, () -> Gurobi.Optimizer(gurobi_env))`. (This should be a relatively rare case.)

Motivation:
The ability to pass solver parameters to solver constructors is now redundant with `set_parameter`. Passing these through `with_optimizer` is cute syntax but IMO worse than `set_parameter` because 1) the syntax is a bit surprising (it's the only instance of a [fluent](https://en.wikipedia.org/wiki/Fluent_interface)-like API in JuMP), and 2) the parameters are harder to access and manipulate inside of the `OptimizerFactory`. Solvers should stop accepting parameters in their constructors once `with_optimizer` is fully removed (in JuMP 0.22?).