### PR TITLE
Add indicator syntax to @constraint

### DIFF
--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -514,13 +514,13 @@ julia> @variable(model, a, Bin)
 a
 
 julia> @constraint(model, a => x + y <= 1)
-[a, x + y] ∈ MathOptInterface.IndicatorSet{MathOptInterface.ACTIVATE_ON_ONE,MathOptInterface.LessThan{Float64}}(MathOptInterface.LessThan{Float64}(1.0))
+a => x + y ≤ 1.0
 ```
 If instead the constraint should hold when `a` is zero, simply add a `!` before
 the binary variable.
 ```jldoctest indicator
 julia> @constraint(model, !a => x + y <= 1)
-[a, x + y] ∈ MathOptInterface.IndicatorSet{MathOptInterface.ACTIVATE_ON_ZERO,MathOptInterface.LessThan{Float64}}(MathOptInterface.LessThan{Float64}(1.0))
+!a => x + y ≤ 1.0
 ```
 
 ## Semidefinite constraints

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -497,6 +497,32 @@ julia> @constraint(model, x in MOI.SOS2([3.0, 1.0, 2.0]))
 [x[1], x[2], x[3]] in MathOptInterface.SOS2{Float64}([3.0, 1.0, 2.0])
 ```
 
+## Indicator constraints
+
+JuMP provides a special syntax for creating indicator constraints, that is,
+enforce a constraint to hold depending on the value of a binary variable.
+In order to constrain the constraint `x + y <= 1` to hold when a binary
+variable `a` is one, use the following syntax:
+```jldoctest indicator; setup=:(model = Model())
+julia> @variable(model, x)
+x
+
+julia> @variable(model, y)
+y
+
+julia> @variable(model, a, Bin)
+a
+
+julia> @constraint(model, a => x + y <= 1)
+[a, x + y] ∈ MathOptInterface.IndicatorSet{MathOptInterface.ACTIVATE_ON_ONE,MathOptInterface.LessThan{Float64}}(MathOptInterface.LessThan{Float64}(1.0))
+```
+If instead the constraint should hold when `a` is zero, simply add a `!` before
+the binary variable.
+```jldoctest indicator
+julia> @constraint(model, !a => x + y <= 1)
+[a, x + y] ∈ MathOptInterface.IndicatorSet{MathOptInterface.ACTIVATE_ON_ZERO,MathOptInterface.LessThan{Float64}}(MathOptInterface.LessThan{Float64}(1.0))
+```
+
 ## Semidefinite constraints
 
 JuMP provides a special syntax for constraining a matrix to be symmetric

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -516,8 +516,8 @@ a
 julia> @constraint(model, a => {x + y <= 1})
 a => {x + y ≤ 1.0}
 ```
-If instead the constraint should hold when `a` is zero, simply add a `!` before
-the binary variable.
+If instead the constraint should hold when `a` is zero, simply add a `!` or `¬`
+before the binary variable.
 ```jldoctest indicator
 julia> @constraint(model, !a => {x + y <= 1})
 !a => {x + y ≤ 1.0}

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -513,14 +513,14 @@ y
 julia> @variable(model, a, Bin)
 a
 
-julia> @constraint(model, a => x + y <= 1)
-a => x + y ≤ 1.0
+julia> @constraint(model, a => {x + y <= 1})
+a => {x + y ≤ 1.0}
 ```
 If instead the constraint should hold when `a` is zero, simply add a `!` before
 the binary variable.
 ```jldoctest indicator
-julia> @constraint(model, !a => x + y <= 1)
-!a => x + y ≤ 1.0
+julia> @constraint(model, !a => {x + y <= 1})
+!a => {x + y ≤ 1.0}
 ```
 
 ## Semidefinite constraints

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -696,6 +696,8 @@ include("quad_expr.jl")
 
 include("sets.jl")
 
+# Indicator constraint
+include("indicator.jl")
 # SDConstraint
 include("sd.jl")
 

--- a/src/indicator.jl
+++ b/src/indicator.jl
@@ -1,3 +1,11 @@
+#  Copyright 2017, Iain Dunning, Joey Huchette, Miles Lubin, and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file extends JuMP to indicator constraints. It is a good example of how
+# JuMP can be extended.
+
 function build_indicator_constraint(
     _error::Function, variable::JuMP.AbstractVariableRef, constraint::JuMP.ScalarConstraint, ::Type{MOI.IndicatorSet{A}}) where A
 
@@ -34,4 +42,15 @@ function parse_one_operator_constraint(
         buildcall = :(build_indicator_constraint($_error, $(esc(variable)), $rhs_buildcall, $S))
     end
     return rhs_parsecode, buildcall
+end
+
+function constraint_string(
+    print_mode, constraint::VectorConstraint{F, <:MOI.IndicatorSet{A}}) where {F, A}
+    var_str = function_string(print_mode, constraint.func[1])
+    if A == MOI.ACTIVATE_ON_ZERO
+        var_str = "!" * var_str
+    end
+    con = ScalarConstraint(constraint.func[2], constraint.set.set)
+    con_str = constraint_string(print_mode, con)
+    return var_str * " => " * con_str
 end

--- a/src/indicator.jl
+++ b/src/indicator.jl
@@ -1,0 +1,37 @@
+function build_indicator_constraint(
+    _error::Function, variable::JuMP.AbstractVariableRef, constraint::JuMP.ScalarConstraint, ::Type{MOI.IndicatorSet{A}}) where A
+
+    set = MOI.IndicatorSet{A}(moi_set(constraint))
+    return VectorConstraint([variable, jump_function(constraint)], set)
+end
+function _indicator_variable_set(::Function, variable::Symbol)
+    return variable, MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}
+end
+function _indicator_variable_set(_error::Function, expr::Expr)
+    if expr.args[1] == :¬ || expr.args[1] == :!
+        if length(expr.args) != 2
+            _error("Invalid binary variable expression `$(expr)` for indicator constraint.")
+        end
+        return expr.args[2], MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO}
+    else
+        return expr, MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}
+    end
+end
+function parse_one_operator_constraint(
+    _error::Function, vectorized::Bool, ::Union{Val{:(=>)}, Val{:⇒}}, lhs, rhs)
+
+    variable, S = _indicator_variable_set(_error, lhs)
+    if !(rhs isa Expr)
+        _error("Invalid right-hand side `$(rhs)`.")
+    end
+    rhs_vectorized, rhs_parsecode, rhs_buildcall = parse_constraint(_error, rhs.args...)
+    if vectorized != rhs_vectorized
+        _error("Inconsistent use of `.` in symbols to indicate vectorization.")
+    end
+    if vectorized
+        buildcall = :(build_indicator_constraint.($_error, $(esc(variable)), $rhs_buildcall, $S))
+    else
+        buildcall = :(build_indicator_constraint($_error, $(esc(variable)), $rhs_buildcall, $S))
+    end
+    return rhs_parsecode, buildcall
+end

--- a/src/indicator.jl
+++ b/src/indicator.jl
@@ -7,7 +7,8 @@
 # JuMP can be extended.
 
 function build_indicator_constraint(
-    _error::Function, variable::JuMP.AbstractVariableRef, constraint::JuMP.ScalarConstraint, ::Type{MOI.IndicatorSet{A}}) where A
+    _error::Function, variable::JuMP.AbstractVariableRef,
+    constraint::JuMP.ScalarConstraint, ::Type{MOI.IndicatorSet{A}}) where A
 
     set = MOI.IndicatorSet{A}(moi_set(constraint))
     return VectorConstraint([variable, jump_function(constraint)], set)
@@ -29,7 +30,7 @@ function parse_one_operator_constraint(
     _error::Function, vectorized::Bool, ::Union{Val{:(=>)}, Val{:⇒}}, lhs, rhs)
 
     variable, S = _indicator_variable_set(_error, lhs)
-    if !(rhs isa Expr) || rhs.head != :braces || length(rhs.args) != 1
+    if !isexpr(rhs, :braces) || length(rhs.args) != 1
         _error("Invalid right-hand side `$(rhs)` of indicator constraint. Expected constraint surrounded by `{` and `}`.")
     end
     rhs_con = rhs.args[1]
@@ -47,6 +48,7 @@ end
 
 function constraint_string(
     print_mode, constraint::VectorConstraint{F, <:MOI.IndicatorSet{A}}) where {F, A}
+    # TODO Implement pretty IJulia printing
     var_str = function_string(print_mode, constraint.func[1])
     if A == MOI.ACTIVATE_ON_ZERO
         var_str = "!" * var_str

--- a/src/indicator.jl
+++ b/src/indicator.jl
@@ -29,10 +29,11 @@ function parse_one_operator_constraint(
     _error::Function, vectorized::Bool, ::Union{Val{:(=>)}, Val{:⇒}}, lhs, rhs)
 
     variable, S = _indicator_variable_set(_error, lhs)
-    if !(rhs isa Expr)
-        _error("Invalid right-hand side `$(rhs)`.")
+    if !(rhs isa Expr) || rhs.head != :braces || length(rhs.args) != 1
+        _error("Invalid right-hand side `$(rhs)` of indicator constraint. Expected constraint surrounded by `{` and `}`.")
     end
-    rhs_vectorized, rhs_parsecode, rhs_buildcall = parse_constraint(_error, rhs.args...)
+    rhs_con = rhs.args[1]
+    rhs_vectorized, rhs_parsecode, rhs_buildcall = parse_constraint(_error, rhs_con.args...)
     if vectorized != rhs_vectorized
         _error("Inconsistent use of `.` in symbols to indicate vectorization.")
     end
@@ -52,5 +53,5 @@ function constraint_string(
     end
     con = ScalarConstraint(constraint.func[2], constraint.set.set)
     con_str = constraint_string(print_mode, con)
-    return var_str * " => " * con_str
+    return var_str * " => {" * con_str * "}"
 end

--- a/src/indicator.jl
+++ b/src/indicator.jl
@@ -6,7 +6,7 @@
 # This file extends JuMP to indicator constraints. It is a good example of how
 # JuMP can be extended.
 
-function build_indicator_constraint(
+function _build_indicator_constraint(
     _error::Function, variable::JuMP.AbstractVariableRef,
     constraint::JuMP.ScalarConstraint, ::Type{MOI.IndicatorSet{A}}) where A
 
@@ -39,9 +39,9 @@ function parse_one_operator_constraint(
         _error("Inconsistent use of `.` in symbols to indicate vectorization.")
     end
     if vectorized
-        buildcall = :(build_indicator_constraint.($_error, $(esc(variable)), $rhs_buildcall, $S))
+        buildcall = :(_build_indicator_constraint.($_error, $(esc(variable)), $rhs_buildcall, $S))
     else
-        buildcall = :(build_indicator_constraint($_error, $(esc(variable)), $rhs_buildcall, $S))
+        buildcall = :(_build_indicator_constraint($_error, $(esc(variable)), $rhs_buildcall, $S))
     end
     return rhs_parsecode, buildcall
 end

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -239,6 +239,37 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel},
         @test_throws err @constraint(model, [3, x] in SecondOrderCone())
     end
 
+    @testset "Indicator constraint" begin
+        model = ModelType()
+        @variable(model, a, Bin)
+        @variable(model, b, Bin)
+        @variable(model, x)
+        @variable(model, y)
+        for cref in [
+            @constraint(model, a => x + 2y <= 1),
+            @constraint(model, a ⇒  x + 2y ≤ 1)
+        ]
+            c = JuMP.constraint_object(cref)
+            @test c.func == [a, x + 2y]
+            @test c.set == MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(1.0))
+        end
+        for cref in [
+            @constraint(model, !b => 2x + y <= 1);
+            @constraint(model, ¬b ⇒  2x + y ≤ 1);
+            @constraint(model, ![b, b] .=> [2x + y, 2x + y] .≤ 1);
+        ]
+            c = JuMP.constraint_object(cref)
+            @test c.func == [b, 2x + y]
+            @test c.set == MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO}(MOI.LessThan(1.0))
+        end
+        err = ErrorException("In `@constraint(model, !(a, b) => x <= 1)`: Invalid binary variable expression `!(a, b)` for indicator constraint.")
+        @test_macro_throws err @constraint(model, !(a, b) => x <= 1)
+        err = ErrorException("In `@constraint(model, a => x)`: Invalid right-hand side `x`.")
+        @test_macro_throws err @constraint(model, a => x)
+        err = ErrorException("In `@constraint(model, [a, b] .=> x + y <= 1)`: Inconsistent use of `.` in symbols to indicate vectorization.")
+        @test_macro_throws err @constraint(model, [a, b] .=> x + y <= 1)
+    end
+
     @testset "SDP constraint" begin
         m = ModelType()
         @variable(m, x)

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -256,6 +256,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel},
         for cref in [
             @constraint(model, !b => {2x + y <= 1});
             @constraint(model, ¬b ⇒  {2x + y ≤ 1});
+            # This returns a vector of constraints that is concatenated.
             @constraint(model, ![b, b] .=> {[2x + y, 2x + y] .≤ 1});
         ]
             c = JuMP.constraint_object(cref)

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -246,28 +246,32 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel},
         @variable(model, x)
         @variable(model, y)
         for cref in [
-            @constraint(model, a => x + 2y <= 1),
-            @constraint(model, a ⇒  x + 2y ≤ 1)
+            @constraint(model, a => {x + 2y <= 1}),
+            @constraint(model, a ⇒  {x + 2y ≤ 1})
         ]
             c = JuMP.constraint_object(cref)
             @test c.func == [a, x + 2y]
             @test c.set == MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(1.0))
         end
         for cref in [
-            @constraint(model, !b => 2x + y <= 1);
-            @constraint(model, ¬b ⇒  2x + y ≤ 1);
-            @constraint(model, ![b, b] .=> [2x + y, 2x + y] .≤ 1);
+            @constraint(model, !b => {2x + y <= 1});
+            @constraint(model, ¬b ⇒  {2x + y ≤ 1});
+            @constraint(model, ![b, b] .=> {[2x + y, 2x + y] .≤ 1});
         ]
             c = JuMP.constraint_object(cref)
             @test c.func == [b, 2x + y]
             @test c.set == MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO}(MOI.LessThan(1.0))
         end
-        err = ErrorException("In `@constraint(model, !(a, b) => x <= 1)`: Invalid binary variable expression `!(a, b)` for indicator constraint.")
-        @test_macro_throws err @constraint(model, !(a, b) => x <= 1)
-        err = ErrorException("In `@constraint(model, a => x)`: Invalid right-hand side `x`.")
+        err = ErrorException("In `@constraint(model, !(a, b) => {x <= 1})`: Invalid binary variable expression `!(a, b)` for indicator constraint.")
+        @test_macro_throws err @constraint(model, !(a, b) => {x <= 1})
+        err = ErrorException("In `@constraint(model, a => x)`: Invalid right-hand side `x` of indicator constraint. Expected constraint surrounded by `{` and `}`.")
         @test_macro_throws err @constraint(model, a => x)
-        err = ErrorException("In `@constraint(model, [a, b] .=> x + y <= 1)`: Inconsistent use of `.` in symbols to indicate vectorization.")
-        @test_macro_throws err @constraint(model, [a, b] .=> x + y <= 1)
+        err = ErrorException("In `@constraint(model, a => x <= 1)`: Invalid right-hand side `x <= 1` of indicator constraint. Expected constraint surrounded by `{` and `}`.")
+        @test_macro_throws err @constraint(model, a => x <= 1)
+        err = ErrorException("In `@constraint(model, a => {x <= 1, x >= 0})`: Invalid right-hand side `{x <= 1, x >= 0}` of indicator constraint. Expected constraint surrounded by `{` and `}`.")
+        @test_macro_throws err @constraint(model, a => {x <= 1, x >= 0})
+        err = ErrorException("In `@constraint(model, [a, b] .=> {x + y <= 1})`: Inconsistent use of `.` in symbols to indicate vectorization.")
+        @test_macro_throws err @constraint(model, [a, b] .=> {x + y <= 1})
     end
 
     @testset "SDP constraint" begin

--- a/test/print.jl
+++ b/test/print.jl
@@ -344,7 +344,7 @@ function printing_test(ModelType::Type{<:JuMP.AbstractModel})
         io_test(REPLMode, quad_constr, "2 x$sq $le 1.0")
         # TODO: Test in IJulia mode.
     end
-    @testset "Scalar QuadExpr constraints" begin
+    @testset "Scalar Indicator constraints" begin
         le = JuMP._math_symbol(REPLMode, :leq)
 
         model = ModelType()

--- a/test/print.jl
+++ b/test/print.jl
@@ -350,9 +350,9 @@ function printing_test(ModelType::Type{<:JuMP.AbstractModel})
         model = ModelType()
         @variable(model, x, Bin)
         @variable(model, y)
-        ind_constr = @constraint(model, !x => y <= 1)
+        ind_constr = @constraint(model, !x => {y <= 1})
 
-        io_test(REPLMode, ind_constr, "!x => y $le 1.0")
+        io_test(REPLMode, ind_constr, "!x => {y $le 1.0}")
         # TODO: Test in IJulia mode.
     end
 end

--- a/test/print.jl
+++ b/test/print.jl
@@ -344,6 +344,17 @@ function printing_test(ModelType::Type{<:JuMP.AbstractModel})
         io_test(REPLMode, quad_constr, "2 x$sq $le 1.0")
         # TODO: Test in IJulia mode.
     end
+    @testset "Scalar QuadExpr constraints" begin
+        le = JuMP._math_symbol(REPLMode, :leq)
+
+        model = ModelType()
+        @variable(model, x, Bin)
+        @variable(model, y)
+        ind_constr = @constraint(model, !x => y <= 1)
+
+        io_test(REPLMode, ind_constr, "!x => y $le 1.0")
+        # TODO: Test in IJulia mode.
+    end
 end
 
 # Test printing of models of type `ModelType` for which the model is stored in

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -27,5 +27,5 @@ end
 # Test that the macro call `m` throws an error exception during pre-compilation
 macro test_macro_throws(errortype, m)
     # See https://discourse.julialang.org/t/test-throws-with-macros-after-pr-23533/5878
-    :(@test_throws $errortype try @eval $m catch err; throw(err.error) end)
+    :(@test_throws $(esc(errortype)) try @eval $m catch err; throw(err.error) end)
 end


### PR DESCRIPTION
Add the syntax
```julia
julia> @constraint(model, a => x + y <= 1)
[a, x + y] ∈ MathOptInterface.IndicatorSet{MathOptInterface.ACTIVATE_ON_ONE,MathOptInterface.LessThan{Float64}}(MathOptInterface.LessThan{Float64}(1.0))

julia> @constraint(model, !a => x + y <= 1)
[a, x + y] ∈ MathOptInterface.IndicatorSet{MathOptInterface.ACTIVATE_ON_ZERO,MathOptInterface.LessThan{Float64}}(MathOptInterface.LessThan{Float64}(1.0))
```
to create indicator constraints.

Closes #2049