### PR TITLE
[RFC] Interpret NaN as no bound

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -51,9 +51,11 @@ end
 function _keywordify(kw::Expr)
     (kw.args[1], _esc_non_constant(kw.args[2]))
 end
+_is_nan_expr(expr::Number) = isnan(expr)
+_is_nan_expr(expr::Symbol) = expr == :NaN
+_is_nan_expr(expr) = isexpr(expr, :escape) && length(expr.args) == 1 && _is_nan_expr(expr.args[1])
 function _VariableInfoExpr(; lower_bound=NaN, upper_bound=NaN, start=NaN, binary=false, integer=false)
-    # isnan(::Expr) is not defined so we need to do !== NaN
-    _VariableInfoExpr(lower_bound !== NaN, lower_bound, upper_bound !== NaN, upper_bound, false, NaN, start !== NaN, start, binary, integer)
+    _VariableInfoExpr(!_is_nan_expr(lower_bound), lower_bound, !_is_nan_expr(upper_bound), upper_bound, false, NaN, !_is_nan_expr(start), start, binary, integer)
 end
 
 struct VariableInfo{S, T, U, V}


### PR DESCRIPTION
What do you think of the following change of behavior ?

Before:
```julia
julia> @variable(model, x >= 1, upper_bound = NaN)
x

julia> print(model)
Feasibility
Subject to
 x ≥ 1.0
 x ≤ NaN
```
After:
```julia
julia> @variable(model, x >= 1, upper_bound = NaN)
x

julia> print(model)
Feasibility
Subject to
 x ≥ 1.0
```
This fixes the use cases exposed by @ccoffrin in https://github.com/lanl-ansi/PowerModels.jl/issues/630

Have a bound of value `NaN` will have inconsistent behaviors across solvers so it makes sense to interpret it as no bounds but the issue is that this does not work:
```julia
julia> a = NaN
NaN

julia> @variable(model, x >= 1, upper_bound = a)
x

julia> print(model)
Feasibility
Subject to
 x ≥ 1.0
 x ≤ NaN
```

Once we have a consensus, I will do:

- [ ] Add tests
- [ ] Add doc