### PR TITLE
fix knapsack example (with_optimizer)

### DIFF
--- a/examples/knapsack.jl
+++ b/examples/knapsack.jl
@@ -22,7 +22,7 @@ function example_knapsack(; verbose = true)
     profit = [5, 3, 2, 7, 4]
     weight = [2, 8, 4, 2, 5]
     capacity = 10
-    model = Model(GLPK.Optimizer)
+    model = Model(with_optimizer(GLPK.Optimizer))
     @variable(model, x[1:5], Bin)
     # Objective: maximize profit
     @objective(model, Max, profit' * x)


### PR DESCRIPTION
First time experimenting Julia and JuMP... looks like knapsack example is broken. According to QuickStart, we need "with_optimizer": http://www.juliaopt.org/JuMP.jl/v0.20.0/quickstart/

This explains an ugly error I was getting:
```
julia> model = Model(GLPK.Optimizer)
ERROR: MethodError: no method matching Model(::Type{GLPK.Optimizer})
Closest candidates are:
  Model(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) at /home/imcoelho/.julia/packages/JuMP/MsUSY/src/JuMP.jl:126
  Model(; caching_mode, solver) at /home/imcoelho/.julia/packages/JuMP/MsUSY/src/JuMP.jl:163
  Model(::MathOptInterface.AbstractOptimizer, ::Dict{MathOptInterface.ConstraintIndex,AbstractShape}, ::Set{Any}, ::Any, ::Any, ::Dict{Symbol,Any}, ::Int32, ::Dict{Symbol,Any}) at /home/imcoelho/.julia/packages/JuMP/MsUSY/src/JuMP.jl:126
  ...
Stacktrace:
 [1] top-level scope at none:0
```