### PR TITLE
Clearer warning about examples version mismatch

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,10 +1,5 @@
+> :warning: If you are viewing the examples on GitHub, make sure that they match the version of JuMP that you have installed. The JuMP examples for version 0.xx will be on the `release-0.xx` branch. You can also follow the links to examples in the main JuMP readme.
+
 # JuMP Examples
 
 This folder contains a number of examples using JuMP.
-
-## Note
-
-These examples are for the latest JuMP master branch. 
-
-If you're using JuMP 0.18 (or if you get an error about `MathOptInterface` not defined), you're probably after
-[the examples for the `release-0.18` branch](https://github.com/JuliaOpt/JuMP.jl/tree/release-0.18/examples).


### PR DESCRIPTION
See discussion at PR #2116.

@igormcoelho, does this address your concern?

> On "Documentation" for release-2.0, write something like "Documentation (0.20)".
> On "Examples" for release-2.0, write something like "Examples (0.20)"

I'd prefer not to add more hard-coded version numbers to the README, it makes the release process more complicated and has the potential to accidentally fall out of sync.