### PR TITLE
Constrained variables with @variable

### DIFF
--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -607,7 +607,10 @@ julia> @variable(model, y[1:3])
 julia> @constraint(model, y in SecondOrderCone())
 [y[1], y[2], y[3]] ∈ MathOptInterface.SecondOrderCone(3)
 ```
-The variables `x` are called *constrained variables*.
+The variables `x` in the example above are called *constrained variables* in
+contrast which the variables `y` which are called *free variables* because
+the constraint added on the variables is added after their creation as free
+variables.
 
 !!! warn
     When using JuMP in [Direct mode](@ref), it may be required to create

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -402,7 +402,7 @@ of tuples or create a dictionary. Consider the following examples:
 N = 10
 S = [(1, 1, 1),(N, N, N)]
 # Slow. It evaluates conditional N^3 times.
-@variable(model, x1[i=1:N, j=1:N, k=1:N; (i, j, k) in S]) 
+@variable(model, x1[i=1:N, j=1:N, k=1:N; (i, j, k) in S])
 # Fast.
 @variable(model, x2[S])
 # Fast. Manually constructs a dictionary and fills it.
@@ -611,6 +611,16 @@ The variables `x` in the example above are called *constrained variables* in
 contrast which the variables `y` which are called *free variables* because
 the constraint added on the variables is added after their creation as free
 variables.
+
+!!! note
+    Variable bounds and integrality constraints are specified when variables
+    are created, but they don't involve constrained variables, unless you
+    explicitly use the `in` syntax or the `set` keyword. For instance,
+    `@variable(model, z <= 1, Int)` and `@variable(model, upper_bound = 1,
+    integer = true)` are not constrained variables but `@variable(model,
+    z in MOI.LessThan(1.0), Int)` is a constrained variable in
+    `MOI.LessThan(1.0)` and `@variable(model, lower_bound = 1.0,
+    set = MOI.Integer())` is a constrained variable in `MOI.Integer()`.
 
 !!! warn
     When using JuMP in [Direct mode](@ref), it may be required to create

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -521,6 +521,13 @@ julia> @variable(model, x[1:2, 1:2], PSD)
  x[1,1]  x[1,2]
  x[1,2]  x[2,2]
 ```
+or using the [Constrained variables](@ref) syntax:
+```jldoctest; setup=:(model=Model())
+julia> @variable(model, x[1:2, 1:2] in PSDCone())
+2×2 LinearAlgebra.Symmetric{VariableRef,Array{VariableRef,2}}:
+ x[1,1]  x[1,2]
+ x[1,2]  x[2,2]
+```
 
 Note that `x` must be a square 2-dimensional `Array` of JuMP variables; it
 cannot be a DenseAxisArray or a SparseAxisArray.
@@ -579,6 +586,44 @@ julia> x = @variable(model, [i=1:2], base_name="x", lower_bound=i, integer=true)
 !!! warn
     Creating two named JuMP variables with the same name results in an error at
     runtime. Use anonymous variables as an alternative.
+
+## Constrained variables
+
+To create variables constrained to belong to the [`SecondOrderCone`](@ref) either
+of the following two methods can be used:
+```jldoctest constrained_variables; setup=:(model=Model())
+julia> @variable(model, x[1:3] in SecondOrderCone())
+3-element Array{VariableRef,1}:
+ x[1]
+ x[2]
+ x[3]
+
+julia> @variable(model, y[1:3])
+3-element Array{VariableRef,1}:
+ y[1]
+ y[2]
+ y[3]
+
+julia> @constraint(model, y in SecondOrderCone())
+[y[1], y[2], y[3]] ∈ MathOptInterface.SecondOrderCone(3)
+```
+The variables `x` are called *constrained variables*.
+
+!!! warn
+    When using JuMP in [Direct mode](@ref), it may be required to create
+    constrained variables instead of constraining free variables as the solver
+    may only support constrained variables. In [Automatic and Manual modes](@ref),
+    both ways of adding constraints on variables are equivalent. Indeed, during
+    the copy of the cache to the optimizer, the choice of the constraints on
+    variables that are copied as constrained variables does not depend on
+    how it was added to the cache.
+
+Additionally to the `in` syntax, the set can be specified with the `set` keyword
+argument. This is useful when creating anonymous scalar variables:
+```jldoctest constrained_variables
+julia> z = @variable(model, set = MOI.Semiinteger(1.0, 2.0))
+noname
+```
 
 ## User-defined containers
 

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -589,6 +589,15 @@ julia> x = @variable(model, [i=1:2], base_name="x", lower_bound=i, integer=true)
 
 ## Variables constrained on creation
 
+!!! info
+    When using JuMP in [Direct mode](@ref), it may be required to constrain
+    variables on creation instead of constraining free variables as the solver
+    may only support variables constrained on creation. In [Automatic and Manual
+    modes](@ref), both ways of adding constraints on variables are equivalent.
+    Indeed, during the copy of the cache to the optimizer, the choice of the
+    constraints on variables that are copied as variables constrained on creation
+    does not depend on how it was added to the cache.
+
 By default, `@variable(model, x)` creates a _free_ variable that belongs to the
 set of real numbers.
 
@@ -628,7 +637,7 @@ julia> @variable(model, y[1:3] in SecondOrderCone())
  y[2]
  y[3]
 ```
-Importantly, in [Direct mode](@ref) and for some solver, the second-order
+Importantly, in [Direct mode](@ref) and for some solvers, the second-order
 constraint cannot be deleted without deleting the variables `y`.
 
 ### The `set` keyword
@@ -638,15 +647,6 @@ An alternate syntax to `x in Set` is to use the `set` keyword of
 ```julia
 x = @variable(model, [1:2, 1:2], set = PSDCone())
 ```
-
-!!! info
-    When using JuMP in [Direct mode](@ref), it may be required to constrain
-    variables on creation instead of constraining free variables as the solver
-    may only support variables constrained on creation. In [Automatic and Manual
-    modes](@ref), both ways of adding constraints on variables are equivalent.
-    Indeed, during the copy of the cache to the optimizer, the choice of the
-    constraints on variables that are copied as variables constrained on creation
-    does not depend on how it was added to the cache.
 
 ## User-defined containers
 

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -521,7 +521,7 @@ julia> @variable(model, x[1:2, 1:2], PSD)
  x[1,1]  x[1,2]
  x[1,2]  x[2,2]
 ```
-or using the [Constrained variables](@ref) syntax:
+or using the syntax for [Variables constrained on creation](@ref):
 ```jldoctest; setup=:(model=Model())
 julia> @variable(model, x[1:2, 1:2] in PSDCone())
 2×2 LinearAlgebra.Symmetric{VariableRef,Array{VariableRef,2}}:
@@ -587,56 +587,66 @@ julia> x = @variable(model, [i=1:2], base_name="x", lower_bound=i, integer=true)
     Creating two named JuMP variables with the same name results in an error at
     runtime. Use anonymous variables as an alternative.
 
-## Constrained variables
+## Variables constrained on creation
 
-To create variables constrained to belong to the [`SecondOrderCone`](@ref) either
-of the following two methods can be used:
+By default, `@variable(model, x)` creates a _free_ variable that belongs to the
+set of real numbers.
+
+If you add constraints, such as `@variable(model, x >= 0, Int)`, then the
+`@variable` macro is equivalent to:
+```julia
+@variable(model, x)
+@constraint(model, x in MOI.GreaterThan(0.0))
+@constraint(model, x in MOI.Integer())
+```
+Importantly, the bound and integrality constraints are added _after_ the
+variable has been created.
+
+However, in some cases, it is necessary to supply a constraining set _at
+creation time_. We call these variables _variables constrained on creation_ to
+differentiate them from _variables free on creation_.
+
+For example, one way to create a vector of variables constrained to the second
+order cone is as follows:
 ```jldoctest constrained_variables; setup=:(model=Model())
-julia> @variable(model, x[1:3] in SecondOrderCone())
+julia> @variable(model, x[1:3])
 3-element Array{VariableRef,1}:
  x[1]
  x[2]
  x[3]
 
-julia> @variable(model, y[1:3])
+julia> @constraint(model, x in SecondOrderCone())
+[x[1], x[2], x[3]] ∈ MathOptInterface.SecondOrderCone(3)
+```
+
+An alternative approach, creating a vector of variables constrained on creation
+to belong to the [`SecondOrderCone`](@ref) is:
+```jldoctest constrained_variables
+julia> @variable(model, y[1:3] in SecondOrderCone())
 3-element Array{VariableRef,1}:
  y[1]
  y[2]
  y[3]
-
-julia> @constraint(model, y in SecondOrderCone())
-[y[1], y[2], y[3]] ∈ MathOptInterface.SecondOrderCone(3)
 ```
-The variables `x` in the example above are called *constrained variables* in
-contrast which the variables `y` which are called *free variables* because
-the constraint added on the variables is added after their creation as free
-variables.
+Importantly, in [Direct mode](@ref) and for some solver, the second-order
+constraint cannot be deleted without deleting the variables `y`.
 
-!!! note
-    Variable bounds and integrality constraints are specified when variables
-    are created, but they don't involve constrained variables, unless you
-    explicitly use the `in` syntax or the `set` keyword. For instance,
-    `@variable(model, z <= 1, Int)` and `@variable(model, upper_bound = 1,
-    integer = true)` are not constrained variables but `@variable(model,
-    z in MOI.LessThan(1.0), Int)` is a constrained variable in
-    `MOI.LessThan(1.0)` and `@variable(model, lower_bound = 1.0,
-    set = MOI.Integer())` is a constrained variable in `MOI.Integer()`.
+### The `set` keyword
 
-!!! warn
-    When using JuMP in [Direct mode](@ref), it may be required to create
-    constrained variables instead of constraining free variables as the solver
-    may only support constrained variables. In [Automatic and Manual modes](@ref),
-    both ways of adding constraints on variables are equivalent. Indeed, during
-    the copy of the cache to the optimizer, the choice of the constraints on
-    variables that are copied as constrained variables does not depend on
-    how it was added to the cache.
-
-Additionally to the `in` syntax, the set can be specified with the `set` keyword
-argument. This is useful when creating anonymous scalar variables:
-```jldoctest constrained_variables
-julia> z = @variable(model, set = MOI.Semiinteger(1.0, 2.0))
-noname
+An alternate syntax to `x in Set` is to use the `set` keyword of
+[`@variable`](@ref). This is most useful when creating anonymous variables:
+```julia
+x = @variable(model, [1:2, 1:2], set = PSDCone())
 ```
+
+!!! info
+    When using JuMP in [Direct mode](@ref), it may be required to constrain
+    variables on creation instead of constraining free variables as the solver
+    may only support variables constrained on creation. In [Automatic and Manual
+    modes](@ref), both ways of adding constraints on variables are equivalent.
+    Indeed, during the copy of the cache to the optimizer, the choice of the
+    constraints on variables that are copied as variables constrained on creation
+    does not depend on how it was added to the cache.
 
 ## User-defined containers
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -966,6 +966,8 @@ instead of `≤` and the symbol `>=`can be used instead of `≥`)
 * of the form `lb ≤ varexpr ≤ ub` or `ub ≥ varexpr ≥ lb` creating variables
   described by `varexpr` with lower bounds given by `lb` and upper bounds given
   by `ub`.
+* of the form `varexpr in set` creating variables described by
+  `varexpr` constrained to belong to `set`, see [Constrained variables](@ref).
 
 The expression `varexpr` can either be
 
@@ -981,9 +983,11 @@ The recognized positional arguments in `args` are the following:
   when `varexpr` is of the form `varname[1:n,1:n]` or `varname[i=1:n,j=1:n]`.
   It creates a symmetric matrix of variable, that is, it only creates a
   new variable for `varname[i,j]` with `i ≤ j` and sets `varname[j,i]` to the
-  same variable as `varname[i,j]`.
+  same variable as `varname[i,j]`. It is equivalent to using
+  `varexpr in SymMatrixSpace()` as `expr`.
 * `PSD`: The square matrix of variable is both `Symmetric` and constrained to be
-  positive semidefinite.
+  positive semidefinite. It is equivalent to using `varexpr in PSDCone()` as
+  `expr`.
 
 The recognized keyword arguments in `kw_args` are the following:
 
@@ -997,6 +1001,8 @@ The recognized keyword arguments in `kw_args` are the following:
 * `binary`: Sets whether the variable is binary or not.
 * `integer`: Sets whether the variable is integer or not.
 * `variable_type`: See the "Note for extending the variable macro" section below.
+* `set`: Equivalent to using `varexpr in value` as `expr` where `value` is the
+  value of the keyword argument.
 * `container`: Specify the container type, see [Containers in macros](@ref).
 
 ## Examples

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1128,7 +1128,10 @@ macro variable(args...)
     end
 
     info_kw_args = filter(_is_info_keyword, kw_args)
-    extra_kw_args = filter(kw -> kw.args[1] != :base_name && kw.args[1] != :variable_type && kw.args[1] != :set && !_is_info_keyword(kw), kw_args)
+    extra_kw_args = filter(kw -> begin
+        kw.args[1] != :base_name && kw.args[1] != :variable_type &&
+        kw.args[1] != :set && !_is_info_keyword(kw)
+    end, kw_args)
     base_name_kw_args = filter(kw -> kw.args[1] == :base_name, kw_args)
     variable_type_kw_args = filter(kw -> kw.args[1] == :variable_type, kw_args)
     set_kw_args = filter(kw -> kw.args[1] == :set, kw_args)
@@ -1152,7 +1155,9 @@ macro variable(args...)
     end
 
     anonvar = isexpr(var, :vect) || isexpr(var, :vcat) || anon_singleton
-    anonvar && explicit_comparison && set === nothing && _error("Cannot use explicit bounds via >=, <= with an anonymous variable")
+    if anonvar && explicit_comparison && set === nothing
+        _error("Cannot use explicit bounds via >=, <= with an anonymous variable")
+    end
     variable = gensym()
     # TODO: Should we generate non-empty default names for variables?
     name = Containers._get_name(var)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -967,7 +967,7 @@ instead of `≤` and the symbol `>=`can be used instead of `≥`)
   described by `varexpr` with lower bounds given by `lb` and upper bounds given
   by `ub`.
 * of the form `varexpr in set` creating variables described by
-  `varexpr` constrained to belong to `set`, see [Constrained variables](@ref).
+  `varexpr` constrained to belong to `set`, see [Variables constrained on creation](@ref).
 
 The expression `varexpr` can either be
 
@@ -1176,7 +1176,7 @@ macro variable(args...)
             _error("`set` keyword argument was given $(length(set_kw_args)) times.")
         end
         if set !== nothing
-            _error("Cannot specify set of constrained variable twice, it was already set to `$set` so the `set` keyword argument is not allowed.")
+            _error("Cannot specify set twice, it was already set to `$set` so the `set` keyword argument is not allowed.")
         end
         set = esc(set_kw_args[1].args[2])
     end
@@ -1184,13 +1184,13 @@ macro variable(args...)
     # process keyword arguments
     if any(t -> (t == :PSD), extra)
         if set !== nothing
-            _error("Cannot specify set of constrained variable twice, it was already set to `$set` so the `PSD` argument is not allowed.")
+            _error("Cannot specify set twice, it was already set to `$set` so the `PSD` argument is not allowed.")
         end
         set = :(JuMP.PSDCone())
     end
     if any(t -> (t == :Symmetric), extra)
         if set !== nothing
-            _error("Cannot specify `Symmetric` on a constrained variable, the variable is constrained to belong to `$set`.")
+            _error("Cannot specify `Symmetric` when the set is already specified, the variable is constrained to belong to `$set`.")
         end
         set = :(JuMP.SymMatrixSpace())
     end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -828,11 +828,11 @@ end
 
 function build_variable(_error::Function, variable::ScalarVariable,
                         set::MOI.AbstractScalarSet)
-    return ConstrainedVariable(variable, set)
+    return VariableConstrainedOnCreation(variable, set)
 end
 function build_variable(_error::Function, variables::Vector{<:ScalarVariable},
                         set::MOI.AbstractVectorSet)
-    return ConstrainedVariables(variables, set)
+    return VariablesConstrainedOnCreation(variables, set)
 end
 
 

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -160,7 +160,7 @@ This function is used by the [`@variable`](@ref) macro as follows:
 @variable(model, Q[1:2, 1:2], Symmetric)
 ```
 """
-function build_variable(_error::Function, variables, ::SymMatrixSpace)
+function build_variable(_error::Function, variables::Matrix{<:ScalarVariable}, ::SymMatrixSpace)
     n = _square_side(_error, variables)
     set = MOI.Reals(MOI.dimension(MOI.PositiveSemidefiniteConeTriangle(n)))
     shape = SymmetricMatrixShape(n)
@@ -178,7 +178,7 @@ This function is used by the [`@variable`](@ref) macro as follows:
 @variable(model, Q[1:2, 1:2], PSD)
 ```
 """
-function build_variable(_error::Function, variables, ::PSDCone)
+function build_variable(_error::Function, variables::Matrix{<:ScalarVariable}, ::PSDCone)
     n = _square_side(_error, variables)
     set = MOI.PositiveSemidefiniteConeTriangle(n)
     shape = SymmetricMatrixShape(n)

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -151,7 +151,7 @@ end
 """
     build_constraint(_error::Function, variables, ::SymMatrixSpace)
 
-Return a `ConstrainedVariables` of shape [`SymmetricMatrixShape`](@ref)
+Return a `VariablesConstrainedOnCreation` of shape [`SymmetricMatrixShape`](@ref)
 creating variables in `MOI.Reals`, i.e. "free" variables unless they are
 constrained after their creation.
 
@@ -164,13 +164,13 @@ function build_variable(_error::Function, variables::Matrix{<:ScalarVariable}, :
     n = _square_side(_error, variables)
     set = MOI.Reals(MOI.dimension(MOI.PositiveSemidefiniteConeTriangle(n)))
     shape = SymmetricMatrixShape(n)
-    return ConstrainedVariables(_vectorize_variables(_error, variables), set, shape)
+    return VariablesConstrainedOnCreation(_vectorize_variables(_error, variables), set, shape)
 end
 
 """
     build_constraint(_error::Function, variables, ::PSDCone)
 
-Return a `ConstrainedVariables` of shape [`SymmetricMatrixShape`](@ref)
+Return a `VariablesConstrainedOnCreation` of shape [`SymmetricMatrixShape`](@ref)
 constraining the variables to be positive semidefinite.
 
 This function is used by the [`@variable`](@ref) macro as follows:
@@ -182,7 +182,7 @@ function build_variable(_error::Function, variables::Matrix{<:ScalarVariable}, :
     n = _square_side(_error, variables)
     set = MOI.PositiveSemidefiniteConeTriangle(n)
     shape = SymmetricMatrixShape(n)
-    return ConstrainedVariables(_vectorize_variables(_error, variables), set, shape)
+    return VariablesConstrainedOnCreation(_vectorize_variables(_error, variables), set, shape)
 end
 
 """

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -1,9 +1,15 @@
 abstract type AbstractVectorSet end
 
-# Used in `@constraint model f in s`
-function build_constraint(_error::Function, f::AbstractVector,
-                         s::AbstractVectorSet)
-    return build_constraint(_error, f, moi_set(s, length(f)))
+# Used in `@constraint(model, [1:n] in s)`
+function build_variable(_error::Function, variables::Vector{<:ScalarVariable},
+                        set::AbstractVectorSet)
+    return ConstrainedVariables(variables, moi_set(set, length(variables)))
+end
+
+# Used in `@constraint(model, func in set)`
+function build_constraint(_error::Function, func::AbstractVector,
+                          set::AbstractVectorSet)
+    return build_constraint(_error, func, moi_set(set, length(func)))
 end
 
 """

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -3,7 +3,7 @@ abstract type AbstractVectorSet end
 # Used in `@constraint(model, [1:n] in s)`
 function build_variable(_error::Function, variables::Vector{<:ScalarVariable},
                         set::AbstractVectorSet)
-    return ConstrainedVariables(variables, moi_set(set, length(variables)))
+    return VariablesConstrainedOnCreation(variables, moi_set(set, length(variables)))
 end
 
 # Used in `@constraint(model, func in set)`

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -3,6 +3,13 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""
+    AbstractVariable
+
+Variable returned by [`build_variable`](@ref). It represent a variable that has
+not been added yet to any model, it can be added to a given `model` with
+[`add_variable`](@ref).
+"""
 abstract type AbstractVariable end
 
 # Any fields can usually be either a number or an expression

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -815,12 +815,12 @@ function _moi_constrain_variable(backend::MOI.ModelLike, index, info)
 end
 
 """
-    ConstrainedVariables <: AbstractVariable
+    VariablesConstrainedOnCreation <: AbstractVariable
 
 Variable `scalar_variables` constrained to belong to `set`.
 Adding this variable can be understood as doing:
 ```julia
-function JuMP.add_variable(model::Model, variable::JuMP.ConstrainedVariable, names)
+function JuMP.add_variable(model::Model, variable::JuMP.VariableConstrainedOnCreation, names)
     var_ref = JuMP.add_variable(model, variable.scalar_variable, name)
     JuMP.add_constraint(model, JuMP.VectorConstraint(var_ref, variable.set))
     return var_ref
@@ -831,13 +831,13 @@ instead. See [the MOI documentation](http://www.juliaopt.org/MathOptInterface.jl
 for the difference between adding the variables with `MOI.add_constrained_variable`
 and adding them with `MOI.add_variable` and adding the constraint separately.
 """
-struct ConstrainedVariable{S <: MOI.AbstractScalarSet,
+struct VariableConstrainedOnCreation{S <: MOI.AbstractScalarSet,
                            ScalarVarType <: AbstractVariable} <: AbstractVariable
     scalar_variable::ScalarVarType
     set::S
 end
 
-function add_variable(model::Model, variable::ConstrainedVariable, name::String)
+function add_variable(model::Model, variable::VariableConstrainedOnCreation, name::String)
     var_index = _moi_add_constrained_variable(
         backend(model), variable.scalar_variable, variable.set, name)
     return VariableRef(model, var_index)
@@ -855,12 +855,12 @@ function _moi_add_constrained_variable(
 end
 
 """
-    ConstrainedVariables <: AbstractVariable
+    VariablesConstrainedOnCreation <: AbstractVariable
 
 Vector of variables `scalar_variables` constrained to belong to `set`.
 Adding this variable can be thought as doing:
 ```julia
-function JuMP.add_variable(model::Model, variable::JuMP.ConstrainedVariables, names)
+function JuMP.add_variable(model::Model, variable::JuMP.VariablesConstrainedOnCreation, names)
     var_refs = JuMP.add_variable.(model, variable.scalar_variables,
                                   JuMP.vectorize(names, variable.shape))
     JuMP.add_constraint(model, JuMP.VectorConstraint(var_refs, variable.set))
@@ -872,18 +872,18 @@ instead. See [the MOI documentation](http://www.juliaopt.org/MathOptInterface.jl
 for the difference between adding the variables with `MOI.add_constrained_variables`
 and adding them with `MOI.add_variables` and adding the constraint separately.
 """
-struct ConstrainedVariables{S <: MOI.AbstractVectorSet, Shape <: AbstractShape,
+struct VariablesConstrainedOnCreation{S <: MOI.AbstractVectorSet, Shape <: AbstractShape,
                             ScalarVarType <: AbstractVariable} <: AbstractVariable
     scalar_variables::Vector{ScalarVarType}
     set::S
     shape::Shape
 end
 
-function ConstrainedVariables(variables::Vector{<:AbstractVariable}, set::MOI.AbstractVectorSet)
-    return ConstrainedVariables(variables, set, VectorShape())
+function VariablesConstrainedOnCreation(variables::Vector{<:AbstractVariable}, set::MOI.AbstractVectorSet)
+    return VariablesConstrainedOnCreation(variables, set, VectorShape())
 end
 
-function add_variable(model::Model, variable::ConstrainedVariables, names)
+function add_variable(model::Model, variable::VariablesConstrainedOnCreation, names)
     var_indices = _moi_add_constrained_variables(
         backend(model), variable.scalar_variables, variable.set, vectorize(names, variable.shape))
     var_refs = [VariableRef(model, var_index) for var_index in var_indices]

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -6,8 +6,8 @@
 """
     AbstractVariable
 
-Variable returned by [`build_variable`](@ref). It represent a variable that has
-not been added yet to any model, it can be added to a given `model` with
+Variable returned by [`build_variable`](@ref). It represents a variable that has
+not been added yet to any model. It can be added to a given `model` with
 [`add_variable`](@ref).
 """
 abstract type AbstractVariable end
@@ -818,7 +818,7 @@ end
     ConstrainedVariables <: AbstractVariable
 
 Variable `scalar_variables` constrained to belong to `set`.
-Adding this variable can be thought as doing:
+Adding this variable can be understood as doing:
 ```julia
 function JuMP.add_variable(model::Model, variable::JuMP.ConstrainedVariable, names)
     var_ref = JuMP.add_variable(model, variable.scalar_variable, name)

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -59,12 +59,12 @@ function JuMP.add_variable(m::MyModel, v::JuMP.AbstractVariable, name::String=""
     JuMP.set_name(vref, name)
     vref
 end
-function JuMP.add_variable(model::MyModel, variable::JuMP.ConstrainedVariable, name::String)
+function JuMP.add_variable(model::MyModel, variable::JuMP.VariableConstrainedOnCreation, name::String)
     var_ref = JuMP.add_variable(model, variable.scalar_variable, name)
     JuMP.add_constraint(model, JuMP.ScalarConstraint(var_ref, variable.set))
     return var_ref
 end
-function JuMP.add_variable(model::MyModel, variable::JuMP.ConstrainedVariables, names)
+function JuMP.add_variable(model::MyModel, variable::JuMP.VariablesConstrainedOnCreation, names)
     var_refs = JuMP.add_variable.(model, variable.scalar_variables,
                                   JuMP.vectorize(names, variable.shape))
     JuMP.add_constraint(model, JuMP.VectorConstraint(var_refs, variable.set))

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -467,6 +467,39 @@ function test_variable_symmetric(ModelType)
     @test y[1, 2] === y[2, 1]
 end
 
+function test_constrained_variables(ModelType)
+    model = ModelType()
+
+    err = ErrorException("In `@variable(model, x[1:2] in SecondOrderCone(), set = PSDCone())`: Cannot specify set of constrained variable twice, it was already set to `\$(Expr(:escape, :(SecondOrderCone())))` so the `set` keyword argument is not allowed.")
+    @test_macro_throws err @variable(model, x[1:2] in SecondOrderCone(), set = PSDCone())
+    err = ErrorException("In `@variable(model, x[1:2] in SecondOrderCone(), PSD)`: Cannot specify set of constrained variable twice, it was already set to `\$(Expr(:escape, :(SecondOrderCone())))` so the `PSD` argument is not allowed.")
+    @test_macro_throws err @variable(model, x[1:2] in SecondOrderCone(), PSD)
+    err = ErrorException("In `@variable(model, x[1:2] in SecondOrderCone(), Symmetric)`: Cannot specify `Symmetric` on a constrained variable, the variable is constrained to belong to `\$(Expr(:escape, :(SecondOrderCone())))`.")
+    @test_macro_throws err @variable(model, x[1:2] in SecondOrderCone(), Symmetric)
+    err = ErrorException("In `@variable(model, x[1:2], set = SecondOrderCone(), set = PSDCone())`: `set` keyword argument was given 2 times.")
+    @test_macro_throws err @variable(model, x[1:2], set = SecondOrderCone(), set = PSDCone())
+
+    @variable(model, x[1:2] in SecondOrderCone())
+    @test num_constraints(model, typeof(x), MOI.SecondOrderCone) == 1
+    @test name(x[1]) ==  "x[1]"
+    @test name(x[2]) ==  "x[2]"
+
+    @variable(model, [1:2] in SecondOrderCone())
+    @test num_constraints(model, typeof(x), MOI.SecondOrderCone) == 2
+
+    @variable(model, [1:3] in MOI.SecondOrderCone(3))
+    @test num_constraints(model, typeof(x), MOI.SecondOrderCone) == 3
+
+    z = @variable(model, z in MOI.Semiinteger(1.0, 2.0))
+    @test num_constraints(model, typeof(z), MOI.Semiinteger{Float64}) == 1
+
+    @variable(model, set = MOI.Semiinteger(1.0, 2.0))
+    @test num_constraints(model, typeof(z), MOI.Semiinteger{Float64}) == 2
+
+    @variable(model, [1:3, 1:3] in PSDCone())
+    @test num_constraints(model, typeof(x), MOI.PositiveSemidefiniteConeTriangle) == 1
+end
+
 function variables_test(ModelType::Type{<:JuMP.AbstractModel},
                         VariableRefType::Type{<:JuMP.AbstractVariableRef})
     @testset "Variable name" begin
@@ -539,6 +572,10 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel},
 
     @testset "Symmetric variable" begin
         test_variable_symmetric(ModelType)
+    end
+
+    @testset "Constrained variables" begin
+        test_constrained_variables(ModelType)
     end
 end
 

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -467,14 +467,14 @@ function test_variable_symmetric(ModelType)
     @test y[1, 2] === y[2, 1]
 end
 
-function test_constrained_variables(ModelType)
+function test_variables_constrained_on_creation(ModelType)
     model = ModelType()
 
-    err = ErrorException("In `@variable(model, x[1:2] in SecondOrderCone(), set = PSDCone())`: Cannot specify set of constrained variable twice, it was already set to `\$(Expr(:escape, :(SecondOrderCone())))` so the `set` keyword argument is not allowed.")
+    err = ErrorException("In `@variable(model, x[1:2] in SecondOrderCone(), set = PSDCone())`: Cannot specify set twice, it was already set to `\$(Expr(:escape, :(SecondOrderCone())))` so the `set` keyword argument is not allowed.")
     @test_macro_throws err @variable(model, x[1:2] in SecondOrderCone(), set = PSDCone())
-    err = ErrorException("In `@variable(model, x[1:2] in SecondOrderCone(), PSD)`: Cannot specify set of constrained variable twice, it was already set to `\$(Expr(:escape, :(SecondOrderCone())))` so the `PSD` argument is not allowed.")
+    err = ErrorException("In `@variable(model, x[1:2] in SecondOrderCone(), PSD)`: Cannot specify set twice, it was already set to `\$(Expr(:escape, :(SecondOrderCone())))` so the `PSD` argument is not allowed.")
     @test_macro_throws err @variable(model, x[1:2] in SecondOrderCone(), PSD)
-    err = ErrorException("In `@variable(model, x[1:2] in SecondOrderCone(), Symmetric)`: Cannot specify `Symmetric` on a constrained variable, the variable is constrained to belong to `\$(Expr(:escape, :(SecondOrderCone())))`.")
+    err = ErrorException("In `@variable(model, x[1:2] in SecondOrderCone(), Symmetric)`: Cannot specify `Symmetric` when the set is already specified, the variable is constrained to belong to `\$(Expr(:escape, :(SecondOrderCone())))`.")
     @test_macro_throws err @variable(model, x[1:2] in SecondOrderCone(), Symmetric)
     err = ErrorException("In `@variable(model, x[1:2], set = SecondOrderCone(), set = PSDCone())`: `set` keyword argument was given 2 times.")
     @test_macro_throws err @variable(model, x[1:2], set = SecondOrderCone(), set = PSDCone())
@@ -574,8 +574,8 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel},
         test_variable_symmetric(ModelType)
     end
 
-    @testset "Constrained variables" begin
-        test_constrained_variables(ModelType)
+    @testset "Variables constrained on creation" begin
+        test_variables_constrained_on_creation(ModelType)
     end
 end
 


### PR DESCRIPTION
Showcase:
```julia
julia> @variable(model, [1:2] in SecondOrderCone())
2-element Array{VariableRef,1}:
 noname
 noname

julia> @variable(model, [1:2] in MOI.SecondOrderCone(2))
2-element Array{VariableRef,1}:
 noname
 noname

julia> @variable(model, p in MOI.Semiinteger(1.0, 2.0))
p

julia> model
A JuMP Model
Feasibility problem with:
Variables: 5
`Array{VariableRef,1}`-in-`MathOptInterface.SecondOrderCone`: 2 constraints
`VariableRef`-in-`MathOptInterface.Semiinteger{Float64}`: 1 constraints
Model mode: AUTOMATIC
CachingOptimizer state: NO_OPTIMIZER
Solver name: No optimizer attached.
Names registered in the model: p
```

- [x] Add tests
- [x] Add doc

Closes https://github.com/JuliaOpt/JuMP.jl/issues/2105