### PR TITLE
[RFC] Add complementarity constraints

### DIFF
--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -819,7 +819,7 @@ MathOptInterface.LessThan{Float64}(1.0)
 
 ## Complementarity constraints
 
-A mixed complementarity problem `F(x) ⟂ x` consists of finding `x` in the
+A mixed complementarity constraint `F(x) ⟂ x` consists of finding `x` in the
 interval `[lb, ub]`, such that the following holds:
 
 - `F(x) == 0` if `lb < x < ub`
@@ -829,19 +829,31 @@ interval `[lb, ub]`, such that the following holds:
 For more information, see the [`MOI.Complements` documentation](https://www.juliaopt.org/MathOptInterface.jl/v0.9/apireference/#MathOptInterface.Complements).
 
 JuMP supports mixed complementarity constraints via `complements(F(x), x)` or
-`F(x) ⟂ x` in the [`@constraint`](@ref) macro. For example:
+`F(x) ⟂ x` in the [`@constraint`](@ref) macro. The interval set `[lb, ub]` is
+obtained from the variable bounds on `x`.
 
+For example, to define the problem `2x - 1 ⟂ x` with `x ∈ [0, ∞)`, do:
 ```jldoctest complementarity; setup=:(model=Model())
 julia> @variable(model, x >= 0)
 x
-
-julia> @constraint(model, complements(2x - 1, x))
-[2 x - 1, x] ∈ MathOptInterface.Complements(1)
 
 julia> @constraint(model, 2x - 1 ⟂ x)
 [2 x - 1, x] ∈ MathOptInterface.Complements(1)
 ```
 This problem has one solution at `x = 0.5`.
+
+The perp operators `⟂` can be entered in most editors (and the Julia REPL) by
+typing `\perp<tab>`.
+
+An alternative approach that does not require the `⟂` symbol uses the
+`complements` function as follows:
+```jldoctest complementarity
+julia> @constraint(model, complements(2x - 1, x))
+[2 x - 1, x] ∈ MathOptInterface.Complements(1)
+```
+
+In both cases, the mapping `F(x)` is supplied as the first argument, and the
+matching variable `x` is supplied as the second.
 
 Vector-valued complementarity constraints are also supported:
 ```jldoctest complementarity

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -817,6 +817,52 @@ julia> con.set
 MathOptInterface.LessThan{Float64}(1.0)
 ```
 
+## Complementarity constraints
+
+A mixed complementarity problem `F(x) ⟂ x` consists of finding `x` in the
+interval `[lb, ub]`, such that the following holds:
+
+- `F(x) == 0` if `lb < x < ub`
+- `F(x) >= 0` if `lb == x`
+- `F(x) <= 0` if `x == ub`
+
+For more information, see the [`MOI.Complements` documentation](https://www.juliaopt.org/MathOptInterface.jl/v0.9/apireference/#MathOptInterface.Complements).
+
+JuMP supports mixed complementarity constraints via `complements(F(x), x)` or
+`F(x) ⟂ x` in the [`@constraint`](@ref) macro. For example:
+
+```jldoctest complementarity; setup=:(model=Model())
+julia> @variable(model, x >= 0)
+x
+
+julia> @constraint(model, complements(2x - 1, x))
+[2 x - 1, x] ∈ MathOptInterface.Complements(1)
+
+julia> @constraint(model, 2x - 1 ⟂ x)
+[2 x - 1, x] ∈ MathOptInterface.Complements(1)
+```
+This problem has one solution at `x = 0.5`.
+
+Vector-valued complementarity constraints are also supported:
+```jldoctest complementarity
+julia> @variable(model, -2 <= y[1:2] <= 2)
+2-element Array{VariableRef,1}:
+ y[1]
+ y[2]
+
+julia> M = [1 2; 3 4]
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
+
+julia> q = [5, 6]
+2-element Array{Int64,1}:
+ 5
+ 6
+
+julia> @constraint(model, M * y + q ⟂ y)
+[y[1] + 2 y[2] + 5, 3 y[1] + 4 y[2] + 6, y[1], y[2]] ∈ MathOptInterface.Complements(2)
+```
 
 ## Reference
 

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -840,9 +840,9 @@ x
 julia> @constraint(model, 2x - 1 ⟂ x)
 [2 x - 1, x] ∈ MathOptInterface.Complements(1)
 ```
-This problem has one solution at `x = 0.5`.
+This problem has a unique solution at `x = 0.5`.
 
-The perp operators `⟂` can be entered in most editors (and the Julia REPL) by
+The perp operator `⟂` can be entered in most editors (and the Julia REPL) by
 typing `\perp<tab>`.
 
 An alternative approach that does not require the `⟂` symbol uses the

--- a/src/Containers/SparseAxisArray.jl
+++ b/src/Containers/SparseAxisArray.jl
@@ -202,6 +202,22 @@ function Base.copyto!(dest::SparseAxisArray{T, N, K},
     return dest
 end
 
+@static if VERSION >= v"1.3"
+    # `broadcast_preserving_zero_d` calls `axes(A)` which calls `size(A)` which
+    # is not defined. When at least one argument is a `SparseAxisArray`, we can
+    # simply redirect `broadcast_preserving_zero_d` to `broadcast` since we know
+    # the result won't be zero dimensional.
+
+    # Called by `A * 2`
+    function Base.Broadcast.broadcast_preserving_zero_d(f, A::SparseAxisArray, As...)
+        broadcast(f, A, As...)
+    end
+    # Called by `2 * A`
+    function Base.Broadcast.broadcast_preserving_zero_d(f, x, A::SparseAxisArray, As...)
+        broadcast(f, x, A, As...)
+    end
+end
+
 ########
 # Show #
 ########

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -726,6 +726,8 @@ include("sets.jl")
 
 # Indicator constraint
 include("indicator.jl")
+# Complementarity constraint
+include("complement.jl")
 # SDConstraint
 include("sd.jl")
 

--- a/src/complement.jl
+++ b/src/complement.jl
@@ -3,27 +3,54 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# This file extends JuMP to indicator constraints. It is a good example of how
-# JuMP can be extended.
+# This file extends JuMP to complementarity constraints. It is a good example of
+# how JuMP can be extended. In particular, it allows constraints of the form:
+#
+# @constraint(model, complements(2x - 1, x))
+# @constraint(model, 2x - 1 ⟂ x)
 
 function _build_complements_constraint(
-    _error::Function, funcs::Vector{<:AbstractJuMPScalar},
-    variables::Vector{<:AbstractVariableRef})
-    n = length(variables)
-    if length(funcs) != n
-        _error("Number of variables ($n) does not match number of constraints ($(length(funcs))).")
+    _error::Function,
+    F::Vector{<:AbstractJuMPScalar},
+    x::Vector{<:AbstractVariableRef}
+)
+    n = length(x)
+    if length(F) != n
+        _error(
+            "Length of mapping ($(length(F))) is not equal to number of " *
+            "matching variables ($(n))."
+        )
     end
-    return VectorConstraint([variables; funcs], MOI.Complements(n))
-end
-function _build_complements_constraint(
-    _error::Function, func::AbstractJuMPScalar,
-    variable::AbstractVariableRef)
-    return VectorConstraint([variable, func], MOI.Complements(1))
+    return VectorConstraint([F; x], MOI.Complements(n))
 end
 
-function parse_one_operator_constraint(_error::Function, _::Bool,
-                                       s::Union{Val{:complements}, Val{:⟂}},
-                                       func_expr, variable)
-    func, parse_code = _MA.rewrite(func_expr)
-    return parse_code, :(_build_complements_constraint($_error, $func, $(esc(variable))))
+function _build_complements_constraint(
+    _error::Function,
+    ::Vector{<:AbstractJuMPScalar},
+    ::Vector{<:AbstractJuMPScalar},
+)
+    _error("second term must be a vector of variables.")
+end
+
+function _build_complements_constraint(
+    ::Function, F::AbstractJuMPScalar, x::AbstractVariableRef
+)
+    return VectorConstraint([F, x], MOI.Complements(1))
+end
+
+function _build_complements_constraint(
+    _error::Function, ::AbstractJuMPScalar, ::AbstractJuMPScalar
+)
+    _error("second term must be a variable.")
+end
+
+function parse_one_operator_constraint(
+    _error::Function,
+    ::Bool,
+    ::Union{Val{:complements}, Val{:⟂}},
+    F,
+    x
+)
+    f, parse_code = _MA.rewrite(F)
+    return parse_code, :(_build_complements_constraint($_error, $f, $(esc(x))))
 end

--- a/src/complement.jl
+++ b/src/complement.jl
@@ -1,0 +1,48 @@
+#  Copyright 2017, Iain Dunning, Joey Huchette, Miles Lubin, and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file extends JuMP to indicator constraints. It is a good example of how
+# JuMP can be extended.
+
+function _build_complements_constraint(
+    _error::Function, variables::Vector{<:AbstractVariableRef},
+    funcs::Vector{<:AbstractJuMPScalar})
+    n = length(variables)
+    if length(funcs) != n
+        _error("Number of variables ($n) does not match number of constraints ($(length(funcs))).")
+    end
+    return VectorConstraint([variables; funcs], MOI.Complements(n))
+end
+function _build_complements_constraint(
+    _error::Function, variable::AbstractVariableRef,
+    func::AbstractJuMPScalar)
+    return VectorConstraint([variable, func], MOI.Complements(1))
+end
+
+function _is_inequality(expr)
+    return isexpr(expr, :call) && length(expr.args) == 3 && expr.args[1] in [:<=, :≤, :>=, :≥, :(.<=), :.≤, :(.>=), :.≥]
+end
+function parse_one_operator_constraint(_error::Function, _::Bool,
+                                       s::Union{Val{:complements}, Val{:⟂}},
+                                       lhs, rhs)
+    if _is_inequality(lhs) && !_is_inequality(rhs)
+        return parse_one_operator_constraint(_error, vectorized, s, rhs, lhs)
+    end
+    if !_is_inequality(rhs)
+        _error("Expected one of the two sides of the complements to be an inequality.")
+    end
+    sense, vectorized = _check_vectorized(rhs.args[1])
+    if sense in [:<=, :≤]
+        l, r = rhs.args[3], rhs.args[2]
+    else
+        l, r = rhs.args[2], rhs.args[3]
+    end
+    sense = vectorized ? :.≥ : :≥
+    _, rhs_parsecode, _build_call = parse_constraint(_error, sense, l, r)
+    @assert length(_build_call.args) == 4
+    @assert _build_call.args[1] == :build_constraint
+    func = _build_call.args[3]
+    return rhs_parsecode, :(_build_complements_constraint($_error, $(esc(lhs)), $func))
+end

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -29,7 +29,7 @@
     end
 
     @testset "Range index set" begin
-        A = @inferred DenseAxisArray([1.0,2.0], 2:3)
+        A = @inferred DenseAxisArray([1.0, 2.0], 2:3)
         @test size(A) == (2,)
         @test size(A, 1) == 2
         @test @inferred A[2] == 1.0
@@ -39,6 +39,7 @@
         @test isassigned(A, 2)
         @test !isassigned(A, 1)
         @test length.(axes(A)) == (2,)
+
         correct_answer = DenseAxisArray([2.0, 3.0], 2:3)
         @test sprint(show, correct_answer) == """
 1-dimensional DenseAxisArray{Float64,1,...} with index sets:
@@ -46,10 +47,21 @@
 And data, a 2-element Array{Float64,1}:
  2.0
  3.0"""
-        plus1(x) = x + 1
-        @test plus1.(A) == correct_answer
-        @test A .+ 1 == correct_answer
-        @test 1 .+ A == correct_answer
+
+        @testset "Broadcasting" begin
+            plus1(x) = x + 1
+            @test plus1.(A) == correct_answer
+            @test A .+ 1 == correct_answer
+            @test 1 .+ A == correct_answer
+        end
+
+        @testset "Operation with scalar" begin
+            correct_answer = DenseAxisArray([2.0, 4.0], 2:3)
+            @test 2 * A == correct_answer
+            @test A * 2 == correct_answer
+            @test A / (1 / 2) == correct_answer
+        end
+
     end
 
     @testset "Symbol index set" begin

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -71,6 +71,10 @@ SparseAxisArray{$Int,1,Tuple{Symbol}} with 2 entries:
             @test fd isa SparseAxisArray{Real,1,Tuple{Symbol}}
             @test fd == SparseAxisArray(Dict((:a,) => 2, (:b,) => 1.5))
         end
+        @testset "Operation with scalar" begin
+            @test 3 * (d2 / 2) == d3
+            @test (d2 / 2) * 3 == d3
+        end
     end
     @testset "2-dimensional" begin
         SA = SparseAxisArray

--- a/test/complement.jl
+++ b/test/complement.jl
@@ -76,8 +76,8 @@ end
         @variable(model, x[1:2] >= 0)
         @test_throws(
             ErrorException(
-                "In `@constraint(model, x ⟂ [x[1]])`: Length of mapping (2) " *
-                "is not equal to number of matching variables (1)."
+                "In `@constraint(model, x ⟂ [x[1]])`: size of mapping does " *
+                "not match size of variables: (2,) != (1,)."
             ),
             @constraint(model, x ⟂ [x[1]])
         )
@@ -88,8 +88,8 @@ end
         @variable(model, x[1:2] >= 0)
         @test_throws(
             ErrorException(
-                "In `@constraint(model, x ⟂ 2x .- 1)`: second term must be a " *
-                "vector of variables."
+                "In `@constraint(model, x ⟂ 2x .- 1)`: second term must be an " *
+                "array of variables."
             ),
             @constraint(model, x ⟂ 2x .- 1)
         )
@@ -101,9 +101,38 @@ end
         @test_throws(
             ErrorException(
                 "In `@constraint(model, x .+ 1 ⟂ 2x .- 1)`: second term must " *
-                "be a vector of variables."
+                "be an array of variables."
             ),
             @constraint(model, x .+ 1 ⟂ 2x .- 1)
         )
+    end
+end
+
+@testset "SparseAxisArray" begin
+    @testset "complements" begin
+        model = Model()
+        @variable(model, x[i=1:3; isodd(i)] >= 0)
+        @constraint(model, c, complements(2x .- 1, x))
+        obj = constraint_object(c)
+        @test obj.func == [2x[3] - 1, 2x[1] - 1, x[3], x[1]] ||
+            obj.func == [2x[1] - 1, 2x[3] - 1, x[1], x[3]]
+        @test obj.set == MOI.Complements(2)
+    end
+
+    @testset "⟂" begin
+        model = Model()
+        @variable(model, x[i=1:3; isodd(i)] >= 0)
+        @constraint(model, c, 2x .- 1 ⟂ x)
+        obj = constraint_object(c)
+        @test obj.func == [2x[3] - 1, 2x[1] - 1, x[3], x[1]] ||
+            obj.func == [2x[1] - 1, 2x[3] - 1, x[1], x[3]]
+        @test obj.set == MOI.Complements(2)
+    end
+
+    @testset "key mismatch" begin
+        model = Model()
+        @variable(model, x[i=1:3; isodd(i)] >= 0)
+        @variable(model, y[i=3:5; isodd(i)] >= 0)
+        @test_throws(ErrorException, @constraint(model, 2x .- 1 ⟂ y))
     end
 end

--- a/test/complement.jl
+++ b/test/complement.jl
@@ -1,0 +1,109 @@
+#  Copyright 2017, Iain Dunning, Joey Huchette, Miles Lubin, and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using JuMP
+using Test
+
+@testset "Scalar Complementarity" begin
+    @testset "complements" begin
+        model = Model()
+        @variable(model, x >= 0)
+        @constraint(model, c, complements(2x - 1, x))
+        obj = constraint_object(c)
+        @test obj.func == [2x - 1, x]
+        @test obj.set == MOI.Complements(1)
+    end
+
+    @testset "⟂" begin
+        model = Model()
+        @variable(model, x >= 0)
+        @variable(model, y >= 0)
+        @constraint(model, c, x ⟂ y)
+        obj = constraint_object(c)
+        @test obj.func == [x, y]
+        @test obj.set == MOI.Complements(1)
+    end
+
+    @testset "error: x--F" begin
+        model = Model()
+        @variable(model, x >= 0)
+        @test_throws(
+            ErrorException(
+                "In `@constraint(model, x ⟂ 2x - 1)`: second term must be a " *
+                "variable."
+            ),
+            @constraint(model, x ⟂ 2x - 1)
+        )
+    end
+
+    @testset "error: F--F" begin
+        model = Model()
+        @variable(model, x >= 0)
+        @test_throws(
+            ErrorException(
+                "In `@constraint(model, x + 1 ⟂ 2x - 1)`: second term must " *
+                "be a variable."
+            ),
+            @constraint(model, x + 1 ⟂ 2x - 1)
+        )
+    end
+end
+
+@testset "Vector Complementarity" begin
+    @testset "complements" begin
+        model = Model()
+        @variable(model, x[1:2] >= 0)
+        @constraint(model, c, complements(2x .- 1, x))
+        obj = constraint_object(c)
+        @test obj.func == [2x .- 1; x]
+        @test obj.set == MOI.Complements(2)
+    end
+
+    @testset "⟂" begin
+        model = Model()
+        @variable(model, x[1:2] >= 0)
+        @variable(model, y[1:2] >= 0)
+        @constraint(model, c, x ⟂ y)
+        obj = constraint_object(c)
+        @test obj.func == [x; y]
+        @test obj.set == MOI.Complements(2)
+    end
+
+    @testset "error: length mismatch" begin
+        model = Model()
+        @variable(model, x[1:2] >= 0)
+        @test_throws(
+            ErrorException(
+                "In `@constraint(model, x ⟂ [x[1]])`: Length of mapping (2) " *
+                "is not equal to number of matching variables (1)."
+            ),
+            @constraint(model, x ⟂ [x[1]])
+        )
+    end
+
+    @testset "error: x--F" begin
+        model = Model()
+        @variable(model, x[1:2] >= 0)
+        @test_throws(
+            ErrorException(
+                "In `@constraint(model, x ⟂ 2x .- 1)`: second term must be a " *
+                "vector of variables."
+            ),
+            @constraint(model, x ⟂ 2x .- 1)
+        )
+    end
+
+    @testset "error: F--F" begin
+        model = Model()
+        @variable(model, x[1:2] >= 0)
+        @test_throws(
+            ErrorException(
+                "In `@constraint(model, x .+ 1 ⟂ 2x .- 1)`: second term must " *
+                "be a vector of variables."
+            ),
+            @constraint(model, x .+ 1 ⟂ 2x .- 1)
+        )
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,21 +21,19 @@ include("Containers/Containers.jl")
 include("utilities.jl")
 include("JuMPExtension.jl")
 
-include("derivatives.jl")
-include("derivatives_coloring.jl")
-include("model.jl")
-include("variable.jl")
-include("expr.jl")
-include("objective.jl")
-include("constraint.jl")
-include("nlp.jl")
-include("generate_and_solve.jl")
-include("print.jl")
-include("operator.jl")
-include("mutable_arithmetics.jl")
-include("macros.jl")
-include("lp_sensitivity.jl")
-include("callbacks.jl")
-include("file_formats.jl")
-# TODO: The hygiene test should run in a separate Julia instance where JuMP hasn't been loaded via `using`.
+@testset "$(file)" for file in filter(f -> endswith(f, ".jl"), readdir(@__DIR__))
+    if file in [
+        "runtests.jl",
+        "utilities.jl",
+        "JuMPExtension.jl",
+        "nlp_solver.jl",
+        "hygiene.jl",
+    ]
+        continue
+    end
+    include(file)
+end
+
+# TODO: The hygiene test should run in a separate Julia instance where JuMP
+# hasn't been loaded via `using`.
 include("hygiene.jl")


### PR DESCRIPTION
```julia
julia> using JuMP; model = Model(); @variable(model, x);

julia> @constraint(model, complements(x, x >= 1))
[x, x - 1] ∈ MathOptInterface.Complements(1)

julia> @constraint(model, complements(x, x <= 1))
[x, -x + 1] ∈ MathOptInterface.Complements(1)
```
What about `⟂` (that can be entered with `\perp<TAB>`) ?
Do you prefer:
```julia
@constraint(model, x ⟂ x <= 1)
```
or, similarly to the indicator constraint `@constraint(x => {x <= 1})`,
```julia
@constraint(model, x ⟂ {x <= 1})
```
The argument for the indicator constraint that the two signs were two symmetric may not hold here, see the discussion in https://github.com/JuliaOpt/JuMP.jl/pull/2092.