### PR TITLE
Create a version of method delete that deletes a vector of variables.

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -173,6 +173,22 @@ function delete(model::Model, con_ref::ConstraintRef{Model})
 end
 
 """
+    delete(model::Model, con_refs::Vector{ConstraintRef})
+
+Delete the constraints associated with `con_refs` from the model `model`.
+Solvers may implement methods for deleting multiple constraints that are
+more efficient than repeatedly calling the single constraint delete method.
+"""
+function delete(model::Model, con_refs::Vector{<:ConstraintRef{Model}})
+    # This is just a fallback of the fallback. To be really useful,
+    # instead of calling JuMP.delete repeatedly it needs to call a
+    # (currently unimplemented) fallback in MOI like the one for
+    # batch variable deletion: https://github.com/JuliaOpt/MathOptInterface.jl/blob/78c15baee/src/indextypes.jl#L119
+    # Then the solvers may reimplement the fallback in MOI level.
+    delete.(model, con_refs)
+end
+
+"""
     is_valid(model::Model, con_ref::ConstraintRef{Model})
 
 Return `true` if `constraint_ref` refers to a valid constraint in `model`.

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -180,12 +180,12 @@ Solvers may implement methods for deleting multiple constraints that are
 more efficient than repeatedly calling the single constraint delete method.
 """
 function delete(model::Model, con_refs::Vector{<:ConstraintRef{Model}})
-    # This is just a fallback of the fallback. To be really useful,
-    # instead of calling JuMP.delete repeatedly it needs to call a
-    # (currently unimplemented) fallback in MOI like the one for
-    # batch variable deletion: https://github.com/JuliaOpt/MathOptInterface.jl/blob/78c15baee/src/indextypes.jl#L119
-    # Then the solvers may reimplement the fallback in MOI level.
-    delete.(model, con_refs)
+    if any(c -> model !== c.model, con_refs)
+        error("A constraint reference you are trying to delete does not" * "
+            belong to the model.")
+    end
+    MOI.delete(backend(model), index.(con_refs))
+    return
 end
 
 """

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -177,8 +177,9 @@ end
 
 Delete the constraints associated with `con_refs` from the model `model`.
 Solvers may implement specialized methods for deleting multiple constraints of
-the same concrete type. These may be more efficient than repeatedly calling the
-single constraint delete method.
+the same concrete type, i.e., when `isconcretetype(eltype(con_refs))`. These
+may be more efficient than repeatedly calling the single constraint delete
+method.
 """
 function delete(model::Model, con_refs::Vector{<:ConstraintRef{Model}})
     if any(c -> model !== c.model, con_refs)

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -164,7 +164,7 @@ end
 
 Delete the constraint associated with `constraint_ref` from the model `model`.
 """
-function delete(model::Model, con_ref::ConstraintRef{Model})
+function delete(model::Model, con_ref::ConstraintRef)
     if model !== con_ref.model
         error("The constraint reference you are trying to delete does not " *
               "belong to the model.")
@@ -173,11 +173,12 @@ function delete(model::Model, con_ref::ConstraintRef{Model})
 end
 
 """
-    delete(model::Model, con_refs::Vector{ConstraintRef})
+    delete(model::Model, con_refs::Vector{<:ConstraintRef})
 
 Delete the constraints associated with `con_refs` from the model `model`.
-Solvers may implement methods for deleting multiple constraints that are
-more efficient than repeatedly calling the single constraint delete method.
+Solvers may implement specialized methods for deleting multiple constraints of
+the same concrete type. These may be more efficient than repeatedly calling the
+single constraint delete method.
 """
 function delete(model::Model, con_refs::Vector{<:ConstraintRef{Model}})
     if any(c -> model !== c.model, con_refs)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -180,8 +180,8 @@ end
     delete(model::Model, variable_refs::Vector{VariableRef})
 
 Delete the variables associated with `variable_refs` from the model `model`.
-The Solvers may implement methods for deleting multiple variables that are
-more efficient than repeatedely calling the single variable delete method.
+Solvers may implement methods for deleting multiple variables that are
+more efficient than repeatedly calling the single variable delete method.
 """
 function delete(model::Model, variable_refs::Vector{VariableRef})
     if any(model !== owner_model(v) for v in variable_refs)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -177,6 +177,22 @@ function delete(model::Model, variable_ref::VariableRef)
 end
 
 """
+    delete(model::Model, variable_refs::VariableRef)
+
+Delete the variables associated with `variable_refs` from the model `model`.
+The solvers may implement methods for deleting multiple variables that are
+more efficient than repeatedely calling the single variable delete method.
+"""
+function delete(model::Model, variable_refs::Vector{VariableRef})
+    if any(model !== owner_model(v) for v in variable_refs)
+        error("A variable reference you are trying to delete does not " *
+              "belong to the model.")
+    end
+    MOI.delete(backend(model), index.(variable_refs))
+    return
+end
+
+"""
     is_valid(model::Model, variable_ref::VariableRef)
 
 Return `true` if `variable` refers to a valid variable in `model`.

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -177,10 +177,10 @@ function delete(model::Model, variable_ref::VariableRef)
 end
 
 """
-    delete(model::Model, variable_refs::VariableRef)
+    delete(model::Model, variable_refs::Vector{VariableRef})
 
 Delete the variables associated with `variable_refs` from the model `model`.
-The solvers may implement methods for deleting multiple variables that are
+The Solvers may implement methods for deleting multiple variables that are
 more efficient than repeatedely calling the single variable delete method.
 """
 function delete(model::Model, variable_refs::Vector{VariableRef})

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -76,11 +76,7 @@ function JuMP.delete(model::MyModel, vref::MyVariableRef)
     delete!(model.var_to_name, vref.idx)
 end
 function JuMP.delete(model::MyModel, vrefs::Vector{MyVariableRef})
-    @assert all(JuMP.is_valid.(model, vrefs))
-    for idx in [vref.idx for vref in vrefs]
-        delete!(model.variables, idx)
-        delete!(model.var_to_name, idx)
-    end
+    JuMP.delete.(model, vrefs)
 end
 function JuMP.is_valid(model::MyModel, vref::MyVariableRef)
     return (model === vref.model &&

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -75,6 +75,13 @@ function JuMP.delete(model::MyModel, vref::MyVariableRef)
     delete!(model.variables, vref.idx)
     delete!(model.var_to_name, vref.idx)
 end
+function JuMP.delete(model::MyModel, vrefs::Vector{MyVariableRef})
+    @assert all(JuMP.is_valid.(model, vrefs))
+    for idx in [vref.idx for vref in vrefs]
+        delete!(model.variables, idx)
+        delete!(model.var_to_name, idx)
+    end
+end
 function JuMP.is_valid(model::MyModel, vref::MyVariableRef)
     return (model === vref.model &&
             vref.idx in keys(model.variables))

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -230,6 +230,9 @@ function JuMP.delete(model::MyModel, constraint_ref::MyConstraintRef)
     delete!(model.constraints, constraint_ref.index)
     delete!(model.con_to_name, constraint_ref.index)
 end
+function JuMP.delete(model::MyModel, con_refs::Vector{<:MyConstraintRef})
+    JuMP.delete.(model, con_refs)
+end
 function JuMP.is_valid(model::MyModel, constraint_ref::MyConstraintRef)
     return (model === constraint_ref.model &&
             constraint_ref.index in keys(model.constraints))

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -119,6 +119,21 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel},
         @test_throws Exception JuMP.delete(second_model, constraint_ref)
     end
 
+    @testset "batch delete / is_valid constraints" begin
+        model = ModelType()
+        @variable(model, x[1:9])
+        cons = [@constraint(model, sum(x[1:2:9]) <= 3)]
+        push!(cons, @constraint(model, sum(x[2:2:8]) <= 2))
+        push!(cons, @constraint(model, sum(x[1:3:9]) <= 1))
+        @test all(JuMP.is_valid.(model, cons))
+        JuMP.delete(model, cons[[1, 3]])
+        @test all((!JuMP.is_valid).(model, cons[[1, 3]]))
+        @test JuMP.is_valid(model, cons[2])
+        second_model = ModelType()
+        @test_throws Exception JuMP.delete(second_model, cons[[1, 3]])
+        @test_throws Exception JuMP.delete(second_model, [cons[2]])
+    end
+
     @testset "Two-sided constraints" begin
         m = ModelType()
         @variable(m, x)

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -633,6 +633,16 @@ end
     end
 end
 
+@testset "Deletion of a batch of variables" begin
+    model = Model()
+    @variable(model, x[1:3] >= 1)
+    @objective(model, Min, sum([1, 2, 3] .* x))
+    @test all(is_valid.(model, x))
+    delete(model, x[[1, 3]])
+    @test all((!is_valid).(model, x[[1, 3]]))
+    @test is_valid(model, x[2])
+end
+
 @testset "Variables for JuMPExtension.MyModel" begin
     variables_test(JuMPExtension.MyModel, JuMPExtension.MyVariableRef)
 end

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -500,6 +500,19 @@ function test_variables_constrained_on_creation(ModelType)
     @test num_constraints(model, typeof(x), MOI.PositiveSemidefiniteConeTriangle) == 1
 end
 
+function test_batch_delete_variables(ModelType)
+    model = ModelType()
+    @variable(model, x[1:3] >= 1)
+    @objective(model, Min, sum([1, 2, 3] .* x))
+    @test all(is_valid.(model, x))
+    delete(model, x[[1, 3]])
+    @test all((!is_valid).(model, x[[1, 3]]))
+    @test is_valid(model, x[2])
+    second_model = ModelType()
+    @test_throws Exception JuMP.delete(second_model, x[2])
+    @test_throws Exception JuMP.delete(second_model, x[[1, 3]])
+end
+
 function variables_test(ModelType::Type{<:JuMP.AbstractModel},
                         VariableRefType::Type{<:JuMP.AbstractVariableRef})
     @testset "Variable name" begin
@@ -577,6 +590,10 @@ function variables_test(ModelType::Type{<:JuMP.AbstractModel},
     @testset "Variables constrained on creation" begin
         test_variables_constrained_on_creation(ModelType)
     end
+
+    @testset "Batch deletion of variables" begin
+        test_batch_delete_variables(ModelType)
+    end
 end
 
 @testset "Variables for JuMP.Model" begin
@@ -631,16 +648,6 @@ end
         @test !JuMP.is_integer(q)
         @test JuMP.start_value(q) === 0.5
     end
-end
-
-@testset "Deletion of a batch of variables" begin
-    model = Model()
-    @variable(model, x[1:3] >= 1)
-    @objective(model, Min, sum([1, 2, 3] .* x))
-    @test all(is_valid.(model, x))
-    delete(model, x[[1, 3]])
-    @test all((!is_valid).(model, x[[1, 3]]))
-    @test is_valid(model, x[2])
 end
 
 @testset "Variables for JuMPExtension.MyModel" begin


### PR DESCRIPTION
This calls the version of MOI.delete that also works over a vector of variables, and is specialized by solvers for greater performance than repeatedly calling the single variable version.

The code was suggested by @odow in a discussion with him and @mlubin.

This is related to:
https://github.com/JuliaOpt/MathOptInterface.jl/pull/989
https://github.com/JuliaOpt/Gurobi.jl/pull/282
https://github.com/JuliaOpt/CPLEX.jl/pull/273

The CPLEX and Gurobi PR's are already closed, the MathOptInterface is just waiting more reviewers (I think). Anyway, MathOptInterface already has a "delete a vector of variables" fallback method  (https://github.com/JuliaOpt/MathOptInterface.jl/blob/c4beceb4e9444c752f7e655f7a50a38a70181b06/src/indextypes.jl#L124-L128). So this addition to JuMP would already be working if it was approved immediately. I suppose tests may be necessary, but it is MOI that does the heavy lifting and this method is basically the same as the single variable version except by the type of the parameters and the version of the MOI method it calls.

I imported the JuMP package changed by my branch in the REPL and called the method to test against typos.