### PR TITLE
Fix missing docstring source links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ jobs:
       julia: 1.0
       os: linux
       script:
-        - julia --project=docs -e 'using Pkg; Pkg.instantiate(); Pkg.add(PackageSpec(path=pwd()))'
+        - julia --project=docs -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
         - julia --project=docs --color=yes docs/make.jl
       after_success: skip
     - stage: "Examples"
       julia: 1.0
       os: linux
       script:
-        - julia --project=examples -e 'using Pkg; Pkg.instantiate(); Pkg.add(PackageSpec(path=pwd()))'
+        - julia --project=examples -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
         - julia --project=examples --color=yes examples/run_examples.jl


### PR DESCRIPTION
-> https://github.com/JuliaDocs/Documenter.jl/issues/834#issuecomment-602854108
`JuMP.jl` has the same problem.