### PR TITLE
added conjugation operator for scalars

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -259,6 +259,9 @@ Base.promote_rule(::Type{GenericQuadExpr{S, V}}, R::Type{<:Real}) where {S, V} =
 
 Base.transpose(x::AbstractJuMPScalar) = x
 
+# only real scalars are supported
+Base.conj(x::AbstractJuMPScalar) = x
+
 # Can remove the following code once == overloading is removed
 
 function LinearAlgebra.issymmetric(x::Matrix{T}) where {T <: _JuMPTypes}

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -133,6 +133,8 @@ function operators_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
             @test_expression_with_string w - q "-2.5 y*z + w - 7.1 x - 2.5"
             @test_throws ErrorException w*q
             @test_throws ErrorException w/q
+            @test transpose(x) === x
+            @test conj(x) === x
         end
 
         # 3. AffExpr tests
@@ -177,6 +179,8 @@ function operators_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
             @test_expression_with_string aff2 - q "-2.5 y*z + 1.2 y - 7.1 x - 1.3"
             @test_throws ErrorException aff2 * q
             @test_throws ErrorException aff2 / q
+            @test transpose(aff) === aff
+            @test conj(aff) === aff
         end
 
         # 4. QuadExpr
@@ -209,6 +213,8 @@ function operators_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
             @test_expression_with_string q - q2 "2.5 y*z - 8 x*z + 7.1 x - 1.2 y + 1.3"
             @test_throws ErrorException q * q2
             @test_throws ErrorException q / q2
+            @test transpose(q) === q
+            @test conj(q) === q
         end
     end
 


### PR DESCRIPTION
Fixes #2208 and adds a few tests.

Again, this is useful because `conj` is sometimes called recursively on containers and Julia has particularly simple syntax for taking the adjoint.

I'm not sure if there was some reason why this wasn't added already, but if people are open to it, here's a PR.