### PR TITLE
Jwscook/exampleswith optimizer

### DIFF
--- a/examples/basic.jl
+++ b/examples/basic.jl
@@ -22,7 +22,7 @@ Formulate and solve a simple LP:
 If `verbose = true`, print the model and the solution.
 """
 function example_basic(; verbose = true)
-    model = Model(GLPK.Optimizer)
+    model = Model(with_optimizer(GLPK.Optimizer))
 
     @variable(model, 0 <= x <= 2)
     @variable(model, 0 <= y <= 30)

--- a/examples/callbacks.jl
+++ b/examples/callbacks.jl
@@ -19,7 +19,7 @@ using Test
 An example using a lazy constraint callback.
 """
 function example_lazy_constraint()
-    model = Model(GLPK.Optimizer)
+    model = Model(with_optimizer(GLPK.Optimizer))
     @variable(model, 0 <= x <= 2.5, Int)
     @variable(model, 0 <= y <= 2.5, Int)
     @objective(model, Max, y)
@@ -57,7 +57,7 @@ function example_user_cut_constraint()
     N = 30
     item_weights, item_values = rand(N), rand(N)
 
-    model = Model(GLPK.Optimizer)
+    model = Model(with_optimizer(GLPK.Optimizer))
     @variable(model, x[1:N], Bin)
     @constraint(model, sum(item_weights[i] * x[i] for i = 1:N) <= 10)
     @objective(model, Max, sum(item_values[i] * x[i] for i = 1:N))
@@ -95,7 +95,7 @@ function example_heuristic_solution()
     N = 30
     item_weights, item_values = rand(N), rand(N)
 
-    model = Model(GLPK.Optimizer)
+    model = Model(with_optimizer(GLPK.Optimizer))
     @variable(model, x[1:N], Bin)
     @constraint(model, sum(item_weights[i] * x[i] for i = 1:N) <= 10)
     @objective(model, Max, sum(item_values[i] * x[i] for i = 1:N))
@@ -124,7 +124,7 @@ example_heuristic_solution()
 An example using a solver_dependent callback.
 """
 function example_solver_dependent_callback()
-    model = Model(GLPK.Optimizer)
+    model = Model(with_optimizer(GLPK.Optimizer))
     @variable(model, 0 <= x <= 2.5, Int)
     @variable(model, 0 <= y <= 2.5, Int)
     @objective(model, Max, y)

--- a/examples/cannery.jl
+++ b/examples/cannery.jl
@@ -36,7 +36,7 @@ function example_cannery(; verbose = true)
     num_plants = length(plants)
     num_markets = length(markets)
 
-    cannery = Model(GLPK.Optimizer)
+    cannery = Model(with_optimizer(GLPK.Optimizer))
 
     @variable(cannery, ship[1:num_plants, 1:num_markets] >= 0)
 

--- a/examples/clnlbeam.jl
+++ b/examples/clnlbeam.jl
@@ -29,7 +29,7 @@ function example_clnlbeam()
     N = 1000
     h = 1/N
     alpha = 350
-    model = Model(Ipopt.Optimizer)
+    model = Model(with_optimizer(Ipopt.Optimizer))
     set_silent(model)
     @variables(model, begin
         -1 <= t[1:(N + 1)] <= 1

--- a/examples/cluster.jl
+++ b/examples/cluster.jl
@@ -33,7 +33,7 @@ function example_cluster(; verbose = true)
         end
     end
 
-    model = Model(SCS.Optimizer)
+    model = Model(with_optimizer(SCS.Optimizer))
     set_silent(model)
     # Z >= 0, PSD
     @variable(model, Z[1:m, 1:m], PSD)

--- a/examples/corr_sdp.jl
+++ b/examples/corr_sdp.jl
@@ -25,7 +25,7 @@ We can use the following property of the correlations to determine bounds on
     | ρ_AC  ρ_BC   1   |
 """
 function example_corr_sdp()
-    model = Model(SCS.Optimizer)
+    model = Model(with_optimizer(SCS.Optimizer))
     set_silent(model)
     @variable(model, X[1:3, 1:3], PSD)
 

--- a/examples/cutting_stock_column_generation.jl
+++ b/examples/cutting_stock_column_generation.jl
@@ -24,7 +24,7 @@ function solve_pricing(dual_demand_satisfaction, maxwidth, widths, rollcost, dem
     n = length(reduced_costs)
 
     # The actual pricing model.
-    submodel = Model(GLPK.Optimizer)
+    submodel = Model(with_optimizer(GLPK.Optimizer))
     @variable(submodel, xs[1:n] >= 0, Int)
     @constraint(submodel, sum(xs .* widths) <= maxwidth)
     @objective(submodel, Max, sum(xs .* reduced_costs))
@@ -114,7 +114,7 @@ function example_cutting_stock(; max_gen_cols::Int=5000)
     # Write the master problem with this "reduced" set of patterns.
     # Not yet integer variables: otherwise, the dual values may make no sense
     # (actually, GLPK will yell at you if you're trying to get duals for integer problems)
-    m = Model(GLPK.Optimizer)
+    m = Model(with_optimizer(GLPK.Optimizer))
     @variable(m, θ[1:ncols] >= 0)
     @objective(m, Min,
         sum(θ[p] * (rollcost - sum(patterns[j, p] * prices[j] for j in 1:n)) for p in 1:ncols)

--- a/examples/diet.jl
+++ b/examples/diet.jl
@@ -64,7 +64,7 @@ function example_diet(; verbose = true)
     @test food_data["milk", "fat"] == 2.5
 
     # Build model
-    model = Model(GLPK.Optimizer)
+    model = Model(with_optimizer(GLPK.Optimizer))
 
     @variables(model, begin
         # Variables for nutrition info

--- a/examples/knapsack.jl
+++ b/examples/knapsack.jl
@@ -22,7 +22,7 @@ function example_knapsack(; verbose = true)
     profit = [5, 3, 2, 7, 4]
     weight = [2, 8, 4, 2, 5]
     capacity = 10
-    model = Model(GLPK.Optimizer)
+    model = Model(with_optimizer(GLPK.Optimizer))
     @variable(model, x[1:5], Bin)
     # Objective: maximize profit
     @objective(model, Max, profit' * x)

--- a/examples/max_cut_sdp.jl
+++ b/examples/max_cut_sdp.jl
@@ -31,7 +31,7 @@ function solve_max_cut_sdp(num_vertex, weights)
     laplacian = diagm(0 => weights * ones(num_vertex)) - weights
 
     # Solve the SDP relaxation
-    model = Model(SCS.Optimizer)
+    model = Model(with_optimizer(SCS.Optimizer))
     @variable(model, X[1:num_vertex, 1:num_vertex], PSD)
     @objective(model, Max, 1 / 4 * dot(laplacian, X))
     @constraint(model, diag(X) .== 1)

--- a/examples/min_distortion.jl
+++ b/examples/min_distortion.jl
@@ -40,7 +40,7 @@ For more detail, see "Lectures on discrete geometry" by J. Matoušek, Springer,
 2002, pp. 378-379.
 """
 function example_min_distortion()
-    model = Model(SCS.Optimizer)
+    model = Model(with_optimizer(SCS.Optimizer))
     set_silent(model)
     D = [0.0 1.0 1.0 1.0;
          1.0 0.0 2.0 2.0;

--- a/examples/min_ellipse.jl
+++ b/examples/min_ellipse.jl
@@ -33,7 +33,7 @@ function example_min_ellipse()
     ]
     # We change the weights to see different solutions, if they exist
     weights = [1.0 0.0; 0.0 1.0]
-    model = Model(SCS.Optimizer)
+    model = Model(with_optimizer(SCS.Optimizer))
     set_silent(model)
     @variable(model, X[i=1:2, j=1:2], PSD, start = [2.0 0.0; 0.0 3.0][i, j])
     @objective(model, Min, tr(weights * X))

--- a/examples/mle.jl
+++ b/examples/mle.jl
@@ -20,7 +20,7 @@ function example_mle(; verbose = true)
     n = 1_000
     Random.seed!(1234)
     data = randn(n)
-    model = Model(Ipopt.Optimizer)
+    model = Model(with_optimizer(Ipopt.Optimizer))
     set_silent(model)
     @variable(model, μ, start = 0.0)
     @variable(model, σ >= 0.0, start = 1.0)

--- a/examples/multi.jl
+++ b/examples/multi.jl
@@ -64,7 +64,7 @@ function example_multi(; verbose = true)
 
 
     #  DECLARE MODEL
-    multi = Model(GLPK.Optimizer)
+    multi = Model(with_optimizer(GLPK.Optimizer))
 
     #  VARIABLES
     @variable(multi, trans[1:numorig, 1:numdest, 1:numprod] >= 0)

--- a/examples/prod.jl
+++ b/examples/prod.jl
@@ -120,7 +120,7 @@ function example_prod(; verbose = true)
     minv = [[dem[p][t+1] * checkpro(p,t, pro, pir, rir) for t in numperiods] for p in 1:numprd]
     # Lower limit on inventory at end of period t
 
-    prod = Model(GLPK.Optimizer)
+    prod = Model(with_optimizer(GLPK.Optimizer))
 
     ###  VARIABLES  ###
     @variable(prod, Crews[0:lastperiod] >= 0)

--- a/examples/qcp.jl
+++ b/examples/qcp.jl
@@ -17,7 +17,7 @@ A simple quadratically constrained program based on
 http://www.gurobi.com/documentation/5.5/example-tour/node25
 """
 function example_qcp(; verbose = true)
-    model = Model(Ipopt.Optimizer)
+    model = Model(with_optimizer(Ipopt.Optimizer))
     set_silent(model)
     @variable(model, x)
     @variable(model, y >= 0)

--- a/examples/robust_uncertainty.jl
+++ b/examples/robust_uncertainty.jl
@@ -33,7 +33,7 @@ function example_robust_uncertainty()
     Γ1(𝛿, N) = R / sqrt(N) * (2 + sqrt(2 * log(1 / 𝛿)))
     Γ2(𝛿, N) = 2 * R^2 / sqrt(N) * (2 + sqrt(2 * log(2 / 𝛿)))
 
-    model = Model(SCS.Optimizer)
+    model = Model(with_optimizer(SCS.Optimizer))
     set_silent(model)
 
     @variable(model, Σ[1:d, 1:d], PSD)

--- a/examples/rosenbrock.jl
+++ b/examples/rosenbrock.jl
@@ -11,7 +11,7 @@
 using JuMP, Ipopt, Test
 
 function example_rosenbrock()
-    model = Model(Ipopt.Optimizer)
+  model = Model(with_optimizer(Ipopt.Optimizer))
     set_silent(model)
     @variable(model, x)
     @variable(model, y)

--- a/examples/rosenbrock.jl
+++ b/examples/rosenbrock.jl
@@ -11,7 +11,7 @@
 using JuMP, Ipopt, Test
 
 function example_rosenbrock()
-  model = Model(with_optimizer(Ipopt.Optimizer))
+    model = Model(with_optimizer(Ipopt.Optimizer))
     set_silent(model)
     @variable(model, x)
     @variable(model, y)

--- a/examples/steelT3.jl
+++ b/examples/steelT3.jl
@@ -51,7 +51,7 @@ function example_steelT3(; verbose = true)
     )
 
     # Model
-    model = Model(GLPK.Optimizer)
+    model = Model(with_optimizer(GLPK.Optimizer))
 
     # Decision Variables
     @variables(model, begin

--- a/examples/sudoku.jl
+++ b/examples/sudoku.jl
@@ -32,7 +32,7 @@ function example_sudoku(filepath)
         end
     end
 
-    model = Model(GLPK.Optimizer)
+    model = Model(with_optimizer(GLPK.Optimizer))
 
     @variable(model, x[1:9, 1:9, 1:9], Bin)
 

--- a/examples/transp.jl
+++ b/examples/transp.jl
@@ -35,7 +35,7 @@ function example_transp()
 		24   14   17   13   28   99   20
 	]
 
-	model = Model(GLPK.Optimizer)
+        model = Model(with_optimizer(GLPK.Optimizer))
 
 	@variable(model, trans[1:length(ORIG), 1:length(DEST)] >= 0)
 	@objective(model, Min, sum(cost[i, j] * trans[i, j] for i in 1:length(ORIG), j in 1:length(DEST)))

--- a/examples/urban_plan.jl
+++ b/examples/urban_plan.jl
@@ -17,7 +17,7 @@ An "urban planning" problem. Based on
 http://www.puzzlor.com/2013-08_UrbanPlanning.html
 """
 function example_urban_plan()
-    model = Model(GLPK.Optimizer)
+    model = Model(with_optimizer(GLPK.Optimizer))
 
     # x is indexed by row and column
     @variable(model, 0 <= x[1:5, 1:5] <= 1, Int)


### PR DESCRIPTION
I found that the `Ipopt` model in `rosenbrock.jl` example required

```
model = Model(with_optimizer(Ipopt.Optimizer, max_cpu_time=60.0))
```
to make it work. I've gone ahead and made the changes to all the examples to construct a model via `with_optimizer`.