### PR TITLE
Mention tutorials in the docs

### DIFF
--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -8,7 +8,8 @@ familiar. If you are coming from an AMPL or similar background, you may find
 some of the concepts novel but the general appearance will still be familiar.
 
 The example in this guide is deliberately kept simple. There are more complex
-examples in the [`JuMP/examples/` folder](https://github.com/JuliaOpt/JuMP.jl/tree/master/examples).
+examples in the [`JuMP/examples/` folder](https://github.com/JuliaOpt/JuMP.jl/tree/master/examples)
+and in Jupyter notebook form at [JuMPTutorials.jl](https://github.com/JuliaOpt/JuMPTutorials.jl).
 
 Once JuMP is installed, to use JuMP in your programs, you just need to say:
 ```jldoctest quickstart_example


### PR DESCRIPTION
This PR adds a mention of https://github.com/JuliaOpt/JuMPTutorials.jl in `docs/src/quickstart.md`

I see on the roadmap that integrating tutorials with docs is planned, that's great.

This is a quick little fix so that new users like me can find the existing (very nice!) tutorials more easily.