### PR TITLE
Add parse_constraint_expr and parse_constraint_head

### DIFF
--- a/src/indicator.jl
+++ b/src/indicator.jl
@@ -34,7 +34,7 @@ function parse_one_operator_constraint(
         _error("Invalid right-hand side `$(rhs)` of indicator constraint. Expected constraint surrounded by `{` and `}`.")
     end
     rhs_con = rhs.args[1]
-    rhs_vectorized, rhs_parsecode, rhs_buildcall = parse_constraint(_error, rhs_con.args...)
+    rhs_vectorized, rhs_parsecode, rhs_buildcall = parse_constraint_expr(_error, rhs_con)
     if vectorized != rhs_vectorized
         _error("Inconsistent use of `.` in symbols to indicate vectorization.")
     end


### PR DESCRIPTION
This PR continues https://github.com/JuliaOpt/JuMP.jl/pull/2051. We avoid breaking the `parse_constraint` API. We might consider renaming `parse_constraint` in `parse_call_constraint` and `parse_constraint_head` in `parse_constraint` but this might be breaking. We can consider this renaming just before we plan to release JuMP v0.22 or v1.0.
Allow parsing of non-`:call` expressions in `@constraint`.
@dourouc05 Could you provide an example use case for this ?
This is point 1) of https://github.com/JuliaOpt/JuMP.jl/pull/2051#issuecomment-617591521