### PR TITLE
Revert Tokenize version fix

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -20,8 +20,6 @@ jobs:
           using Pkg
           # If you update the version, also update the style guide docs.
           Pkg.add(PackageSpec(name="JuliaFormatter", version="0.13.2"))
-          # Remove once issue #189 in Tokenize.jl is fixed
-          Pkg.add(PackageSpec(name="Tokenize", version="0.5.18"))
           using JuliaFormatter
           format("src", verbose=true)
           format("test", verbose=true)


### PR DESCRIPTION
Version 0.5.20 has been released with the offending commit reverted.

Closes #2673 