### PR TITLE
Fixing a missed case in the OR logic in tips_and_tricks.jl

### DIFF
--- a/docs/src/tutorials/Mixed-integer linear programs/tips_and_tricks.jl
+++ b/docs/src/tutorials/Mixed-integer linear programs/tips_and_tricks.jl
@@ -44,6 +44,7 @@ model = Model()
 @constraints(model, begin
     x[1] <= x[3]
     x[2] <= x[3]
+    x[3] <= x[1] + x[2]
 end)
 
 # ### And


### PR DESCRIPTION
In the OR logic operator, it is necessary to avoid the case x[1]=0, x[2]=0, x[3]=1.  The condition x[3] <= x[1] + x[2] fixes this.