### PR TITLE
Add a test for reordering kwargs in macros

### DIFF
--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1432,6 +1432,15 @@ function test_broadcasting_variable_in_set()
     return
 end
 
+function test_reorder_keyword_arguments()
+    model = Model()
+    @variable(model, integer = true, x)
+    @test is_integer(x)
+    c = @constraint(model, base_name = "my_c", x <= 1)
+    @test name(c) == "my_c"
+    return
+end
+
 end  # module
 
 TestMacros.runtests()


### PR DESCRIPTION
Closes #2651 

It seems like this was supported, so I added a test to make sure we don't break it going forward. I don't think we want to advertise it as recommended behavior though.