### PR TITLE
[Containers] maintenance of SparseAxisArray.jl

### DIFF
--- a/src/Containers/SparseAxisArray.jl
+++ b/src/Containers/SparseAxisArray.jl
@@ -253,6 +253,12 @@ _getindex(x::Ref, ::Any) = x[]
     end
 end
 
+########
+# Show #
+########
+
+# Inspired from Julia SparseArrays stdlib package
+# `Base.summary` is also called from `showerror` on `BoundsError`.
 function Base.summary(io::IO, sa::SparseAxisArray)
     num_entries = length(sa.data)
     return print(
@@ -266,7 +272,7 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", sa::SparseAxisArray)
     summary(io, sa)
-    if length(sa.data) > 0
+    if !isempty(sa.data)
         println(io, ":")
         show(io, sa)
     end


### PR DESCRIPTION
In particular, this cleans up the broadcast implementation to avoid
private Base functions.

I started to look at the `size` issue, but I got distracted by style issues. Then I saw the broadcast implementation called `Base.Broadcast._broadcast_getindex(bc, I)` so I fixed that. I can break up the style part if requested.