### PR TITLE
Allow array in nonlinear expressions

### DIFF
--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -575,6 +575,8 @@ function moi_function(f::GenericNonlinearExpr{V}) where {V}
     for i in length(f.args):-1:1
         if f.args[i] isa GenericNonlinearExpr{V}
             push!(stack, (ret, i, f.args[i]))
+        elseif f.args[i] isa AbstractArray
+            ret.args[i] = moi_function.(f.args[i])
         else
             ret.args[i] = moi_function(f.args[i])
         end
@@ -586,6 +588,8 @@ function moi_function(f::GenericNonlinearExpr{V}) where {V}
         for j in length(arg.args):-1:1
             if arg.args[j] isa GenericNonlinearExpr{V}
                 push!(stack, (child, j, arg.args[j]))
+            elseif arg.args[j] isa AbstractArray
+                child.args[j] = moi_function.(arg.args[j])
             else
                 child.args[j] = moi_function(arg.args[j])
             end
@@ -611,6 +615,8 @@ function jump_function(model::GenericModel, f::MOI.ScalarNonlinearFunction)
             for child in reverse(arg.args)
                 push!(stack, (new_ret, child))
             end
+        elseif arg isa AbstractArray
+            push!(parent.args, jump_function.(model, arg))
         else
             push!(parent.args, jump_function(model, arg))
         end

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -330,14 +330,16 @@ Base.isreal(::GenericNonlinearExpr) = true
 
 # Univariate operators
 
-_is_real(::Any) = false
-_is_real(::Real) = true
-_is_real(::AbstractVariableRef) = true
-_is_real(::GenericAffExpr{<:Real}) = true
-_is_real(::GenericQuadExpr{<:Real}) = true
-_is_real(::GenericNonlinearExpr) = true
-_is_real(::NonlinearExpression) = true
-_is_real(::NonlinearParameter) = true
+_is_real(::Type) = false
+_is_real(::Type{<:Real}) = true
+_is_real(::Type{<:AbstractVariableRef}) = true
+_is_real(::Type{<:GenericAffExpr{<:Real}}) = true
+_is_real(::Type{<:GenericQuadExpr{<:Real}}) = true
+_is_real(::Type{<:GenericNonlinearExpr}) = true
+_is_real(::Type{<:NonlinearExpression}) = true
+_is_real(::Type{<:NonlinearParameter}) = true
+_is_real(::Type{<:AbstractArray{T}}) where {T} = _is_real(T)
+_is_real(x) = _is_real(typeof(x))
 
 function _throw_if_not_real(x)
     if !_is_real(x)

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -571,14 +571,19 @@ end
 
 moi_function(x::Number) = x
 
+# MOI.Nonlinear.ReverseAD does not support arrays but ArrayDiff.jl and
+# Convex.jl do.
+# We use `Array` and not `AbstractArray` for now because ArrayDiff
+# and Convex.jl currently only support `Array` anyway and we can expand
+# the signature in a non-breaking way later anyway.
+moi_function(x::Array{<:Number}) = x
+
 function moi_function(f::GenericNonlinearExpr{V}) where {V}
     ret = MOI.ScalarNonlinearFunction(f.head, similar(f.args))
     stack = Tuple{MOI.ScalarNonlinearFunction,Int,GenericNonlinearExpr{V}}[]
     for i in length(f.args):-1:1
         if f.args[i] isa GenericNonlinearExpr{V}
             push!(stack, (ret, i, f.args[i]))
-        elseif f.args[i] isa AbstractArray
-            ret.args[i] = moi_function.(f.args[i])
         else
             ret.args[i] = moi_function(f.args[i])
         end
@@ -590,8 +595,6 @@ function moi_function(f::GenericNonlinearExpr{V}) where {V}
         for j in length(arg.args):-1:1
             if arg.args[j] isa GenericNonlinearExpr{V}
                 push!(stack, (child, j, arg.args[j]))
-            elseif arg.args[j] isa AbstractArray
-                child.args[j] = moi_function.(arg.args[j])
             else
                 child.args[j] = moi_function(arg.args[j])
             end
@@ -617,8 +620,6 @@ function jump_function(model::GenericModel, f::MOI.ScalarNonlinearFunction)
             for child in reverse(arg.args)
                 push!(stack, (new_ret, child))
             end
-        elseif arg isa AbstractArray
-            push!(parent.args, jump_function.(model, arg))
         else
             push!(parent.args, jump_function(model, arg))
         end

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -112,6 +112,13 @@ function variable_ref_type(::Type{GenericNonlinearExpr}, x::AbstractJuMPScalar)
     return variable_ref_type(x)
 end
 
+function variable_ref_type(
+    ::Type{GenericNonlinearExpr},
+    ::AbstractArray{T},
+) where {T<:AbstractJuMPScalar}
+    return variable_ref_type(T)
+end
+
 value_type(::Type{GenericNonlinearExpr{V}}) where {V} = value_type(V)
 
 function _has_variable_ref_type(a)
@@ -571,12 +578,9 @@ end
 
 moi_function(x::Number) = x
 
-# MOI.Nonlinear.ReverseAD does not support arrays but ArrayDiff.jl and
-# Convex.jl do.
-# We use `Array` and not `AbstractArray` for now because ArrayDiff
-# and Convex.jl currently only support `Array` anyway and we can expand
-# the signature in a non-breaking way later anyway.
-moi_function(x::Array) = moi_function.(x)
+# `moi_function(::Array)` would be ambiguous with
+# `moi_function(AbstractArray{<:AbstractVariableRef})`
+moi_function(x::AbstractArray) = moi_function.(x)
 
 function moi_function(f::GenericNonlinearExpr{V}) where {V}
     ret = MOI.ScalarNonlinearFunction(f.head, similar(f.args))

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -576,7 +576,7 @@ moi_function(x::Number) = x
 # We use `Array` and not `AbstractArray` for now because ArrayDiff
 # and Convex.jl currently only support `Array` anyway and we can expand
 # the signature in a non-breaking way later anyway.
-moi_function(x::Array{<:Number}) = x
+moi_function(x::Array) = moi_function.(x)
 
 function moi_function(f::GenericNonlinearExpr{V}) where {V}
     ret = MOI.ScalarNonlinearFunction(f.head, similar(f.args))

--- a/test/test_nlp_expr.jl
+++ b/test/test_nlp_expr.jl
@@ -6,6 +6,7 @@
 module TestNLPExpr
 
 using JuMP
+using LinearAlgebra
 using Test
 
 import LinearAlgebra
@@ -1230,6 +1231,16 @@ function test_extension_euler_to_exp(
     @test isequal_canonical(sum(ℯ^xᵢ for xᵢ in xy), exp(x) + exp(y))
     @test isequal_canonical(ℯ^prod(xy), exp(x*y))
     return
+end
+
+function test_array()
+    model = Model()
+    @variable(model, x)
+    op_norm = NonlinearOperator(:det, det)
+    @objective(model, Min, op_norm([x]))
+    f = MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarNonlinearFunction}())
+    @test f.head == :norm
+    @test f.args == [[index(x)]]
 end
 
 end  # module

--- a/test/test_nlp_expr.jl
+++ b/test/test_nlp_expr.jl
@@ -6,7 +6,6 @@
 module TestNLPExpr
 
 using JuMP
-using LinearAlgebra
 using Test
 
 import LinearAlgebra
@@ -1233,24 +1232,28 @@ function test_extension_euler_to_exp(
     return
 end
 
-function test_array()
+function test_array_det()
     model = Model()
     @variable(model, x)
-    vov = MOI.VectorOfVariables([index(x)])
-    op_det = NonlinearOperator(det, :det)
+    op_det = NonlinearOperator(LinearAlgebra.det, :det)
     @objective(model, Min, op_det([x]))
-    f = MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarNonlinearFunction}())
-    @test f.head == :det
-    @test f.args == [vov]
+    @test isapprox(
+        MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarNonlinearFunction}()),
+        MOI.ScalarNonlinearFunction(:det, Any[moi_function([x])]),
+    )
+    return
+end
 
-    op_dot = NonlinearOperator(dot, :dot)
-    a = [2.0]
-    @objective(model, Min, op_dot([x], a))
-    f = MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarNonlinearFunction}())
-    @test f.head == :dot
-    @test length(f.args) == 2
-    @test f.args[1] == vov
-    @test f.args[2] == a
+function test_array_dot()
+    model = Model()
+    @variable(model, x)
+    op_dot = NonlinearOperator(LinearAlgebra.dot, :dot)
+    @objective(model, Min, op_dot([x], [2.0]))
+    @test isapprox(
+        MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarNonlinearFunction}()),
+        MOI.ScalarNonlinearFunction(:dot, Any[moi_function([x]), [2.0]]),
+    )
+    return
 end
 
 # Inspired from contiguous arrays in ArrayDiff and GenOpt
@@ -1263,11 +1266,11 @@ struct Contiguous end
 
 function JuMP.Containers.container(
     _,
-    axe::JuMP.Containers.VectorizedProductIterator{Tuple{Base.OneTo{Int}}},
+    axes::JuMP.Containers.VectorizedProductIterator{Tuple{Base.OneTo{Int}}},
     ::Contiguous,
 )
     # Correctness don't matter, it's not for the sake of this test
-    return ContiguousVectorOfVariableRefs(0, length(axe))
+    return ContiguousVectorOfVariableRefs(0, length(axes))
 end
 
 struct ContiguousVectorOfVariableIndices <: MOI.AbstractVectorFunction
@@ -1289,7 +1292,8 @@ function test_custom_array()
     @objective(model, Min, op_norm(x))
     f = MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarNonlinearFunction}())
     @test f.head == :norm
-    @test f.args[] == ContiguousVectorOfVariableIndices(0, 2)
+    @test only(f.args) == ContiguousVectorOfVariableIndices(0, 2)
+    return
 end
 
 end  # module

--- a/test/test_nlp_expr.jl
+++ b/test/test_nlp_expr.jl
@@ -1236,11 +1236,11 @@ end
 function test_array()
     model = Model()
     @variable(model, x)
-    op_norm = NonlinearOperator(:det, det)
-    @objective(model, Min, op_norm([x]))
+    op_det = NonlinearOperator(det, :det)
+    @objective(model, Min, op_det([x]))
     f = MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarNonlinearFunction}())
-    @test f.head == :norm
-    @test f.args == [[index(x)]]
+    @test f.head == :det
+    @test f.args == [MOI.VectorOfVariables([index(x)])]
 end
 
 end  # module

--- a/test/test_nlp_expr.jl
+++ b/test/test_nlp_expr.jl
@@ -1236,11 +1236,60 @@ end
 function test_array()
     model = Model()
     @variable(model, x)
+    vov = MOI.VectorOfVariables([index(x)])
     op_det = NonlinearOperator(det, :det)
     @objective(model, Min, op_det([x]))
     f = MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarNonlinearFunction}())
     @test f.head == :det
-    @test f.args == [MOI.VectorOfVariables([index(x)])]
+    @test f.args == [vov]
+
+    op_dot = NonlinearOperator(dot, :dot)
+    a = [2.0]
+    @objective(model, Min, op_dot([x], a))
+    f = MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarNonlinearFunction}())
+    @test f.head == :dot
+    @test length(f.args) == 2
+    @test f.args[1] == vov
+    @test f.args[2] == a
+end
+
+# Inspired from contiguous arrays in ArrayDiff and GenOpt
+struct ContiguousVectorOfVariableRefs <: AbstractVector{JuMP.VariableRef}
+    offset::Int
+    length::Int
+end
+
+struct Contiguous end
+
+function JuMP.Containers.container(
+    _,
+    axe::JuMP.Containers.VectorizedProductIterator{Tuple{Base.OneTo{Int}}},
+    ::Contiguous,
+)
+    # Correctness don't matter, it's not for the sake of this test
+    return ContiguousVectorOfVariableRefs(0, length(axe))
+end
+
+struct ContiguousVectorOfVariableIndices <: MOI.AbstractVectorFunction
+    offset::Int
+    length::Int
+end
+
+Base.copy(x::ContiguousVectorOfVariableIndices) = x
+
+function JuMP.moi_function(x::ContiguousVectorOfVariableRefs)
+    return ContiguousVectorOfVariableIndices(x.offset, x.length)
+end
+
+function test_custom_array()
+    model = Model()
+    @variable(model, x[1:2], container = Contiguous())
+    @test x === ContiguousVectorOfVariableRefs(0, 2)
+    op_norm = NonlinearOperator(LinearAlgebra.norm, :norm)
+    @objective(model, Min, op_norm(x))
+    f = MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarNonlinearFunction}())
+    @test f.head == :norm
+    @test f.args[] == ContiguousVectorOfVariableIndices(0, 2)
 end
 
 end  # module


### PR DESCRIPTION
This PR is a proof of concept to show the possibility of storing arrays in the JuMP nonlinear expression and MOI nonlinear function.
Of course, it won't work with the AD but it can be supported by a solver or by a Disciplined Convex Programming transformation.
```julia
julia> model = Model();

julia> @variable(model, X[1:3, 1:3], Symmetric)
3×3 LinearAlgebra.Symmetric{VariableRef, Matrix{VariableRef}}:
 X[1,1]  X[1,2]  X[1,3]
 X[1,2]  X[2,2]  X[2,3]
 X[1,3]  X[2,3]  X[3,3]

julia> using LinearAlgebra

julia> @constraint(model, log(det(X)) >= 0)
log(det(VariableRef[X[1,1] X[1,2] X[1,3]; X[1,2] X[2,2] X[2,3]; X[1,3] X[2,3] X[3,3]])) - 0.0 ≥ 0
```