### PR TITLE
Update `extension-tests` workflow to include DisjunctiveProgramming

### DIFF
--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -13,6 +13,7 @@ jobs:
         include:
           - package: 'Alpine'
           - package: 'BilevelJuMP'
+          - package: 'DisjunctiveProgramming'
           - package: 'InfiniteOpt'
           - package: 'LinearFractional'
           - package: 'Plasmo'


### PR DESCRIPTION
DisjunctiveProgramming has now reached a fairly mature state as an extension.