### PR TITLE
(slow) operations tracker

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -126,6 +126,8 @@ mutable struct GenericModel{T<:Real} <: AbstractModel
     set_string_names_on_creation::Bool
     #
     variable_in_set_ref::Dict{Any,MOI.ConstraintIndex}
+    # A cache for tracking ineficient use of operations.
+    operation_stack::Union{Nothing,Vector{Vector{Base.StackTraces.StackFrame}}}
 end
 
 value_type(::Type{GenericModel{T}}) where {T} = T
@@ -242,6 +244,7 @@ function direct_generic_model(
         Dict{Symbol,Any}(),
         true,
         Dict{Any,MOI.ConstraintIndex}(),
+        nothing,
     )
 end
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -495,7 +495,7 @@ function Base.:-(lhs::GenericQuadExpr)
     if _trackable_model(model)
         push!(model.operation_stack, stacktrace())
     end
-    map_coefficients(-, lhs)
+    return map_coefficients(-, lhs)
 end
 
 # GenericQuadExpr--_Constant
@@ -870,7 +870,7 @@ See also [`set_operator_tracking`](@ref), [`get_operator_tracking_list`](@ref),
 and [`unset_operator_tracking`](@ref).
 """
 function reset_operator_tracking(model::AbstractModel)
-    model.operation_stack = Vector{Base.StackFrame}()
+    return model.operation_stack = Vector{Base.StackFrame}()
 end
 
 """
@@ -883,7 +883,7 @@ See also [`set_operator_tracking`](@ref), [`get_operator_tracking_list`](@ref),
 and [`reset_operator_tracking`](@ref).
 """
 function unset_operator_tracking(model::AbstractModel)
-    model.operation_stack = nothing
+    return model.operation_stack = nothing
 end
 
 """


### PR DESCRIPTION
This adds the optional ability to mark all places where slow operations that allocate expression occur. Keeping the stack might be a lot of data, but it is a way to properly identify the issues instead of erroring one by one.

Possible additional functionality:
1 - also mark the operation type. A bit redundant with the stack, but might lead to summary reports.
2 - create a user friendly summary

TODO

- [ ] add tests
- [ ] add docs session, to be referenced in the performance issues.