### PR TITLE
Cache subexpressions when building MOI.ScalarNonlinearExpression

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -15,6 +15,7 @@ BasedOnStyles = Vale, Google
 
 # TODO(odow): fix all of these
 Google.Ellipses = OFF
+Google.EmDash = OF
 Google.Exclamation = OFF
 Google.FirstPerson = OFF
 Google.OptionalPlurals = OFF

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -162,6 +162,8 @@ mutable struct GenericModel{T<:Real} <: AbstractModel
     # A dictionary to store timing information from the JuMP macros.
     enable_macro_timing::Bool
     macro_times::Dict{Tuple{LineNumberNode,String},Float64}
+    # We use `Any` as key because we haven't defined `GenericNonlinearExpr` yet
+    subexpressions::Dict{Any,MOI.ScalarNonlinearFunction}
 end
 
 value_type(::Type{GenericModel{T}}) where {T} = T
@@ -276,6 +278,7 @@ function direct_generic_model(
         Dict{Any,MOI.ConstraintIndex}(),
         false,
         Dict{Tuple{LineNumberNode,String},Float64}(),
+        Dict{Any,MOI.ScalarNonlinearFunction}(),
     )
 end
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -162,7 +162,7 @@ mutable struct GenericModel{T<:Real} <: AbstractModel
     # A dictionary to store timing information from the JuMP macros.
     enable_macro_timing::Bool
     macro_times::Dict{Tuple{LineNumberNode,String},Float64}
-    # We use `Any` as key because we haven't defined `GenericNonlinearExpr` yet
+    # A cache to track common subexpressions based on their `objectid`.
     subexpressions::Dict{UInt64,MOI.ScalarNonlinearFunction}
 end
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -163,7 +163,7 @@ mutable struct GenericModel{T<:Real} <: AbstractModel
     enable_macro_timing::Bool
     macro_times::Dict{Tuple{LineNumberNode,String},Float64}
     # We use `Any` as key because we haven't defined `GenericNonlinearExpr` yet
-    subexpressions::Dict{Any,MOI.ScalarNonlinearFunction}
+    subexpressions::Dict{UInt64,MOI.ScalarNonlinearFunction}
 end
 
 value_type(::Type{GenericModel{T}}) where {T} = T
@@ -278,7 +278,7 @@ function direct_generic_model(
         Dict{Any,MOI.ConstraintIndex}(),
         false,
         Dict{Tuple{LineNumberNode,String},Float64}(),
-        Dict{Any,MOI.ScalarNonlinearFunction}(),
+        Dict{UInt64,MOI.ScalarNonlinearFunction}(),
     )
 end
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -769,6 +769,10 @@ function moi_function(constraint::AbstractConstraint)
     return moi_function(jump_function(constraint))
 end
 
+function moi_function(constraint::AbstractConstraint, model)
+    return moi_function(jump_function(constraint), model)
+end
+
 """
     moi_set(constraint::AbstractConstraint)
 
@@ -1028,6 +1032,11 @@ function _moi_add_constraint(
     return MOI.add_constraint(model, f, s)
 end
 
+function moi_function(f, model)
+    check_belongs_to_model(f, model)
+    return moi_function(f)
+end
+
 """
     add_constraint(
         model::GenericModel,
@@ -1044,10 +1053,9 @@ function add_constraint(
     name::String = "",
 )
     con = model_convert(model, con)
+    func, set = moi_function(con, model), moi_set(con)
     # The type of backend(model) is unknown so we directly redirect to another
     # function.
-    check_belongs_to_model(con, model)
-    func, set = moi_function(con), moi_set(con)
     cindex = _moi_add_constraint(
         backend(model),
         func,

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1036,6 +1036,7 @@ function check_belongs_to_model(f::Vector, model)
     for func in f
         check_belongs_to_model(func, model)
     end
+    return
 end
 
 function moi_function(model, f)

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1032,6 +1032,12 @@ function _moi_add_constraint(
     return MOI.add_constraint(model, f, s)
 end
 
+function check_belongs_to_model(f::Vector, model)
+    for func in f
+        check_belongs_to_model(func, model)
+    end
+end
+
 function moi_function(f, model)
     check_belongs_to_model(f, model)
     return moi_function(f)

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -769,8 +769,8 @@ function moi_function(constraint::AbstractConstraint)
     return moi_function(jump_function(constraint))
 end
 
-function moi_function(constraint::AbstractConstraint, model)
-    return moi_function(jump_function(constraint), model)
+function moi_function(model, constraint::AbstractConstraint)
+    return moi_function(model, jump_function(constraint))
 end
 
 """
@@ -1038,7 +1038,7 @@ function check_belongs_to_model(f::Vector, model)
     end
 end
 
-function moi_function(f, model)
+function moi_function(model, f)
     check_belongs_to_model(f, model)
     return moi_function(f)
 end
@@ -1059,7 +1059,7 @@ function add_constraint(
     name::String = "",
 )
     con = model_convert(model, con)
-    func, set = moi_function(con, model), moi_set(con)
+    func, set = moi_function(model, con), moi_set(con)
     # The type of backend(model) is unknown so we directly redirect to another
     # function.
     cindex = _moi_add_constraint(

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -1241,6 +1241,7 @@ function moi_function(f::AbstractVector{<:GenericNonlinearExpr})
 end
 
 function MOI.VectorNonlinearFunction(f::Vector{<:AbstractJuMPScalar})
+    model = owner_model(first(f))
     return MOI.VectorNonlinearFunction(moi_function.(f, model))
 end
 
@@ -1287,7 +1288,7 @@ x
 ```
 """
 function simplify(model::GenericModel, f::AbstractJuMPScalar)
-    g = MOI.Nonlinear.SymbolicAD.simplify(moi_function(f))
+    g = MOI.Nonlinear.SymbolicAD.simplify(moi_function(f, model))
     return jump_function(model, g)
 end
 
@@ -1384,7 +1385,7 @@ julia> ∇f[y]
 ```
 """
 function gradient(model::GenericModel{T}, f::AbstractJuMPScalar) where {T}
-    g = moi_function(f)
+    g = moi_function(f, model)
     ∇f = Dict{GenericVariableRef{T},Any}()
     for xi in MOI.Nonlinear.SymbolicAD.variables(g)
         df_dx = MOI.Nonlinear.SymbolicAD.simplify!(

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -588,8 +588,9 @@ function moi_function(
     model::JuMP.GenericModel,
 ) where {V}
     cache = model.subexpressions
-    if haskey(cache, f)
-        return cache[f]
+    key = objectid(f)
+    if haskey(cache, key)
+        return cache[key]
     end
     ret = MOI.ScalarNonlinearFunction(f.head, similar(f.args))
     stack = Tuple{MOI.ScalarNonlinearFunction,Int,GenericNonlinearExpr{V}}[]
@@ -604,8 +605,9 @@ function moi_function(
     end
     while !isempty(stack)
         parent, i, arg = pop!(stack)
-        if haskey(cache, arg)
-            parent.args[i] = cache[arg]
+        arg_key = objectid(arg)
+        if haskey(cache, arg_key)
+            parent.args[i] = cache[arg_key]
             continue
         end
         child = MOI.ScalarNonlinearFunction(arg.head, similar(arg.args))
@@ -617,9 +619,9 @@ function moi_function(
                 child.args[j] = moi_function(arg.args[j])
             end
         end
-        cache[arg] = child
+        cache[arg_key] = child
     end
-    cache[f] = ret
+    cache[key] = ret
     return ret
 end
 

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -597,7 +597,7 @@ function moi_function(
         if f.args[i] isa GenericNonlinearExpr{V}
             push!(stack, (ret, i, f.args[i]))
         elseif f.args[i] isa AbstractJuMPScalar
-            ret.args[i] = moi_function(model, f.args[i])
+            ret.args[i] = moi_function(f.args[i], model)
         else
             ret.args[i] = moi_function(f.args[i])
         end

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -584,6 +584,10 @@ end
 moi_function(x::Number) = x
 
 function moi_function(f::GenericNonlinearExpr{V}) where {V}
+    model = owner_model(f)
+    if haskey(model.subexpressions, f)
+        return model.subexpressions[f]
+    end
     ret = MOI.ScalarNonlinearFunction(f.head, similar(f.args))
     stack = Tuple{MOI.ScalarNonlinearFunction,Int,GenericNonlinearExpr{V}}[]
     for i in length(f.args):-1:1
@@ -595,6 +599,10 @@ function moi_function(f::GenericNonlinearExpr{V}) where {V}
     end
     while !isempty(stack)
         parent, i, arg = pop!(stack)
+        if haskey(model.subexpressions, arg)
+            parent.args[i] = model.subexpressions[arg]
+            continue
+        end
         child = MOI.ScalarNonlinearFunction(arg.head, similar(arg.args))
         parent.args[i] = child
         for j in length(arg.args):-1:1
@@ -604,7 +612,9 @@ function moi_function(f::GenericNonlinearExpr{V}) where {V}
                 child.args[j] = moi_function(arg.args[j])
             end
         end
+        model.subexpressions[arg] = child
     end
+    model.subexpressions[f] = ret
     return ret
 end
 

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -585,8 +585,9 @@ moi_function(x::Number) = x
 
 function moi_function(f::GenericNonlinearExpr{V}) where {V}
     model = owner_model(f)
-    if haskey(model.subexpressions, f)
-        return model.subexpressions[f]
+    cache = isnothing(model) ? nothing : model.subexpressions
+    if !isnothing(cache) && haskey(cache, f)
+        return cache[f]
     end
     ret = MOI.ScalarNonlinearFunction(f.head, similar(f.args))
     stack = Tuple{MOI.ScalarNonlinearFunction,Int,GenericNonlinearExpr{V}}[]
@@ -599,8 +600,8 @@ function moi_function(f::GenericNonlinearExpr{V}) where {V}
     end
     while !isempty(stack)
         parent, i, arg = pop!(stack)
-        if haskey(model.subexpressions, arg)
-            parent.args[i] = model.subexpressions[arg]
+        if !isnothing(cache) && haskey(cache, arg)
+            parent.args[i] = cache[arg]
             continue
         end
         child = MOI.ScalarNonlinearFunction(arg.head, similar(arg.args))
@@ -612,9 +613,13 @@ function moi_function(f::GenericNonlinearExpr{V}) where {V}
                 child.args[j] = moi_function(arg.args[j])
             end
         end
-        model.subexpressions[arg] = child
+        if !isnothing(cache)
+            cache[arg] = child
+        end
     end
-    model.subexpressions[f] = ret
+    if !isnothing(cache)
+        cache[f] = ret
+    end
     return ret
 end
 

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -583,7 +583,10 @@ end
 
 moi_function(x::Number) = x
 
-function moi_function(f::GenericNonlinearExpr{V}, model::JuMP.GenericModel) where {V}
+function moi_function(
+    f::GenericNonlinearExpr{V},
+    model::JuMP.GenericModel,
+) where {V}
     cache = model.subexpressions
     if haskey(cache, f)
         return cache[f]

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -583,10 +583,9 @@ end
 
 moi_function(x::Number) = x
 
-function moi_function(f::GenericNonlinearExpr{V}) where {V}
-    model = owner_model(f)
-    cache = isnothing(model) ? nothing : model.subexpressions
-    if !isnothing(cache) && haskey(cache, f)
+function moi_function(f::GenericNonlinearExpr{V}, model::JuMP.GenericModel) where {V}
+    cache = model.subexpressions
+    if haskey(cache, f)
         return cache[f]
     end
     ret = MOI.ScalarNonlinearFunction(f.head, similar(f.args))
@@ -594,13 +593,15 @@ function moi_function(f::GenericNonlinearExpr{V}) where {V}
     for i in length(f.args):-1:1
         if f.args[i] isa GenericNonlinearExpr{V}
             push!(stack, (ret, i, f.args[i]))
+        elseif f.args[i] isa AbstractJuMPScalar
+            ret.args[i] = moi_function(model, f.args[i])
         else
             ret.args[i] = moi_function(f.args[i])
         end
     end
     while !isempty(stack)
         parent, i, arg = pop!(stack)
-        if !isnothing(cache) && haskey(cache, arg)
+        if haskey(cache, arg)
             parent.args[i] = cache[arg]
             continue
         end
@@ -613,13 +614,9 @@ function moi_function(f::GenericNonlinearExpr{V}) where {V}
                 child.args[j] = moi_function(arg.args[j])
             end
         end
-        if !isnothing(cache)
-            cache[arg] = child
-        end
+        cache[arg] = child
     end
-    if !isnothing(cache)
-        cache[f] = ret
-    end
+    cache[f] = ret
     return ret
 end
 

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -584,8 +584,8 @@ end
 moi_function(x::Number) = x
 
 function moi_function(
-    f::GenericNonlinearExpr{V},
     model::JuMP.GenericModel,
+    f::GenericNonlinearExpr{V},
 ) where {V}
     cache = model.subexpressions
     key = objectid(f)
@@ -598,7 +598,7 @@ function moi_function(
         if f.args[i] isa GenericNonlinearExpr{V}
             push!(stack, (ret, i, f.args[i]))
         elseif f.args[i] isa AbstractJuMPScalar
-            ret.args[i] = moi_function(f.args[i], model)
+            ret.args[i] = moi_function(model, f.args[i])
         else
             ret.args[i] = moi_function(f.args[i])
         end
@@ -1244,7 +1244,7 @@ end
 
 function MOI.VectorNonlinearFunction(f::Vector{<:AbstractJuMPScalar})
     model = owner_model(first(f))
-    return MOI.VectorNonlinearFunction(moi_function.(f, model))
+    return MOI.VectorNonlinearFunction(moi_function.(model, f))
 end
 
 """
@@ -1290,7 +1290,7 @@ x
 ```
 """
 function simplify(model::GenericModel, f::AbstractJuMPScalar)
-    g = MOI.Nonlinear.SymbolicAD.simplify(moi_function(f, model))
+    g = MOI.Nonlinear.SymbolicAD.simplify(moi_function(model, f))
     return jump_function(model, g)
 end
 
@@ -1342,7 +1342,7 @@ function derivative(
     x::GenericVariableRef{T},
 ) where {T}
     df_dx =
-        MOI.Nonlinear.SymbolicAD.derivative(moi_function(f, model), index(x))
+        MOI.Nonlinear.SymbolicAD.derivative(moi_function(model, f), index(x))
     return jump_function(model, MOI.Nonlinear.SymbolicAD.simplify!(df_dx))
 end
 
@@ -1387,7 +1387,7 @@ julia> ∇f[y]
 ```
 """
 function gradient(model::GenericModel{T}, f::AbstractJuMPScalar) where {T}
-    g = moi_function(f, model)
+    g = moi_function(model, f)
     ∇f = Dict{GenericVariableRef{T},Any}()
     for xi in MOI.Nonlinear.SymbolicAD.variables(g)
         df_dx = MOI.Nonlinear.SymbolicAD.simplify!(

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -1241,7 +1241,7 @@ function moi_function(f::AbstractVector{<:GenericNonlinearExpr})
 end
 
 function MOI.VectorNonlinearFunction(f::Vector{<:AbstractJuMPScalar})
-    return MOI.VectorNonlinearFunction(map(moi_function, f))
+    return MOI.VectorNonlinearFunction(moi_function.(f, model))
 end
 
 """

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -1338,7 +1338,8 @@ function derivative(
     f::AbstractJuMPScalar,
     x::GenericVariableRef{T},
 ) where {T}
-    df_dx = MOI.Nonlinear.SymbolicAD.derivative(moi_function(f), index(x))
+    df_dx =
+        MOI.Nonlinear.SymbolicAD.derivative(moi_function(f, model), index(x))
     return jump_function(model, MOI.Nonlinear.SymbolicAD.simplify!(df_dx))
 end
 

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -583,14 +583,10 @@ end
 
 moi_function(x::Number) = x
 
-function moi_function(
-    model::JuMP.GenericModel,
-    f::GenericNonlinearExpr{V},
-) where {V}
-    cache = model.subexpressions
+function moi_function(model::GenericModel, f::GenericNonlinearExpr{V}) where {V}
     key = objectid(f)
-    if haskey(cache, key)
-        return cache[key]
+    if haskey(model.subexpressions, key)
+        return model.subexpressions[key]
     end
     ret = MOI.ScalarNonlinearFunction(f.head, similar(f.args))
     stack = Tuple{MOI.ScalarNonlinearFunction,Int,GenericNonlinearExpr{V}}[]
@@ -606,8 +602,8 @@ function moi_function(
     while !isempty(stack)
         parent, i, arg = pop!(stack)
         arg_key = objectid(arg)
-        if haskey(cache, arg_key)
-            parent.args[i] = cache[arg_key]
+        if haskey(model.subexpressions, arg_key)
+            parent.args[i] = model.subexpressions[arg_key]
             continue
         end
         child = MOI.ScalarNonlinearFunction(arg.head, similar(arg.args))
@@ -619,9 +615,9 @@ function moi_function(
                 child.args[j] = moi_function(arg.args[j])
             end
         end
-        cache[arg_key] = child
+        model.subexpressions[arg_key] = child
     end
-    cache[key] = ret
+    model.subexpressions[key] = ret
     return ret
 end
 

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -280,7 +280,7 @@ end
 
 function set_objective_function(model::GenericModel, func::AbstractJuMPScalar)
     check_belongs_to_model(func, model)
-    set_objective_function(model, moi_function(func, model))
+    set_objective_function(model, moi_function(model, func))
     return
 end
 
@@ -299,7 +299,7 @@ function set_objective_function(
     for f in func
         check_belongs_to_model(f, model)
     end
-    set_objective_function(model, moi_function(func, model))
+    set_objective_function(model, moi_function(model, func))
     return
 end
 

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -280,7 +280,7 @@ end
 
 function set_objective_function(model::GenericModel, func::AbstractJuMPScalar)
     check_belongs_to_model(func, model)
-    set_objective_function(model, moi_function(func))
+    set_objective_function(model, moi_function(func, model))
     return
 end
 
@@ -299,7 +299,7 @@ function set_objective_function(
     for f in func
         check_belongs_to_model(f, model)
     end
-    set_objective_function(model, moi_function(func))
+    set_objective_function(model, moi_function(func, model))
     return
 end
 

--- a/test/perf/benchmark_cache.jl
+++ b/test/perf/benchmark_cache.jl
@@ -196,20 +196,14 @@ end
 # `e_k = e_{k-1} + e_{k-1}`. With no cache this expands to 2^K leaves; with
 # either cache it stays linear in K.
 #
-# We build the `+` node directly via the GenericNonlinearExpr constructor so
-# JuMP's `+` operator overload does NOT flatten the n-ary sum. Without this,
-# `e + e` returns a flat `:+(args...)` of 2^K identical leaf references and
-# the master walk only iterates 2^K times instead of doing 2^K *recursive*
-# descents through K levels — which would mask the worst case the PR is
-# meant to fix.
+# We build use `atan` as with `+`, it gets flattened.
 function scenario_aliased_tree(; K::Int)
-    V = JuMP.VariableRef
     return function ()
         model = Model()
         @variable(model, x)
         e = sin(x)
         for _ in 1:K
-            e = JuMP.GenericNonlinearExpr{V}(:+, e, e)
+            e = atan(e, e)
         end
         @constraint(model, e <= 1)
         return model
@@ -259,14 +253,13 @@ end
 # across constraints there is nothing to share. This is the natural
 # territory of odow's per-call dict.
 function scenario_many_aliased(; M::Int = 200, K::Int = 8)
-    V = JuMP.VariableRef
     return function ()
         model = Model()
         @variable(model, x[1:M])
         for i in 1:M
             e = sin(x[i])
             for _ in 1:K
-                e = JuMP.GenericNonlinearExpr{V}(:+, e, e)
+                e = atan(e, e)
             end
             @constraint(model, e <= 1)
         end
@@ -285,32 +278,10 @@ function run_bench(label, build)
     println("="^72)
     println(label)
     println("="^72)
-    # Warm up each mode (compile its method specializations) before
-    # timing, so the first sample isn't biased by JIT.
     for m in MODES
         BENCH_MODE[] = m
-        build()
+        display(@benchmark $build())
     end
-    results = Dict{Symbol,Any}()
-    for m in MODES
-        BENCH_MODE[] = m
-        b = @benchmark $build() samples = 5 evals = 1 seconds = 30
-        results[m] = b
-        t_ms = minimum(b).time / 1e6
-        mem_mb = minimum(b).memory / 1024^2
-        allocs = minimum(b).allocs
-        @printf("  %-13s  %10.2f ms   %9.2f MiB   %12d allocs\n",
-                string(m), t_ms, mem_mb, allocs)
-    end
-    # Ratios versus the branch's model_struct baseline so we can see
-    # where each strategy wins, ties, or loses.
-    base = minimum(results[:model_struct]).time
-    println()
-    for m in MODES
-        r = minimum(results[m]).time / base
-        @printf("  ratio(%-13s / model_struct) = %.2f\n", string(m), r)
-    end
-    println()
 end
 
 function one_aliased_tree(; K = 16)
@@ -336,4 +307,4 @@ function run_all()
     many_aliased_tree()
 end
 
-#run_all()
+run_all()

--- a/test/perf/benchmark_cache.jl
+++ b/test/perf/benchmark_cache.jl
@@ -158,11 +158,12 @@ const BENCH_MODE = Ref(:model_struct)
 # branch's `Dict{Any,...}`. We store them on the model as a side table so
 # they survive across constraints inside one build but are cleared between
 # builds (because each scenario builds a fresh `Model()`).
-const _OID_CACHE = IdDict{JuMP.GenericModel,Dict{UInt64,MOI.ScalarNonlinearFunction}}()
+const _OID_CACHE =
+    IdDict{JuMP.GenericModel,Dict{UInt64,MOI.ScalarNonlinearFunction}}()
 
 function _oid_cache(model)
     get!(_OID_CACHE, model) do
-        Dict{UInt64,MOI.ScalarNonlinearFunction}()
+        return Dict{UInt64,MOI.ScalarNonlinearFunction}()
     end
 end
 
@@ -271,7 +272,6 @@ end
 # Runner
 # ---------------------------------------------------------------------------
 
-
 const MODES = [:none, :per_call_oid, :model_struct, :model_oid]
 
 function run_bench(label, build)
@@ -285,26 +285,38 @@ function run_bench(label, build)
 end
 
 function one_aliased_tree(; K = 16)
-    run_bench("A: aliased tree (one big DAG, K=$K)",      scenario_aliased_tree(; K))
+    return run_bench(
+        "A: aliased tree (one big DAG, K=$K)",
+        scenario_aliased_tree(; K),
+    )
 end
 
 function independent()
-    run_bench("B: many independent constraints (N=5000)", scenario_many_independent(N = 5_000))
+    return run_bench(
+        "B: many independent constraints (N=5000)",
+        scenario_many_independent(; N = 5_000),
+    )
 end
 
 function shared_subexpr()
-    run_bench("C: shared big subexpr (N=200, M=200)",     scenario_shared_big(N = 200, M = 200))
+    return run_bench(
+        "C: shared big subexpr (N=200, M=200)",
+        scenario_shared_big(; N = 200, M = 200),
+    )
 end
 
 function many_aliased_tree()
-    run_bench("D: many aliased trees (M=200, K=8)",       scenario_many_aliased(M = 200, K = 8))
+    return run_bench(
+        "D: many aliased trees (M=200, K=8)",
+        scenario_many_aliased(; M = 200, K = 8),
+    )
 end
 
 function run_all()
     one_aliased_tree()
     independent()
     shared_subexpr()
-    many_aliased_tree()
+    return many_aliased_tree()
 end
 
 run_all()

--- a/test/perf/benchmark_cache.jl
+++ b/test/perf/benchmark_cache.jl
@@ -1,3 +1,8 @@
+#  Copyright 2017, Iain Dunning, Joey Huchette, Miles Lubin, and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 # Benchmark for PR #4032: caching strategies for moi_function on
 # GenericNonlinearExpr.
 #

--- a/test/perf/benchmark_cache.jl
+++ b/test/perf/benchmark_cache.jl
@@ -50,7 +50,7 @@
 #                                               objectid keys fixes it.
 #   C: shared big subexpr (N=200, M=200)       model_struct 171 / model_oid 170
 #                                               vs none 191 / per_call_oid 195
-#                                               → 12–14% win for the model-
+#                                               → 12 to 14% win for the model-
 #                                               level cache. Per-call cannot
 #                                               see the cross-constraint
 #                                               sharing.

--- a/test/perf/benchmark_cache.jl
+++ b/test/perf/benchmark_cache.jl
@@ -202,7 +202,7 @@ end
 # the master walk only iterates 2^K times instead of doing 2^K *recursive*
 # descents through K levels — which would mask the worst case the PR is
 # meant to fix.
-function scenario_aliased_tree(; K::Int = 14)
+function scenario_aliased_tree(; K::Int)
     V = JuMP.VariableRef
     return function ()
         model = Model()
@@ -278,54 +278,62 @@ end
 # Runner
 # ---------------------------------------------------------------------------
 
-const SCENARIOS = [
-    ("A: aliased tree (one big DAG, K=14)",      scenario_aliased_tree(K = 14)),
-    ("B: many independent constraints (N=5000)", scenario_many_independent(N = 5_000)),
-    ("C: shared big subexpr (N=200, M=200)",     scenario_shared_big(N = 200, M = 200)),
-    ("D: many aliased trees (M=200, K=8)",       scenario_many_aliased(M = 200, K = 8)),
-]
 
 const MODES = [:none, :per_call_oid, :model_struct, :model_oid]
 
-function run_all()
-    println("Benchmarking PR #4032 cache strategies\n")
-    for (label, build) in SCENARIOS
-        println("="^72)
-        println(label)
-        println("="^72)
-        # Warm up each mode (compile its method specializations) before
-        # timing, so the first sample isn't biased by JIT.
-        for m in MODES
-            BENCH_MODE[] = m
-            try
-                build()
-            catch err
-                @warn "warm-up failed for mode $m" exception = err
-            end
-        end
-        results = Dict{Symbol,Any}()
-        for m in MODES
-            BENCH_MODE[] = m
-            b = @benchmark $build() samples = 5 evals = 1 seconds = 30
-            results[m] = b
-            t_ms = minimum(b).time / 1e6
-            mem_mb = minimum(b).memory / 1024^2
-            allocs = minimum(b).allocs
-            @printf("  %-13s  %10.2f ms   %9.2f MiB   %12d allocs\n",
-                    string(m), t_ms, mem_mb, allocs)
-        end
-        # Ratios versus the branch's model_struct baseline so we can see
-        # where each strategy wins, ties, or loses.
-        base = minimum(results[:model_struct]).time
-        println()
-        for m in MODES
-            r = minimum(results[m]).time / base
-            @printf("  ratio(%-13s / model_struct) = %.2f\n", string(m), r)
-        end
-        println()
+function run_bench(label, build)
+    println("="^72)
+    println(label)
+    println("="^72)
+    # Warm up each mode (compile its method specializations) before
+    # timing, so the first sample isn't biased by JIT.
+    for m in MODES
+        BENCH_MODE[] = m
+        build()
     end
+    results = Dict{Symbol,Any}()
+    for m in MODES
+        BENCH_MODE[] = m
+        b = @benchmark $build() samples = 5 evals = 1 seconds = 30
+        results[m] = b
+        t_ms = minimum(b).time / 1e6
+        mem_mb = minimum(b).memory / 1024^2
+        allocs = minimum(b).allocs
+        @printf("  %-13s  %10.2f ms   %9.2f MiB   %12d allocs\n",
+                string(m), t_ms, mem_mb, allocs)
+    end
+    # Ratios versus the branch's model_struct baseline so we can see
+    # where each strategy wins, ties, or loses.
+    base = minimum(results[:model_struct]).time
+    println()
+    for m in MODES
+        r = minimum(results[m]).time / base
+        @printf("  ratio(%-13s / model_struct) = %.2f\n", string(m), r)
+    end
+    println()
 end
 
-if abspath(PROGRAM_FILE) == @__FILE__
-    run_all()
+function one_aliased_tree(; K = 16)
+    run_bench("A: aliased tree (one big DAG, K=$K)",      scenario_aliased_tree(; K))
 end
+
+function independent()
+    run_bench("B: many independent constraints (N=5000)", scenario_many_independent(N = 5_000))
+end
+
+function shared_subexpr()
+    run_bench("C: shared big subexpr (N=200, M=200)",     scenario_shared_big(N = 200, M = 200))
+end
+
+function many_aliased_tree()
+    run_bench("D: many aliased trees (M=200, K=8)",       scenario_many_aliased(M = 200, K = 8))
+end
+
+function run_all()
+    one_aliased_tree()
+    independent()
+    shared_subexpr()
+    many_aliased_tree()
+end
+
+#run_all()

--- a/test/perf/benchmark_cache.jl
+++ b/test/perf/benchmark_cache.jl
@@ -1,0 +1,331 @@
+# Benchmark for PR #4032: caching strategies for moi_function on
+# GenericNonlinearExpr.
+#
+# Four modes are compared:
+#   :none           — master behaviour: NO cache. `add_constraint` runs
+#                      `check_belongs_to_model` and then `moi_function`, both
+#                      of which traverse the expression independently.
+#   :per_call_oid   — odow's actual PR snippet: a fresh `Dict{UInt64, ...}`
+#                      allocated INSIDE every call to `moi_function`, keyed by
+#                      `objectid(arg)` (so cache lookups are O(1)).
+#                      `check_belongs_to_model` still runs as a separate walk.
+#   :model_struct   — this branch as-is: cache stored on the model, keyed by
+#                      the JuMP `GenericNonlinearExpr` itself. Default `==`/
+#                      `hash` on that struct is structural and walks the whole
+#                      sub-tree, so a cache hit still costs O(size) — which
+#                      can defeat the cache for deeply aliased DAGs.
+#   :model_oid      — model-level cache, but keyed by `objectid` like odow's
+#                      snippet. Shows what the branch could evolve to once
+#                      blegat's "use hash as keys" suggestion is applied.
+#
+# Run from the repo root, in an environment that has BenchmarkTools added on
+# top of dev'd JuMP (do NOT add BenchmarkTools to JuMP's own Project.toml):
+#
+#   julia> using Pkg
+#   julia> Pkg.activate(temp = true)
+#   julia> Pkg.develop(path = ".")
+#   julia> Pkg.add("BenchmarkTools")
+#   julia> include("benchmark_cache.jl"); run_all()
+#
+# The script monkey-patches `JuMP.moi_function(::GenericNonlinearExpr,
+# ::GenericModel)` so the same JuMP build can be exercised under each mode
+# without rebuilding the package.
+#
+# Sample numbers from this branch (Julia 1.12, K=14, etc.):
+#
+#   A: aliased tree (one big DAG, K=14)        ~46 ms — all four modes within
+#                                               1% (MOI-tree alloc cost is
+#                                               small vs. the rest of
+#                                               add_constraint here).
+#   B: many independent constraints (N=5000)   none 84 / per_call_oid 86 /
+#                                               model_struct 91 / model_oid 86
+#                                               → the *current branch* is the
+#                                               slowest; struct keys hurt the
+#                                               common case. Switching to
+#                                               objectid keys fixes it.
+#   C: shared big subexpr (N=200, M=200)       model_struct 171 / model_oid 170
+#                                               vs none 191 / per_call_oid 195
+#                                               → 12–14% win for the model-
+#                                               level cache. Per-call cannot
+#                                               see the cross-constraint
+#                                               sharing.
+#   D: many aliased trees (M=200, K=8)         all ~140 ms (per-constraint
+#                                               sharing is small and JuMP's
+#                                               `+` would flatten without the
+#                                               explicit GenericNonlinearExpr
+#                                               construction we use here).
+#
+# Takeaways:
+#  * The model-level scope is the right call when subexpressions are shared
+#    across constraints (scenario C).
+#  * Using the JuMP struct as the cache key (current branch) is what costs
+#    in scenario B — the deep `==`/`hash` adds overhead per node. Switching
+#    to `objectid` keys (blegat's "use hash as keys" suggestion) recovers
+#    most of it.
+#  * Scenario A's exponential blow-up is more visible in MEMORY than in
+#    TIME at K=14; bump K higher (or use the bench.jl example with
+#    |R|*|S| ≈ 3600) to make the time gap obvious.
+
+using Printf
+using JuMP
+using BenchmarkTools
+import MathOptInterface as MOI
+
+const _G = JuMP.GenericNonlinearExpr
+
+# ---------------------------------------------------------------------------
+# Three implementations of the GenericNonlinearExpr → ScalarNonlinearFunction
+# walk. They share the same skeleton; only the cache differs.
+# ---------------------------------------------------------------------------
+
+function _moi_no_cache(f::_G{V}) where {V}
+    ret = MOI.ScalarNonlinearFunction(f.head, similar(f.args))
+    stack = Tuple{MOI.ScalarNonlinearFunction,Int,_G{V}}[]
+    for i in length(f.args):-1:1
+        if f.args[i] isa _G{V}
+            push!(stack, (ret, i, f.args[i]))
+        else
+            ret.args[i] = JuMP.moi_function(f.args[i])
+        end
+    end
+    while !isempty(stack)
+        parent, i, arg = pop!(stack)
+        child = MOI.ScalarNonlinearFunction(arg.head, similar(arg.args))
+        parent.args[i] = child
+        for j in length(arg.args):-1:1
+            if arg.args[j] isa _G{V}
+                push!(stack, (child, j, arg.args[j]))
+            else
+                child.args[j] = JuMP.moi_function(arg.args[j])
+            end
+        end
+    end
+    return ret
+end
+
+# Cache walk parameterised by the `keyfn` that maps a JuMP NL expression to
+# the dict key. `keyfn = identity` matches the branch (struct keys, deep
+# hash). `keyfn = objectid` matches odow's snippet (UInt64 keys, O(1) hash).
+function _moi_with_cache(f::_G{V}, cache, keyfn::F) where {V,F}
+    fk = keyfn(f)
+    if haskey(cache, fk)
+        return cache[fk]
+    end
+    ret = MOI.ScalarNonlinearFunction(f.head, similar(f.args))
+    stack = Tuple{MOI.ScalarNonlinearFunction,Int,_G{V}}[]
+    for i in length(f.args):-1:1
+        if f.args[i] isa _G{V}
+            push!(stack, (ret, i, f.args[i]))
+        else
+            ret.args[i] = JuMP.moi_function(f.args[i])
+        end
+    end
+    while !isempty(stack)
+        parent, i, arg = pop!(stack)
+        argk = keyfn(arg)
+        if haskey(cache, argk)
+            parent.args[i] = cache[argk]
+            continue
+        end
+        child = MOI.ScalarNonlinearFunction(arg.head, similar(arg.args))
+        parent.args[i] = child
+        for j in length(arg.args):-1:1
+            if arg.args[j] isa _G{V}
+                push!(stack, (child, j, arg.args[j]))
+            else
+                child.args[j] = JuMP.moi_function(arg.args[j])
+            end
+        end
+        cache[argk] = child
+    end
+    cache[fk] = ret
+    return ret
+end
+
+# ---------------------------------------------------------------------------
+# Switching mechanism. We re-define JuMP's `moi_function(::GenericNonlinearExpr,
+# ::GenericModel)` so that `add_constraint` dispatches differently per mode.
+#
+# Modes :none and :per_call mirror what those PR options would actually
+# look like in production: a separate `check_belongs_to_model` walk, then
+# the (cached or uncached) build walk.
+# Mode :model_level matches the branch: a single integrated walk.
+# ---------------------------------------------------------------------------
+
+const BENCH_MODE = Ref(:model_struct)
+
+# Per-mode caches that need a UInt64 (objectid) key type rather than the
+# branch's `Dict{Any,...}`. We store them on the model as a side table so
+# they survive across constraints inside one build but are cleared between
+# builds (because each scenario builds a fresh `Model()`).
+const _OID_CACHE = IdDict{JuMP.GenericModel,Dict{UInt64,MOI.ScalarNonlinearFunction}}()
+
+function _oid_cache(model)
+    get!(_OID_CACHE, model) do
+        Dict{UInt64,MOI.ScalarNonlinearFunction}()
+    end
+end
+
+@eval JuMP function moi_function(
+    f::JuMP.GenericNonlinearExpr{V},
+    model::JuMP.GenericModel,
+) where {V}
+    mode = Main.BENCH_MODE[]
+    if mode === :none
+        JuMP.check_belongs_to_model(f, model)
+        return Main._moi_no_cache(f)
+    elseif mode === :per_call_oid
+        JuMP.check_belongs_to_model(f, model)
+        cache = Dict{UInt64,$(MOI.ScalarNonlinearFunction)}()
+        return Main._moi_with_cache(f, cache, objectid)
+    elseif mode === :model_struct
+        # branch behaviour: belongs-check is integrated; struct keys (deep hash)
+        return Main._moi_with_cache(f, model.subexpressions, identity)
+    else  # :model_oid
+        return Main._moi_with_cache(f, Main._oid_cache(model), objectid)
+    end
+end
+
+# ---------------------------------------------------------------------------
+# Scenarios. Each `scenario_*` returns a 0-arg closure that builds a fresh
+# model from scratch, so each BenchmarkTools sample sees an empty
+# `model.subexpressions` cache.
+# ---------------------------------------------------------------------------
+
+# Scenario A — odow's case: ONE constraint with a deeply aliased binary tree.
+# `e_k = e_{k-1} + e_{k-1}`. With no cache this expands to 2^K leaves; with
+# either cache it stays linear in K.
+#
+# We build the `+` node directly via the GenericNonlinearExpr constructor so
+# JuMP's `+` operator overload does NOT flatten the n-ary sum. Without this,
+# `e + e` returns a flat `:+(args...)` of 2^K identical leaf references and
+# the master walk only iterates 2^K times instead of doing 2^K *recursive*
+# descents through K levels — which would mask the worst case the PR is
+# meant to fix.
+function scenario_aliased_tree(; K::Int = 14)
+    V = JuMP.VariableRef
+    return function ()
+        model = Model()
+        @variable(model, x)
+        e = sin(x)
+        for _ in 1:K
+            e = JuMP.GenericNonlinearExpr{V}(:+, e, e)
+        end
+        @constraint(model, e <= 1)
+        return model
+    end
+end
+
+# Scenario B — many small INDEPENDENT NL constraints. No subexpression
+# sharing within or across constraints. The model-level cache pays an
+# insertion + hash cost for every new node; the per-call cache pays an
+# extra Dict allocation per constraint; master pays nothing.
+#
+# This is the case blegat warned about in the PR thread: "we start
+# creating many small dictionaries if there are a lot of constraints,
+# but that's probably negligible". The benchmark tells us whether it
+# really is negligible.
+function scenario_many_independent(; N::Int = 5_000)
+    return function ()
+        model = Model()
+        @variable(model, x[1:N])
+        for i in 1:N
+            @constraint(model, sin(x[i]) + cos(x[i]) * exp(x[i]) <= 1)
+        end
+        return model
+    end
+end
+
+# Scenario C — many constraints sharing one big subexpression.
+# `big = sum(sin(x[i]) for i in 1:N)` appears once in each of M constraints.
+# The per-call cache cannot help here (each call sees `big` only once); only
+# the model-level cache deduplicates `big` across constraints. This is the
+# case that genuinely motivates the model-level cache.
+function scenario_shared_big(; N::Int = 200, M::Int = 200)
+    return function ()
+        model = Model()
+        @variable(model, x[1:N])
+        big = sum(sin(x[i]) for i in 1:N)
+        for j in 1:M
+            @constraint(model, big * x[j] <= 1)
+        end
+        return model
+    end
+end
+
+# Scenario D — many constraints, each with internal aliasing (a smaller
+# binary tree per constraint, distinct leaf variable per constraint).
+# Both per-call and model-level caches help WITHIN each constraint;
+# across constraints there is nothing to share. This is the natural
+# territory of odow's per-call dict.
+function scenario_many_aliased(; M::Int = 200, K::Int = 8)
+    V = JuMP.VariableRef
+    return function ()
+        model = Model()
+        @variable(model, x[1:M])
+        for i in 1:M
+            e = sin(x[i])
+            for _ in 1:K
+                e = JuMP.GenericNonlinearExpr{V}(:+, e, e)
+            end
+            @constraint(model, e <= 1)
+        end
+        return model
+    end
+end
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+const SCENARIOS = [
+    ("A: aliased tree (one big DAG, K=14)",      scenario_aliased_tree(K = 14)),
+    ("B: many independent constraints (N=5000)", scenario_many_independent(N = 5_000)),
+    ("C: shared big subexpr (N=200, M=200)",     scenario_shared_big(N = 200, M = 200)),
+    ("D: many aliased trees (M=200, K=8)",       scenario_many_aliased(M = 200, K = 8)),
+]
+
+const MODES = [:none, :per_call_oid, :model_struct, :model_oid]
+
+function run_all()
+    println("Benchmarking PR #4032 cache strategies\n")
+    for (label, build) in SCENARIOS
+        println("="^72)
+        println(label)
+        println("="^72)
+        # Warm up each mode (compile its method specializations) before
+        # timing, so the first sample isn't biased by JIT.
+        for m in MODES
+            BENCH_MODE[] = m
+            try
+                build()
+            catch err
+                @warn "warm-up failed for mode $m" exception = err
+            end
+        end
+        results = Dict{Symbol,Any}()
+        for m in MODES
+            BENCH_MODE[] = m
+            b = @benchmark $build() samples = 5 evals = 1 seconds = 30
+            results[m] = b
+            t_ms = minimum(b).time / 1e6
+            mem_mb = minimum(b).memory / 1024^2
+            allocs = minimum(b).allocs
+            @printf("  %-13s  %10.2f ms   %9.2f MiB   %12d allocs\n",
+                    string(m), t_ms, mem_mb, allocs)
+        end
+        # Ratios versus the branch's model_struct baseline so we can see
+        # where each strategy wins, ties, or loses.
+        base = minimum(results[:model_struct]).time
+        println()
+        for m in MODES
+            r = minimum(results[m]).time / base
+            @printf("  ratio(%-13s / model_struct) = %.2f\n", string(m), r)
+        end
+        println()
+    end
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    run_all()
+end

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -2393,4 +2393,24 @@ function test_reshape_vector_nothing()
     return
 end
 
+function test_check_belongs_to_model_scalar()
+    model = Model()
+    @variable(model, x)
+    c = @constraint(model, 2 * x + 1 == 0)
+    o = constraint_object(c)
+    check_belongs_to_model(o, model)
+    @test isapprox(moi_function(o), moi_function(model, o))
+    return
+end
+
+function test_check_belongs_to_model_vector()
+    model = Model()
+    @variable(model, x)
+    c = @constraint(model, [2 * x + 1] in Zeros())
+    o = constraint_object(c)
+    check_belongs_to_model(o, model)
+    @test isapprox(moi_function(o), moi_function(model, o))
+    return
+end
+
 end  # module


### PR DESCRIPTION
Here is a simplified reproducer of the performance issue identified in https://github.com/jump-dev/MathOptInterface.jl/issues/3015:
```julia
using JuMP

f(x, u) = [sin(x[1]) - x[1] * u, cos(x[2]) + x[1] * u]
function RK4(f, X, u)
    k1 = f(X     , u)
    k2 = f(X+k1/2, u)
    k3 = f(X+k2/2, u)
    k4 = f(X+k3  , u)
    X + (k1 + 2k2 + 2k3 + k4) / 6
end

model = Model()

@variable(model, q[1:2])
@variable(model, u)

x = q
for m = 1:4
    x = RK4(f, x, u)
end
@time moi_function.(x)
```
Before this PR, this gives
```
14.610110 seconds (207.45 M allocations: 6.927 GiB, 68.63% gc time)
```
After this PR, this gives
```
0.000103 seconds (2.16 k allocations: 74.250 KiB)
```

Note that the `MOI.ScalarNonlinearFunction` we generate now share common sub-expression by pointers! If I'm not mistaken, we don't support modifying these in-place so that shouldn't be an issue.

This fixes the slow model-building issue but ReverseAD will still be terribly slow. One thing we could do is to detect, in `MOI.Nonlinear`, the `MOI.ScalarNonlinearFunction` that share sub-functions correponding to the same object (with a dictionary). When it detects two functions with the same pointer, it can then create subexpressions and use its existing support for subexpressions.
The nice thing about it is that we're not doing any change to the MOI interface. Creating `MOI.ScalarNonlinearFunction` was already possible from the beginning, we just didn't treat it any differently. So this change will just be a performance optimization of the AD but the interface is as simple and non-breaking as it gets.

## Results on other benchmarks

For this benchmark, cherry-pick both https://github.com/jump-dev/MathOptInterface.jl/pull/2803 and https://github.com/jump-dev/MathOptInterface.jl/pull/3008. We don't know yet what's the right fix at the MOI level, these PRs just make sure we only see the JuMP-side in the timing.
Then, execute `test/perf/benchmark_cache.jl`.
The conclusion of the benchmark seems to be that a global dict is better than a new dict per constraint and also that we have a small win to hash the `ObjectId`.
The benchmark was generated by Claude as a neutral judge.

### A: aliased tree (one big DAG, K=16)

#### Current
```
BenchmarkTools.Trial: 149 samples with 1 evaluation per sample.
 Range (min … max):  10.813 ms … 176.359 ms  ┊ GC (min … max):  0.00% … 86.85%
 Time  (median):     26.873 ms               ┊ GC (median):     0.00%
 Time  (mean ± σ):   33.761 ms ±  30.991 ms  ┊ GC (mean ± σ):  22.81% ± 20.14%

  ▁▂  ▆▆▂█▃                                                     
  ██▇▅█████▆▆▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆▅▁▁▁▆▁▅▅ ▅
  10.8 ms       Histogram: log(frequency) by time       168 ms <

 Memory estimate: 24.01 MiB, allocs estimate: 721053.
```
#### One dict per constraint
```
BenchmarkTools.Trial: 1850 samples with 1 evaluation per sample.
 Range (min … max):  2.579 ms …  4.681 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.689 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.704 ms ± 86.148 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

          ▂▂▄▄▄▆█▄▅▂▆▂▃▂▁▃▂▁                                  
  ▂▂▂▃▃▅▆███████████████████▇█▆▆▅▅▇▄▅▅▄▄▄▄▃▃▃▃▃▃▃▂▃▃▃▃▂▂▁▂▂▃ ▄
  2.58 ms        Histogram: frequency by time        2.92 ms <

 Memory estimate: 17.45 KiB, allocs estimate: 303.
```
#### Global dict
```
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):   9.567 μs … 150.842 ms  ┊ GC (min … max):  0.00% … 99.95%
 Time  (median):     12.009 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   28.061 μs ±   1.508 ms  ┊ GC (mean ± σ):  53.73% ±  1.00%

      ▃▆█▇▄▂                                                    
  ▁▂▃▇███████▆▅▆▆▆▇▇▆▆▅▅▄▃▂▂▂▃▃▃▂▃▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  9.57 μs         Histogram: frequency by time         22.6 μs <

 Memory estimate: 17.41 KiB, allocs estimate: 325.
```
#### Global dict + object id
```
BenchmarkTools.Trial: 10000 samples with 3 evaluations per sample.
 Range (min … max):   9.182 μs … 211.604 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     13.418 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   14.339 μs ±   5.920 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

       ▂▅▆▇██▇▅▅▃▂▂▁                                            
  ▂▂▃▄▆███████████████▆▆▅▄▄▄▄▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▁▂▂▂ ▄
  9.18 μs         Histogram: frequency by time         30.1 μs <

 Memory estimate: 16.58 KiB, allocs estimate: 297.
```

### B: many independent constraints (N=5000)

#### Current
```
BenchmarkTools.Trial: 271 samples with 1 evaluation per sample.
 Range (min … max):   9.258 ms … 313.421 ms  ┊ GC (min … max):  0.00% … 95.58%
 Time  (median):     14.209 ms               ┊ GC (median):     0.00%
 Time  (mean ± σ):   18.470 ms ±  34.692 ms  ┊ GC (mean ± σ):  25.40% ± 12.79%

  ▆█▁                                                           
  ███▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▄ ▅
  9.26 ms       Histogram: log(frequency) by time       251 ms <

 Memory estimate: 14.49 MiB, allocs estimate: 380142.
```
#### One dict per constraint
```
BenchmarkTools.Trial: 221 samples with 1 evaluation per sample.
 Range (min … max):  10.698 ms … 329.769 ms  ┊ GC (min … max):  0.00% … 94.39%
 Time  (median):     16.632 ms               ┊ GC (median):     0.00%
 Time  (mean ± σ):   22.627 ms ±  41.113 ms  ┊ GC (mean ± σ):  29.84% ± 15.29%

  ▆█                                                            
  ██▇█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▁▁▁▄▁▁▁▄▁▁▄ ▅
  10.7 ms       Histogram: log(frequency) by time       267 ms <

 Memory estimate: 17.23 MiB, allocs estimate: 400142.
```
#### Global dict
```
BenchmarkTools.Trial: 236 samples with 1 evaluation per sample.
 Range (min … max):   7.718 ms … 338.331 ms  ┊ GC (min … max):  0.00% … 93.87%
 Time  (median):     18.529 ms               ┊ GC (median):     0.00%
 Time  (mean ± σ):   21.190 ms ±  36.381 ms  ┊ GC (mean ± σ):  22.21% ± 12.21%

  ▅▅█                                                           
  ███▇▆▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▁▄ ▅
  7.72 ms       Histogram: log(frequency) by time       287 ms <

 Memory estimate: 17.37 MiB, allocs estimate: 418600.
```
#### Global dict + object id
```
BenchmarkTools.Trial: 156 samples with 1 evaluation per sample.
 Range (min … max):   6.855 ms …    2.565 s  ┊ GC (min … max):  0.00% … 99.34%
 Time  (median):     13.982 ms               ┊ GC (median):     0.00%
 Time  (mean ± σ):   32.069 ms ± 204.190 ms  ┊ GC (mean ± σ):  50.93% ±  7.95%

            ▁▄▁▃█                                               
  ▃▁▁▃▃▅▃▁▁▃█████▆▄▃▁▆▃▃▃▁▃▃▄▃▃▁▁▃▁▃▃▁▁▄▃▃▃▁▁▃▁▁▃▁▁▁▁▁▃▃▁▁▁▁▁▃ ▃
  6.85 ms         Histogram: frequency by time         37.4 ms <

 Memory estimate: 15.81 MiB, allocs estimate: 360177.
```

### C: shared big subexpr (N=200, M=200)

#### Current
```
BenchmarkTools.Trial: 292 samples with 1 evaluation per sample.
 Range (min … max):   6.926 ms … 522.915 ms  ┊ GC (min … max):  0.00% … 97.27%
 Time  (median):     10.711 ms               ┊ GC (median):     0.00%
 Time  (mean ± σ):   17.169 ms ±  41.033 ms  ┊ GC (mean ± σ):  19.03% ±  8.04%

  ▃▆▄█▄ ▄▃ ▂                                                    
  ████████▆█▅█▆▄▄▁▄▁▁▄▁▁▁▄▄▁▁▁▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▄▁▄▁▁▁▁▄▄▄▅ ▅
  6.93 ms       Histogram: log(frequency) by time      74.8 ms <

 Memory estimate: 20.51 MiB, allocs estimate: 449903.
```
#### One dict per constraint
```
BenchmarkTools.Trial: 160 samples with 1 evaluation per sample.
 Range (min … max):  18.589 ms … 618.022 ms  ┊ GC (min … max):  0.00% … 94.65%
 Time  (median):     22.911 ms               ┊ GC (median):     0.00%
 Time  (mean ± σ):   31.275 ms ±  60.962 ms  ┊ GC (mean ± σ):  21.55% ± 10.59%

    █▃ ▄       ▅▂▅▇           ▄ ▃                               
  ▅▃████▆▇▁▆▅▅▇████▇▃▁▅▁▃▁▁▆▇▇███▇▅▁▁▁▁▁▁▁▁▁▁▁▃▁▃▁▁▆▆▆▃▃█▇▃▁▃▆ ▃
  18.6 ms         Histogram: frequency by time         34.7 ms <

 Memory estimate: 27.11 MiB, allocs estimate: 453303.
```
#### Global dict
```
BenchmarkTools.Trial: 6570 samples with 1 evaluation per sample.
 Range (min … max):  248.308 μs … 524.374 ms  ┊ GC (min … max):  0.00% … 99.79%
 Time  (median):     554.571 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   760.800 μs ±   8.279 ms  ┊ GC (mean ± σ):  18.82% ±  1.74%

           █▂   ▂▂▁                                              
  ▄▇▅▅▃▄▄▆███▇▄▄███▅▃▃▄▄▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  248 μs           Histogram: frequency by time         1.98 ms <

 Memory estimate: 707.58 KiB, allocs estimate: 13364.
```
#### Global dict + object id
```
BenchmarkTools.Trial: 3525 samples with 1 evaluation per sample.
 Range (min … max):  223.772 μs …   2.514 s  ┊ GC (min … max):  0.00% … 99.83%
 Time  (median):     736.434 μs              ┊ GC (median):     0.00%
 Time  (mean ± σ):     1.879 ms ± 42.358 ms  ┊ GC (mean ± σ):  37.89% ±  1.68%

  ▃█▃▁▅▇▄▄▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▁▁▁▁ ▁                                ▁
  ███████████████████████████████▇▇▇▇▇▇▇▅▁▅▅▅▆▃▅▅▆▅▃▁▅▄▁▄▁▃▁▃▆ █
  224 μs        Histogram: log(frequency) by time      5.68 ms <

 Memory estimate: 662.53 KiB, allocs estimate: 11724.
```

### D: many aliased trees (M=200, K=8)

#### Current
```
BenchmarkTools.Trial: 91 samples with 1 evaluation per sample.
 Range (min … max):  14.584 ms …    1.458 s  ┊ GC (min … max):  0.00% … 98.41%
 Time  (median):     53.483 ms               ┊ GC (median):     0.00%
 Time  (mean ± σ):   69.033 ms ± 149.943 ms  ┊ GC (mean ± σ):  22.83% ± 10.32%

       ▁    █                                                   
  ▃▄▄▆▆█▇▆███▇▄▃▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃ ▁
  14.6 ms         Histogram: frequency by time          285 ms <

 Memory estimate: 19.29 MiB, allocs estimate: 574306.
```
#### One dict per constraint
```
BenchmarkTools.Trial: 1481 samples with 1 evaluation per sample.
 Range (min … max):  3.041 ms …   4.058 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.369 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.377 ms ± 196.428 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

                   ▂▁▃▅▄▃█▄                                    
  ▁▁▂▄▆▅▆▅██▆▃▁▂▃▅██████████▃▁▁▁▁▁▁▂▁▂▂▂▂▂▁▂▁▂▁▁▁▁▁▂▁▁▁▂▃▂▃▂▂ ▃
  3.04 ms         Histogram: frequency by time           4 ms <

 Memory estimate: 1.19 MiB, allocs estimate: 26906.
```
#### Global dict
```
BenchmarkTools.Trial: 3090 samples with 1 evaluation per sample.
 Range (min … max):  954.119 μs … 986.423 ms  ┊ GC (min … max):  0.00% … 99.38%
 Time  (median):       1.246 ms               ┊ GC (median):     0.00%
 Time  (mean ± σ):     1.618 ms ±  17.724 ms  ┊ GC (mean ± σ):  19.61% ±  1.79%

    ▁█▅ ▁                                                        
  ▂▅██████▅▃▄▄▄▄▄▄▄▄▃▂▁▁▁▁▄██▅▆███▇▆▅▄▃▂▁▁▂▂▂▁▁▁▂▁▂▂▁▁▁▁▁▁▁▁▁▁▁ ▃
  954 μs           Histogram: frequency by time         2.08 ms <

 Memory estimate: 1.24 MiB, allocs estimate: 28180.
```
#### Global dict + object id
```
BenchmarkTools.Trial: 1992 samples with 1 evaluation per sample.
 Range (min … max):  845.061 μs …   2.848 s  ┊ GC (min … max):  0.00% … 99.98%
 Time  (median):     998.244 μs              ┊ GC (median):     0.00%
 Time  (mean ± σ):     2.510 ms ± 63.787 ms  ┊ GC (mean ± σ):  56.95% ±  2.24%

   ▃▁  █▅▃▂▁▁     ▁                                             
  ▅██▆▇██████▆▄▃▃▇█▅▃▃▃▂▂▃▃▄▄▄▃▃▄▅▄▃▂▂▂▂▂▂▃▃▃▂▂▂▂▂▂▂▁▁▂▂▂▂▂▂▂▂ ▃
  845 μs          Histogram: frequency by time         1.89 ms <

 Memory estimate: 1.15 MiB, allocs estimate: 25129.
```