### PR TITLE
Fix a major correctess bug with comparison legacy nonlinear constraints

### DIFF
--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -496,6 +496,9 @@ function _expr_to_constraint(expr::Expr)
         @assert expr.args[2] in (:<=, :>=)
         lhs, body, rhs =
             _normalize_constraint_expr(expr.args[1], expr.args[3], expr.args[5])
+        if expr.args[2] == :(>=)
+            lhs, rhs = rhs, lhs
+        end
         return body, MOI.Interval(lhs, rhs)
     end
     lhs, rhs = _normalize_constraint_expr(expr.args[2], expr.args[3])

--- a/test/test_nlp.jl
+++ b/test/test_nlp.jl
@@ -1711,4 +1711,12 @@ function test_NL_too_many_arguments_errors()
     return
 end
 
+function test_NL_reversed_comparison()
+    model = Model()
+    @variable(model, x)
+    c = @NLconstraint(model, 2 >= x >= 1)
+    @test model.nlp_model[index(c)].set == MOI.Interval(1.0, 2.0)
+    return
 end
+
+end  # module TestNLP


### PR DESCRIPTION
Well this one is truly, truly horrific. The only solace is that no one seems to have been using it because it is immediately obvious.

This bug applies only to people who:
 1. wrote a new model using `@NLconstraint` AFTER the switch to MOI.Nonlinear
 2. wrote `@NLconstraint(model, u >= f(x) >= l)` instead of `@NLconstraint(model, l <= f(x) <= u)`
 3. didn't notice they got a wrong answer because they either:
    a. got that their model was infeasible and never checked why
    b. made a typo that switched `l` and `u` and solved the right model by mistake?

## JuMP 1.0

Old JuMP would have thrown a syntax error:
```Julia
julia> using JuMP

julia> model = Model();

julia> @variable(model, x);

julia> @NLconstraint(model, 2 >= x >= 1)
ERROR: LoadError: At REPL[4]:1: `@NLconstraint(model, 2 >= x >= 1)`: only ranged rows of the form lb <= expr <= ub are supported.
Stacktrace:
 [1] error(::String, ::String)
   @ Base ./error.jl:44
 [2] _macro_error(macroname::Symbol, args::Tuple{Symbol, Expr}, source::LineNumberNode, str::String)
   @ JuMP ~/.julia/packages/JuMP/0C6kd/src/macros.jl:1527
 [3] (::JuMP.var"#_error#110"{LineNumberNode, Symbol, Expr, Tuple{}})(str::String)
   @ JuMP ~/.julia/packages/JuMP/0C6kd/src/macros.jl:2076
 [4] var"@NLconstraint"(__source__::LineNumberNode, __module__::Module, m::Any, x::Any, args::Vararg{Any})
   @ JuMP ~/.julia/packages/JuMP/0C6kd/src/macros.jl:2133
in expression starting at REPL[4]:1

(jmp) pkg> st
Status `/private/tmp/jmp/Project.toml`
⌃ [4076af6c] JuMP v1.0.0
Info Packages marked with ⌃ have new versions available and may be upgradable.
```

## JuMP 1.27.0

```Julia
julia> using JuMP

julia> model = Model();

julia> @variable(model, x);

julia> @NLconstraint(model, 2 >= x >= 1)
2 ≤ x ≤ 1

(jmp) pkg> st
Status `/private/tmp/jmp/Project.toml`
  [4076af6c] JuMP v1.27.0
```