### PR TITLE
[Containers] fix DenseAxisArray with Base.OneTo{<:Integer}

### DIFF
--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -385,7 +385,8 @@ function Base.to_index(A::DenseAxisArray{T,N}, idx) where {T,N}
 end
 
 _is_range(::Any) = false
-_is_range(::Union{Vector{Int},Colon}) = true
+_is_range(::Colon) = true
+_is_range(::AbstractVector{<:Integer}) = true
 
 function _kwargs_to_args(A::DenseAxisArray{T,N}; kwargs...) where {T,N}
     return ntuple(N) do i

--- a/test/Containers/test_DenseAxisArray.jl
+++ b/test/Containers/test_DenseAxisArray.jl
@@ -933,4 +933,10 @@ function test_promote_shape()
     return
 end
 
+function test_container_Base_OneTo_Integer()
+    Containers.@container(x[i = 0x01:0x08], 2 * i)
+    @test x[0x01:0x02] == Containers.@container([i = 0x01:0x02], 2 * i)
+    return
+end
+
 end  # module


### PR DESCRIPTION
Part of #4053 