### PR TITLE
Update column generation tutorial

### DIFF
--- a/docs/src/tutorials/algorithms/cutting_stock_column_generation.jl
+++ b/docs/src/tutorials/algorithms/cutting_stock_column_generation.jl
@@ -336,8 +336,6 @@ while true
         set_normalized_coefficient(demand[i], x[end], count)
     end
     println("Found new pattern. Total patterns = $(length(patterns))")
-    ## Uncomment the next line to see the model formulation at each interation
-    # println(model)
 end
 
 # We found lots of new patterns. Here's pattern 21:


### PR DESCRIPTION
The column generation tutorial contains multiple orders of the same length.

I think this becomes misleading for 2 reasons:

1.  Our RMP can choose an integer number of each pattern. Yet the first 5 patterns are identical.  The natural question is why were 5 of the same added when we could have just chosen 5 of pattern 1.

2. If you print out the RMP at each CG iteration, you will see the a new pattern that contains length 75 added to only one of the demand rows for i=1-5.  The exact one being which ever the MIP solver determined in the knapsack subproblem.  But this pattern could feasibly satisfy the demand for any of those orders (just not at the same time)

This PR just changes the input data and updates the solution values.

I have also added a comment to the user, prompting them to check out the formulation of the RMP at every CG iteration.  I think this will be helpful for some to understand the bigger picture.  Although this produces a lot of output, so I've left it commented out.

Hope this makes sense :)