### PR TITLE
[docs] pin to use Julia v1.11

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,7 +14,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1'
+          # Fix the Julia version, because Enzyme doesn't always like being updated
+          # to `latest`.
+          version: '1.11'
       - uses: julia-actions/cache@v2
       - name: Install Gurobi license
         env: 


### PR DESCRIPTION
Fix the Julia version to 1.11 for compatibility with Enzyme.