### PR TITLE
Fix set_start_values with parameters

### DIFF
--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -1739,7 +1739,9 @@ function set_start_values(
     )
     if support_variable_primal && variable_primal_start !== nothing
         for x in all_variables(model)
-            variable_primal[x] = variable_primal_start(x)
+            if !is_parameter(x)
+                variable_primal[x] = variable_primal_start(x)
+            end
         end
     end
     constraint_primal = Dict{ConstraintRef,T}()

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1537,4 +1537,19 @@ function test_with_cache_type_set_optimizer()
     return
 end
 
+function test_issue_4089()
+    model = Model()
+    @variable(model, x)
+    @variable(model, p in Parameter(42))
+    set_start_values(
+        model;
+        variable_primal_start = x -> index(x).value,
+        constraint_primal_start = nothing,
+        constraint_dual_start = nothing,
+    )
+    @test start_value(x) == index(x).value
+    @test !has_start_value(p)
+    return
+end
+
 end  # module TestModels


### PR DESCRIPTION
Closes #4089, but I don't know if this is the correct fix. Maybe we should just `try-catch` around all setters for `SetAttributeNotAllowed`?