### PR TITLE
Parse `ℯ^x` as `exp(x)` instead of `2.718281828459045^x`

### DIFF
--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -398,6 +398,7 @@ for f in (:+, :-, :*, :^, :/, :atan, :min, :max)
         end
     end
 end
+
 function Base.:^(::Irrational{:ℯ}, y::AbstractJuMPScalar)
     # without this, ℯ^y becomes 2.718281828459045^y instead of exp(y)
     return exp(y)

--- a/test/test_nlp_expr.jl
+++ b/test/test_nlp_expr.jl
@@ -1208,13 +1208,11 @@ function test_extension_euler_to_exp(
     @variable(model, x)
     @variable(model, y)
     xy = [x, y]
-
     expr = ℯ^x
     @test expr isa GenericNonlinearExpr{VariableRefType}
     @test expr.head == :exp
     @test expr.args[1] == x
     @test isequal_canonical(expr, exp(x))
-
     @test isequal_canonical(ℯ^(1.0 + x), exp(1.0 + x))
     @test isequal_canonical(ℯ^x^2, exp(x^2))
     @test isequal_canonical(ℯ^sin(x), exp(sin(x)))
@@ -1231,7 +1229,6 @@ function test_extension_euler_to_exp(
     @test isequal_canonical(ℯ^(sum(xy)), exp(x + y))
     @test isequal_canonical(sum(ℯ^xᵢ for xᵢ in xy), exp(x) + exp(y))
     @test isequal_canonical(ℯ^prod(xy), exp(x*y))
-
     return
 end
 


### PR DESCRIPTION
First, happy new year! :champagne: Wishing you all the best in 2026 :smile:

___
This PR adds a special case for `^` where the LHS is `ℯ` (`\euler`) and the RHS is an `AbstractJuMPScalar`. It avoids a conversion from `Irrational{:ℯ}` to `Float64`. https://github.com/jump-dev/MathOptInterface.jl/issues/2776 is sort of related.

Before this PR:

```julia
julia> m = GenericModel{Float32}();

julia> @variable m x;

julia> expr = ℯ^x
2.718281828459045 ^ x

julia> expr.head, expr.args[1], typeof(expr.args[1])
(:^, 2.718281828459045, Float64)

julia> typeof(ℯ)
Irrational{:ℯ}
```

After this PR:

```julia
julia> m = GenericModel{Float32}();

julia> @variable m x;

julia> expr = ℯ^x
exp(x)

julia> expr.head, expr.args[1]
(:exp, x)
```