### PR TITLE
Change test to avoid type inference issue

### DIFF
--- a/test/test_expr.jl
+++ b/test/test_expr.jl
@@ -318,8 +318,8 @@ function test_extension_MA_add_mul(
     @test_expression_with_string MA.add_mul(x^2, x, x + 1) "2 x² + x"
     @test_expression_with_string MA.add_mul!!(x^2, x, x + 1) "2 x² + x"
     # MA.add_mul!!(quad::GenericQuadExpr{C,V},c::GenericQuadExpr{C,V},x::Number) where {C,V}" begin
-    @test_expression_with_string MA.add_mul(x^2 + x, x^2 + x, 2.0) "3 x² + 3 x"
-    @test_expression_with_string MA.add_mul!!(x^2 + x, x^2 + x, 2.0) "3 x² + 3 x"
+    @test_expression_with_string MA.add_mul(x^2 + x, x^2 + x, 2 // 1) "3 x² + 3 x"
+    @test_expression_with_string MA.add_mul!!(x^2 + x, x^2 + x, 2 // 1) "3 x² + 3 x"
     # MA.add_mul!!(ex::GenericQuadExpr{C,V}, c::GenericAffExpr{C,V}, x::GenericAffExpr{C,V}) where {C,V}" begin
     @test_expression_with_string MA.add_mul(x^2 + x, x + 0, x + 1) "2 x² + 2 x"
     @test_expression_with_string MA.add_mul!!(x^2 + x, x + 0, x + 1) "2 x² + 2 x"


### PR DESCRIPTION
It's not surprising that the compiler might struggle to infer the difference here between `Float32` and `Float64`. Since this changed with different Julia versions, we can't rely on it as a stable API test.