### PR TITLE
Please using `objective_bound` in deriving the lower bound in Benders

### DIFF
--- a/docs/src/tutorials/algorithms/benders_decomposition.jl
+++ b/docs/src/tutorials/algorithms/benders_decomposition.jl
@@ -250,7 +250,7 @@ println("Iteration  Lower Bound  Upper Bound          Gap")
 for k in 1:MAXIMUM_ITERATIONS
     optimize!(model)
     assert_is_solved_and_feasible(model)
-    lower_bound = objective_value(model)
+    lower_bound = objective_bound(model)
     x_k = value.(x)
     ret = solve_subproblem(x_k)
     upper_bound = (objective_value(model) - value(θ)) + ret.obj


### PR DESCRIPTION
There are some other issues ([discourse](https://discourse.julialang.org/t/sometimes-no-objective-bound-info-from-an-lp-solve-by-gurobi/135080/9?u=waltermadelim)) related. But the core idea is briefly the title.