### PR TITLE
Combine iterations in `collect_to_with_first!`

### DIFF
--- a/src/Containers/Containers.jl
+++ b/src/Containers/Containers.jl
@@ -40,8 +40,7 @@ function Base.collect_to_with_first!(
 )
     indices = eachindex(iterator)
     dest[first(indices)] = first_value
-    for index in Iterators.drop(indices, 1)
-        element, state = iterate(iterator, state)
+    for (index, element) in zip(Iterators.drop(indices, 1), Iterators.rest(iterator, state))
         dest[index] = element
     end
     return dest

--- a/src/Containers/Containers.jl
+++ b/src/Containers/Containers.jl
@@ -40,7 +40,8 @@ function Base.collect_to_with_first!(
 )
     indices = eachindex(iterator)
     dest[first(indices)] = first_value
-    for (index, element) in zip(Iterators.drop(indices, 1), Iterators.rest(iterator, state))
+    for (index, element) in
+        zip(Iterators.drop(indices, 1), Iterators.rest(iterator, state))
         dest[index] = element
     end
     return dest


### PR DESCRIPTION
This tells the compiler that the iteration over the `iterator` won't terminate before the one over the indices.

On master, using `JET`, we find
```julia
julia> report_call(Base.collect_to_with_first!, (JuMP.Containers.DenseAxisArray, Float32, UnitRange{Int}, Int))
═════ 2 possible errors found ═════
┌ collect_to_with_first!(dest::JuMP.Containers.DenseAxisArray, first_value::Float32, iterator::UnitRange{…}, state::Int64) @ JuMP.Containers /home/jishnu/Dropbox/JuliaPackages/JuMP.jl/src/Containers/Containers.jl:44
│┌ indexed_iterate(I::Nothing, i::Int64) @ Base ./tuple.jl:165
││ no matching method found `iterate(::Nothing)`: x = iterate(I::Nothing)
│└────────────────────
│┌ indexed_iterate(I::Nothing, i::Int64, state::Int64) @ Base ./tuple.jl:170
││ no matching method found `iterate(::Nothing, ::Int64)`: x = iterate(I::Nothing, state::Int64)
│└────────────────────
```
vs this PR
```julia
julia> report_call(Base.collect_to_with_first!, (JuMP.Containers.DenseAxisArray, Float32, UnitRange{Int}, Int))
No errors detected
```