### PR TITLE
Add JaCoP in solver lists

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -56,6 +56,10 @@ Google.Periods = NO
 [docs/src/packages/Ipopt.md]
 Google.Colons = NO
 
+[docs/src/packages/JaCoP.md]
+Google.Exclamation = NO
+Google.Latin = NO
+
 [docs/src/packages/Loraine.md]
 Google.Ellipses = NO
 

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -175,6 +175,9 @@
     rev = "v0.6.1"
     filename = "docs/jump/README.md"
     extension = true
+[JaCoP]
+    user = "JuliaConstraints"
+    rev = "v0.1.0"
 [Juniper]
     user = "lanl-ansi"
     rev = "v0.9.4"

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -134,6 +134,7 @@ The link in the `Solver` column is the corresponding Julia package.
 | [HiGHS](https://github.com/ERGO-Code/HiGHS)                                    | [HiGHS.jl](https://github.com/jump-dev/HiGHS.jl)                                 |        | MIT      | (MI)LP, QP                |
 | [Hypatia.jl](https://github.com/chriscoey/Hypatia.jl)                          |                                                                                  |        | MIT      | LP, SOCP, SDP             |
 | [Ipopt](https://github.com/coin-or/Ipopt)                                      | [Ipopt.jl](https://github.com/jump-dev/Ipopt.jl)                                 |        | EPL      | LP, QP, NLP               |
+| [JaCoP](https://github.com/radsz/jacop)                                        | [JaCoP.jl](https://github.com/JuliaConstraints/JaCoP.jl)                         |        | AGPL     | CP-SAT                    |
 | [Juniper.jl](https://github.com/lanl-ansi/Juniper.jl)                          |                                                                                  |        | MIT      | (MI)SOCP, (MI)NLP         |
 | [Loraine.jl](https://github.com/kocvara/Loraine.jl)                            |                                                                                  |        | MIT      | LP, SDP                   |
 | [MadNLP.jl](https://github.com/sshin23/MadNLP.jl)                              |                                                                                  |        | MIT      | LP, QP, NLP               |


### PR DESCRIPTION
## Basic

 - [x] Check that the solver is a registered Julia package
 - [x] Check that the solver supports the long-term support release of Julia
 - [x] Check that the solver has a MathOptInterface wrapper
 - [x] Check that the tests call `MOI.Test.runtests`. Some test excludes are
       permissible, but the reason for skipping a particular test should be
       documented.
 - [x] Check that the README and/or documentation provides an example of how to
       use the solver with JuMP

## Documentation

 - [x] Add a new row to the table in `docs/src/installation.md`

## Optional

 - [x] Add package metadata to `docs/packages.toml`