### PR TITLE
Fix failing test on Julia nightly

### DIFF
--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -1647,7 +1647,7 @@ function test_set_string_name_PSDCone()
     set_string_names_on_creation(model, false)
     x = @variable(model, [1:2, 1:2] in PSDCone())
     for xi in x
-        @test isempty(name(x))
+        @test isempty(name(xi))
     end
     @test sprint.(show, x) == ["_[1]" "_[2]"; "_[2]" "_[3]"]
     return

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -1635,7 +1635,9 @@ end
 function test_set_string_name_Symmetric()
     model = Model()
     x = @variable(model, [1:2, 1:2], Symmetric, set_string_name = false)
-    @test name.(x) == fill("", 2, 2)
+    for xi in x
+        @test isempty(name(xi))
+    end
     @test sprint.(show, x) == ["_[1]" "_[2]"; "_[2]" "_[3]"]
     return
 end

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -1646,7 +1646,9 @@ function test_set_string_name_PSDCone()
     model = Model()
     set_string_names_on_creation(model, false)
     x = @variable(model, [1:2, 1:2] in PSDCone())
-    @test name.(x) == fill("", 2, 2)
+    for xi in x
+        @test isempty(name(x))
+    end
     @test sprint.(show, x) == ["_[1]" "_[2]"; "_[2]" "_[3]"]
     return
 end


### PR DESCRIPTION
The issue is that even on old versions, you cannot create a Symmetric matrix of Strings.
```julia
julia> using LinearAlgebra

julia> Symmetric(["a" "b"; "b" "c"])
ERROR: MethodError: no method matching symmetric_type(::Type{String})
```

The failure in nightly is because of a change so that broadcasting `name.(x)` over a symmetric matrix `x` now tries to create a symmetric matrix as the answer. (That seems pretty reasonable.)

Yet another problem caused by Julia's ill-defined interfaces.