### PR TITLE
[docs] improve the module docstring

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -11,9 +11,29 @@
 """
     JuMP
 
-An algebraic modeling language for Julia.
+JuMP is an algebraic modeling language for Julia.
 
-For more information, go to https://jump.dev.
+## Documentation
+
+The documentation for JuMP is hosted at https://jump.dev/JuMP.jl
+
+There is also a copy of the documentation in the `/docs/src` directory of the
+source code. To find the directory on your local machine, run
+```julia
+julia> using JuMP; pkgdir(JuMP, "docs", "src")
+```
+
+## Getting help
+
+If you need help, please ask a question on the JuMP community forum at
+https://jump.dev/forum.
+
+If you have a reproducible example of a bug in JuMP, please open a GitHub issue
+by going to https://github.com/jump-dev/JuMP.jl/issues/new.
+
+## More information
+
+For more information on JuMP, go to https://jump.dev.
 """
 module JuMP
 


### PR DESCRIPTION
@mlubin and I have been chatting about ways to make JuMP more accessible for coding agents.

Now if you look at `? JuMP` you get:

```Julia
julia> using JuMP

help?> JuMP
search: JuMP

  JuMP

  JuMP is an algebraic modeling language for Julia.

  Documentation
  =============

  The documentation for JuMP is hosted at https://jump.dev/JuMP.jl

  There is also a copy of the documentation in the /docs/src directory of the source code. To find the
  directory on your local machine, run

  julia> using JuMP; pkgdir(JuMP, "docs", "src")

  Getting help
  ============

  If you need help, please ask a question on the JuMP community forum at https://jump.dev/forum.

  If you have a reproducible example of a bug in JuMP, please open a GitHub issue by going to
  https://github.com/jump-dev/JuMP.jl/issues/new.

  More information
  ================

  For more information on JuMP, go to https://jump.dev.
```

I wonder if we could/should also put something in the comment header at the top of each source file?