### PR TITLE
Improve error messages in src/constraints.jl

### DIFF
--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -726,6 +726,7 @@ ERROR: Constraints of type MathOptInterface.ScalarQuadraticFunction{Float64}-in-
 If you expected the solver to support your problem, you may have an error in your formulation. Otherwise, consider using a different solver.
 
 The list of available solvers, along with the problem types they support, is available at https://jump.dev/JuMP.jl/stable/installation/#Supported-solvers.
+
 Stacktrace:
 ```
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -562,8 +562,12 @@ Stacktrace:
 function delete(model::GenericModel, con_ref::ConstraintRef)
     if model !== con_ref.model
         error(
-            "The constraint reference you are trying to delete does not " *
-            "belong to the model.",
+            """
+            Cannot delete this constraint because it does not belong to this model.
+
+            Use `owner_model(con_ref)` to find which model owns the constraint, then \
+            delete it from that model.
+            """,
         )
     end
     model.is_model_dirty = true
@@ -614,8 +618,13 @@ function delete(
 )
     if any(c -> model !== c.model, con_refs)
         error(
-            "A constraint reference you are trying to delete does not " *
-            "belong to the model.",
+            """
+            One or more constraints in the vector cannot be deleted because they do not \
+            belong to this model.
+
+            Use `owner_model(con_ref)` to check which model owns each constraint, then \
+            delete it from that model.
+            """,
         )
     end
     model.is_model_dirty = true
@@ -1005,12 +1014,15 @@ function _moi_add_constraint(
 ) where {F<:MOI.AbstractFunction,S<:MOI.AbstractSet}
     if !MOI.supports_constraint(model, F, S)
         error(
-            "Constraints of type $(F)-in-$(S) are not supported by the " *
-            "solver.\n\nIf you expected the solver to support your problem, " *
-            "you may have an error in your formulation. Otherwise, consider " *
-            "using a different solver.\n\nThe list of available solvers, " *
-            "along with the problem types they support, is available at " *
-            "https://jump.dev/JuMP.jl/stable/installation/#Supported-solvers.",
+            """
+            Constraints of type $(F)-in-$(S) are not supported by the solver.
+
+            If you expected the solver to support your problem, you may have an error in \
+            your formulation. Otherwise, consider using a different solver.
+
+            The list of available solvers, along with the problem types they support, is \
+            available at https://jump.dev/JuMP.jl/stable/installation/#Supported-solvers.
+            """,
         )
     end
     return MOI.add_constraint(model, f, s)
@@ -1188,17 +1200,18 @@ end
 
 function _moi_add_to_function_constant(
     model::MOI.ModelLike,
-    ci::MOI.ConstraintIndex{
-        <:MOI.AbstractScalarFunction,
-        <:MOI.AbstractScalarSet,
-    },
+    ci::MOI.ConstraintIndex{F,S},
     value,
-)
+) where {F<:MOI.AbstractScalarFunction,S<:MOI.AbstractScalarSet}
     set = MOI.get(model, MOI.ConstraintSet(), ci)
-    if !MOI.Utilities.supports_shift_constant(typeof(set))
+    if !MOI.Utilities.supports_shift_constant(S)
         error(
-            "Unable to add to function constant for constraint type " *
-            "$(typeof(ci))",
+            """
+            Cannot add to the function constant for constraints of type $F-in-$S \
+            because the constraint set does not support shifting the constant term.
+
+            Use `set_normalized_rhs` to modify the right-hand side of scalar constraints.
+            """,
         )
     end
     new_set = MOIU.shift_constant(set, -value)
@@ -1484,15 +1497,24 @@ function shadow_price(
     model = owner_model(con_ref)
     if !has_duals(model)
         error(
-            "The shadow price is not available because no dual result is " *
-            "available.",
+            """
+            The shadow price is not available because no dual result is available.
+
+            Call `optimize!(model)` before querying the shadow price, and check \
+            `has_duals(model)` to verify that a dual solution exists.
+            """,
         )
     end
     sense = objective_sense(model)
     if sense == FEASIBILITY_SENSE
         error(
-            "The shadow price is not available because the objective sense " *
-            "$sense is not minimization or maximization.",
+            """
+            The shadow price is not available because the objective sense $sense is \
+            not minimization or maximization.
+
+            Set an objective using `@objective(model, Min, ...)` or \
+            `@objective(model, Max, ...)` before querying the shadow price.
+            """,
         )
     end
     return _shadow_price(S, dual(con_ref), sense)
@@ -1500,8 +1522,13 @@ end
 
 function _shadow_price(::Type{S}, ::Any, ::Any) where {S}
     return error(
-        "The shadow price is not defined or not implemented for this type " *
-        "of constraint.",
+        """
+        The shadow price is not defined or not implemented for constraints with \
+        set type $(S).
+
+        Shadow prices are only supported for `LessThan`, `GreaterThan`, and \
+        `EqualTo` constraints.
+        """,
     )
 end
 
@@ -1529,15 +1556,23 @@ function _shadow_price(::Type{MOI.EqualTo{T}}, dual, sense) where {T}
     end
 end
 
-function _error_if_not_concrete_type(t)
-    if !isconcretetype(t)
-        error("`$t` is not a concrete type. Did you miss a type parameter?")
+function _error_if_not_concrete_type(::Type{T}) where {T}
+    if !isconcretetype(T)
+        error(
+            """
+            `$T` is not a concrete type. Did you miss a type parameter?
+
+            Provide a concrete type such as `AffExpr` instead of `GenericAffExpr`, or \
+            `MOI.GreaterThan{Float64}` instead of `MOI.GreaterThan`.
+            """,
+        )
     end
     return
 end
+
 # `isconcretetype(Vector{Integer})` is `true`
-function _error_if_not_concrete_type(t::Type{Vector{ElT}}) where {ElT}
-    return _error_if_not_concrete_type(ElT)
+function _error_if_not_concrete_type(::Type{Vector{T}}) where {T}
+    return _error_if_not_concrete_type(T)
 end
 
 """

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -785,13 +785,20 @@ function test_all_constraints_scalar()
     aff_constraints = all_constraints(model, AffExpr, MOI.GreaterThan{Float64})
     @test isempty(aff_constraints)
     err = ErrorException(
-        "`MathOptInterface.GreaterThan` is not a " *
-        "concrete type. Did you miss a type parameter?",
+        """
+        `MathOptInterface.GreaterThan` is not a concrete type. Did you miss a type parameter?
+
+        Provide a concrete type such as `AffExpr` instead of `GenericAffExpr`, or `MOI.GreaterThan{Float64}` instead of `MOI.GreaterThan`.
+        """,
     )
     @test_throws err num_constraints(model, AffExpr, MOI.GreaterThan)
     @test_throws err all_constraints(model, AffExpr, MOI.GreaterThan)
     err = ErrorException(
-        "`JuMP.GenericAffExpr` is not a concrete type. Did you miss a type parameter?",
+        """
+        `JuMP.GenericAffExpr` is not a concrete type. Did you miss a type parameter?
+
+        Provide a concrete type such as `AffExpr` instead of `GenericAffExpr`, or `MOI.GreaterThan{Float64}` instead of `MOI.GreaterThan`.
+        """,
     )
     @test_throws err try
         num_constraints(model, GenericAffExpr, MOI.ZeroOne)
@@ -852,8 +859,11 @@ function test_all_constraints_vector()
     @test isempty(aff_constraints)
     err = ErrorException(
         replace(
-            "`$(GenericAffExpr{Float64})` is not a concrete type. Did you " *
-            "miss a type parameter?",
+            """
+            `$(GenericAffExpr{Float64})` is not a concrete type. Did you miss a type parameter?
+
+            Provide a concrete type such as `AffExpr` instead of `GenericAffExpr`, or `MOI.GreaterThan{Float64}` instead of `MOI.GreaterThan`.
+            """,
             "" => "",
         ),
     )
@@ -876,8 +886,11 @@ function test_all_constraints_vector()
         error(replace(e.msg, "" => ""))
     end
     err = ErrorException(
-        "`MathOptInterface.SOS1` is not a " *
-        "concrete type. Did you miss a type parameter?",
+        """
+        `MathOptInterface.SOS1` is not a concrete type. Did you miss a type parameter?
+
+        Provide a concrete type such as `AffExpr` instead of `GenericAffExpr`, or `MOI.GreaterThan{Float64}` instead of `MOI.GreaterThan`.
+        """,
     )
     @test_throws err all_constraints(
         model,
@@ -2182,8 +2195,11 @@ function test_shadow_price_errors()
     @constraint(model, c4, x in MOI.Interval(0.0, 1.0))
     @test_throws(
         ErrorException(
-            "The shadow price is not available because no dual result is " *
-            "available.",
+            """
+            The shadow price is not available because no dual result is available.
+
+            Call `optimize!(model)` before querying the shadow price, and check `has_duals(model)` to verify that a dual solution exists.
+            """,
         ),
         shadow_price(c1),
     )
@@ -2198,7 +2214,11 @@ function test_shadow_price_errors()
     optimize!(model)
     @test_throws(
         ErrorException(
-            "The shadow price is not available because the objective sense $FEASIBILITY_SENSE is not minimization or maximization.",
+            """
+            The shadow price is not available because the objective sense $FEASIBILITY_SENSE is not minimization or maximization.
+
+            Set an objective using `@objective(model, Min, ...)` or `@objective(model, Max, ...)` before querying the shadow price.
+            """,
         ),
         shadow_price(c1),
     )
@@ -2208,7 +2228,11 @@ function test_shadow_price_errors()
     @test shadow_price(c3) == -1.0
     @test_throws(
         ErrorException(
-            "The shadow price is not defined or not implemented for this type of constraint.",
+            """
+            The shadow price is not defined or not implemented for constraints with set type $(MOI.Interval{Float64}).
+
+            Shadow prices are only supported for `LessThan`, `GreaterThan`, and `EqualTo` constraints.
+            """,
         ),
         shadow_price(c4),
     )
@@ -2218,7 +2242,11 @@ function test_shadow_price_errors()
     @test shadow_price(c3) == 1.0
     @test_throws(
         ErrorException(
-            "The shadow price is not defined or not implemented for this type of constraint.",
+            """
+            The shadow price is not defined or not implemented for constraints with set type $(MOI.Interval{Float64}).
+
+            Shadow prices are only supported for `LessThan`, `GreaterThan`, and `EqualTo` constraints.
+            """,
         ),
         shadow_price(c4),
     )

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -237,12 +237,13 @@ function test_bridges_automatic_disabled()
     F = MOI.ScalarAffineFunction{Float64}
     S = MOI.Interval{Float64}
     err = ErrorException(
-        "Constraints of type $(F)-in-$(S) are not supported by the " *
-        "solver.\n\nIf you expected the solver to support your problem, " *
-        "you may have an error in your formulation. Otherwise, consider " *
-        "using a different solver.\n\nThe list of available solvers, " *
-        "along with the problem types they support, is available at " *
-        "https://jump.dev/JuMP.jl/stable/installation/#Supported-solvers.",
+        """
+        Constraints of type $(F)-in-$(S) are not supported by the solver.
+
+        If you expected the solver to support your problem, you may have an error in your formulation. Otherwise, consider using a different solver.
+
+        The list of available solvers, along with the problem types they support, is available at https://jump.dev/JuMP.jl/stable/installation/#Supported-solvers.
+        """,
     )
     @test_throws err @constraint model 0 <= x + 1 <= 1
 end
@@ -256,12 +257,13 @@ function test_bridges_direct()
     F = MOI.ScalarAffineFunction{Float64}
     S = MOI.Interval{Float64}
     err = ErrorException(
-        "Constraints of type $(F)-in-$(S) are not supported by the " *
-        "solver.\n\nIf you expected the solver to support your problem, " *
-        "you may have an error in your formulation. Otherwise, consider " *
-        "using a different solver.\n\nThe list of available solvers, " *
-        "along with the problem types they support, is available at " *
-        "https://jump.dev/JuMP.jl/stable/installation/#Supported-solvers.",
+        """
+        Constraints of type $(F)-in-$(S) are not supported by the solver.
+
+        If you expected the solver to support your problem, you may have an error in your formulation. Otherwise, consider using a different solver.
+
+        The list of available solvers, along with the problem types they support, is available at https://jump.dev/JuMP.jl/stable/installation/#Supported-solvers.
+        """,
     )
     @test_throws err @constraint model 0 <= x + 1 <= 1
 end


### PR DESCRIPTION
x-ref #4175

`````
I want to improve the error messages in JuMP (the source code is in the current
directory).

Error messages take the form `error("msg")`. For this task, we want to rewrite
the contents of the string `"msg"`. Don't change `error` to a different type of
error.

Good error messages:

 * Start with a user-interpretable sentence explaining why we are throwing an
   error
 * Interpolate any relevant values into the messages
 * Finish with a sentence explaining how to fix or avoid the error.

Good error messages are formatted like this:

```julia
error(
    """
    A sentence decribing what went wrong, including any relevant values
    interpolated into the string.

    A sentence or two describing how to fix the error.
    """,
)
```

An example of a good change is:
```patch
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -170,7 +170,13 @@ struct VariableInfo{S,T,U,V}
             upper_bound = NaN
         end
         if has_fix && !_isfinite(fixed_value)
-            error("Unable to fix variable to $(fixed_value)")
+            error(
+                """
+                Unable to fix variable to $(fixed_value) because the value is not finite.
+
+                Fixed variable bounds must be finite. They cannot be values like `NaN`, `Inf`, or `-Inf`.
+                """,
+            )
```

To begin, propose changes to all of the error messages in src/constraints.jl.
Ask clarifying questions if needed. Once you have made the change to the code in
`src`, we must also make changes to any of the tests in test/ that check for the
exact string in the error message.
`````