### PR TITLE
Add ALGLIB Solver to installation docs

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -108,6 +108,7 @@ The link in the `Solver` column is the corresponding Julia package.
 
 | Solver                                                                         | Julia Package                                                                    | Installation | License | Supports             |
 | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- | ------------ | ------- | ---------------------|
+| [ALGLIB Solver](https://www.alglib.net/)                                       | [ALGLIB.jl](https://github.com/alglib-project/ALGLIB.jl)                         | Manual |Free/Comm.| (MI)NLP                   |
 | [Alpine.jl](https://github.com/lanl-ansi/Alpine.jl)                            |                                                                                  |        | Triad NS | (MI)NLP                   |
 | [Artelys Knitro](https://www.artelys.com/knitro)                               | [KNITRO.jl](https://github.com/jump-dev/KNITRO.jl)                               | Manual | Comm.    | (MI)LP, (MI)SOCP, (MI)NLP |
 | [BARON](http://minlp.com/baron)                                                | [BARON.jl](https://github.com/joehuchette/BARON.jl)                              | Manual | Comm.    | (MI)NLP                   |

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -108,7 +108,7 @@ The link in the `Solver` column is the corresponding Julia package.
 
 | Solver                                                                         | Julia Package                                                                    | Installation | License | Supports             |
 | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- | ------------ | ------- | ---------------------|
-| [ALGLIB Solver](https://www.alglib.net/)                                       | [ALGLIB.jl](https://github.com/alglib-project/ALGLIB.jl)                         | Manual |Free/Comm.| (MI)NLP                   |
+| [ALGLIB Solver](https://www.alglib.net/)                                       | [ALGLIB.jl](https://github.com/alglib-project/ALGLIB.jl)                         | Manual | Comm.    | (MI)NLP                   |
 | [Alpine.jl](https://github.com/lanl-ansi/Alpine.jl)                            |                                                                                  |        | Triad NS | (MI)NLP                   |
 | [Artelys Knitro](https://www.artelys.com/knitro)                               | [KNITRO.jl](https://github.com/jump-dev/KNITRO.jl)                               | Manual | Comm.    | (MI)LP, (MI)SOCP, (MI)NLP |
 | [BARON](http://minlp.com/baron)                                                | [BARON.jl](https://github.com/joehuchette/BARON.jl)                              | Manual | Comm.    | (MI)NLP                   |


### PR DESCRIPTION
This PR adds ALGLIB Solver to the supported solvers table.

ALGLIB.jl is registered in Julia General and provides a JuMP/MathOptInterface wrapper for the external ALGLIB Solver executable.

The checklist is below:

## Basic

 - [x] Check that the solver is a registered Julia package
 - [x] Check that the solver supports the long-term support release of Julia
 - [x] Check that the solver has a MathOptInterface wrapper
 - [x] Check that the tests call `MOI.Test.runtests`. Some test excludes are
       permissible, but the reason for skipping a particular test should be
       documented.
 - [x] Check that the README and/or documentation provides an example of how to
       use the solver with JuMP

## Documentation

 - [x] Add a new row to the table in `docs/src/installation.md`

## Optional

 - [NO] Add package metadata to `docs/packages.toml`
