### PR TITLE
Fix BridgeableConstraint with model_convert

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -747,6 +747,11 @@ function add_constraint(
     con::BridgeableConstraint,
     name::String = "",
 )
+    # Like the generic `add_constraint`, convert to the value type of the model.
+    # This is needed for constraints that reach this method without going through
+    # the `model_convert` call of the `@constraint` macro, e.g. constraints built
+    # in `add_constraint` by an extension that delays their construction.
+    con = model_convert(model, con)
     add_bridge(model, con.bridge_type; coefficient_type = con.coefficient_type)
     return add_constraint(model, con.constraint, name)
 end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -748,9 +748,10 @@ function add_constraint(
     name::String = "",
 )
     # Like the generic `add_constraint`, convert to the value type of the model.
-    # This is needed for constraints that reach this method without going through
-    # the `model_convert` call of the `@constraint` macro, e.g. constraints built
-    # in `add_constraint` by an extension that delays their construction.
+    # This is needed for constraints that reach this method without going
+    # through the `model_convert` call of the `@constraint` macro. This happens
+    # with constraints built in `add_constraint` by an extension that delays
+    # their construction.
     con = model_convert(model, con)
     add_bridge(model, con.bridge_type; coefficient_type = con.coefficient_type)
     return add_constraint(model, con.constraint, name)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -326,15 +326,13 @@ function model_convert(model::AbstractModel, con::BridgeableConstraint)
     # The bridge `coefficient_type` is set by `build_constraint` which does not
     # have access to the model. We convert it to the value type of the model
     # (keeping the same real/complex flavor) just like we convert the
-    # coefficients of the function. This is needed so that, e.g., the bridges
-    # registered for a `GenericModel{T}` with `T != Float64` use `T`.
+    # coefficients of the function. This is needed so that, for example, the
+    # bridges registered for a `GenericModel{T}` with `T != Float64` use `T`.
+    C = _complex_convert_type(value_type(typeof(model)), con.coefficient_type)
     return BridgeableConstraint(
         model_convert(model, con.constraint),
         con.bridge_type;
-        coefficient_type = _complex_convert_type(
-            value_type(typeof(model)),
-            con.coefficient_type,
-        ),
+        coefficient_type = C,
     )
 end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -323,10 +323,18 @@ function model_convert(model::AbstractModel, α::Number)
 end
 
 function model_convert(model::AbstractModel, con::BridgeableConstraint)
+    # The bridge `coefficient_type` is set by `build_constraint` which does not
+    # have access to the model. We convert it to the value type of the model
+    # (keeping the same real/complex flavor) just like we convert the
+    # coefficients of the function. This is needed so that, e.g., the bridges
+    # registered for a `GenericModel{T}` with `T != Float64` use `T`.
     return BridgeableConstraint(
         model_convert(model, con.constraint),
         con.bridge_type;
-        con.coefficient_type,
+        coefficient_type = _complex_convert_type(
+            value_type(typeof(model)),
+            con.coefficient_type,
+        ),
     )
 end
 

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -436,29 +436,28 @@ function test_macro_bridgeable()
     model = Model()
     @variable(model, x)
     @constraint(model, x in BridgeMe{Int,Nonnegative}(Nonnegative()))
-    # `model_convert` normalizes the bridge coefficient type to the value type of
-    # the model (`Float64`), even though `BridgeMe` requested `Int`.
+    # `model_convert` normalizes the bridge coefficient type to the value type
+    # of the model (`Float64`), even though `BridgeMe` requested `Int`.
     @test NonnegativeBridge{Float64} in model.bridge_types
     @test !(NonnegativeBridge{Int} in model.bridge_types)
+    return
 end
 
 function test_model_convert_bridgeable_coefficient_type()
     model = GenericModel{BigFloat}()
     @variable(model, x)
-    constraint = ScalarConstraint(x, Nonnegative())
-    # A real coefficient type is converted to the value type of the model.
-    con = BridgeableConstraint(
-        constraint,
-        NonnegativeBridge;
-        coefficient_type = Int,
-    )
+    c = ScalarConstraint(x, Nonnegative())
+    con = BridgeableConstraint(c, NonnegativeBridge; coefficient_type = Int)
     @test model_convert(model, con).coefficient_type == BigFloat
-    # A complex coefficient type keeps its complex flavor.
-    con = BridgeableConstraint(
-        constraint,
-        NonnegativeBridge;
-        coefficient_type = Complex{Int},
-    )
+    return
+end
+
+function test_model_convert_bridgeable_coefficient_type_complex()
+    model = GenericModel{BigFloat}()
+    @variable(model, x)
+    c = ScalarConstraint(x, Nonnegative())
+    coefficient_type = Complex{Int}
+    con = BridgeableConstraint(c, NonnegativeBridge; coefficient_type)
     @test model_convert(model, con).coefficient_type == Complex{BigFloat}
     return
 end
@@ -473,19 +472,15 @@ function test_macro_bridgeable_generic_value_type()
 end
 
 function test_add_constraint_bridgeable_model_convert()
-    # `add_constraint` applies `model_convert`, so a `BridgeableConstraint` added
-    # directly (not via the `@constraint` macro, e.g. by an extension that delays
-    # the construction of the constraint) also gets its coefficient type
-    # converted to the value type of the model.
+    # `add_constraint` applies `model_convert`, so a `BridgeableConstraint`
+    # added directly (not via the `@constraint` macro, for example, by an
+    # extension that delays the construction of the constraint) also gets its
+    # coefficient type converted to the value type of the model.
     model = GenericModel{BigFloat}()
     @variable(model, x)
-    constraint = ScalarConstraint(x, Nonnegative())
-    bc = BridgeableConstraint(
-        constraint,
-        NonnegativeBridge;
-        coefficient_type = Int,
-    )
-    add_constraint(model, bc)
+    c = ScalarConstraint(x, Nonnegative())
+    con = BridgeableConstraint(c, NonnegativeBridge; coefficient_type = Int)
+    add_constraint(model, con)
     @test NonnegativeBridge{BigFloat} in model.bridge_types
     @test !(NonnegativeBridge{Int} in model.bridge_types)
     return

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -436,7 +436,59 @@ function test_macro_bridgeable()
     model = Model()
     @variable(model, x)
     @constraint(model, x in BridgeMe{Int,Nonnegative}(Nonnegative()))
-    @test NonnegativeBridge{Int} in model.bridge_types
+    # `model_convert` normalizes the bridge coefficient type to the value type of
+    # the model (`Float64`), even though `BridgeMe` requested `Int`.
+    @test NonnegativeBridge{Float64} in model.bridge_types
+    @test !(NonnegativeBridge{Int} in model.bridge_types)
+end
+
+function test_model_convert_bridgeable_coefficient_type()
+    model = GenericModel{BigFloat}()
+    @variable(model, x)
+    constraint = ScalarConstraint(x, Nonnegative())
+    # A real coefficient type is converted to the value type of the model.
+    con = BridgeableConstraint(
+        constraint,
+        NonnegativeBridge;
+        coefficient_type = Int,
+    )
+    @test model_convert(model, con).coefficient_type == BigFloat
+    # A complex coefficient type keeps its complex flavor.
+    con = BridgeableConstraint(
+        constraint,
+        NonnegativeBridge;
+        coefficient_type = Complex{Int},
+    )
+    @test model_convert(model, con).coefficient_type == Complex{BigFloat}
+    return
+end
+
+function test_macro_bridgeable_generic_value_type()
+    model = GenericModel{BigFloat}()
+    @variable(model, x)
+    @constraint(model, x in BridgeMe{Int,Nonnegative}(Nonnegative()))
+    @test NonnegativeBridge{BigFloat} in model.bridge_types
+    @test !(NonnegativeBridge{Int} in model.bridge_types)
+    return
+end
+
+function test_add_constraint_bridgeable_model_convert()
+    # `add_constraint` applies `model_convert`, so a `BridgeableConstraint` added
+    # directly (not via the `@constraint` macro, e.g. by an extension that delays
+    # the construction of the constraint) also gets its coefficient type
+    # converted to the value type of the model.
+    model = GenericModel{BigFloat}()
+    @variable(model, x)
+    constraint = ScalarConstraint(x, Nonnegative())
+    bc = BridgeableConstraint(
+        constraint,
+        NonnegativeBridge;
+        coefficient_type = Int,
+    )
+    add_constraint(model, bc)
+    @test NonnegativeBridge{BigFloat} in model.bridge_types
+    @test !(NonnegativeBridge{Int} in model.bridge_types)
+    return
 end
 
 function test_bridges_add_bridgeable_con_set_optimizer()


### PR DESCRIPTION
Tried fixing https://github.com/jump-dev/SumOfSquares.jl/issues/444 with Claude but he got really confused.
The root cause it that the way `model_convert` works is a bit unclear and inconsistent.
When you call `@constraint(model, ...)`, we first create an `AbstractConstraint` with `build_constraint`. There we don't have the model type so we cannot convert yet.
Then, in the macro code itself we call `model_convert`:
https://github.com/jump-dev/JuMP.jl/blob/44397c71edc7e65d85b55ce062f8b47dad0ea643/src/macros/%40constraint.jl#L188-L206
Then we pass the converted `AbstractConstraint` to `add_constraint` which then also calls `model_convert`:
https://github.com/jump-dev/JuMP.jl/blob/44397c71edc7e65d85b55ce062f8b47dad0ea643/src/constraints.jl#L1046
It a bit redundant. I checked and both were added in github.com/jump-dev/JuMP.jl/pull/3385.
The advantages of doing it in `add_constraint` are that 1) it's easier to maintain method implementations that macro code and 2) we don't need to do a broadcast in case of the vectorization.
In PolyJuMP, we create a constraint outside the macro so we rely on the `model_convert` in `add_constraint`.
https://github.com/jump-dev/PolyJuMP.jl/blob/571a9874547ea44efe38822e073a3aecffdb127c/src/constraint.jl#L282-L288
However, we didn't call `model_convert` there so that's an issue.

So there are a few ways to fix the issue in SumOfSquares. In all of them, we need the fix in `model_convert` of `BridgeableConstraint`. The question is, where should `model_convert` be called.
We should decide who's responsibility it is to call `model_convert`, is it

1) the caller of `add_constraint` or
2) the implementation of `add_constraint`.

In case

1) we should probably remove the `model_convert` in `add_constraint(::AbstractModel, ::AbstractConstraint)` (we may consider it breaking but that would only be for users that weren't using the macro so unclear if it's a big deal) and in case
2) we should add `model_convert` in `add_constraint(::GenericModel, ::BridgeableConstraint)` like done in this PR and then also remove the `model_convert` called from the macro.