### PR TITLE
Adds CONOPT to solvers documentation

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -39,6 +39,10 @@ Vale.Spelling = NO
 [docs/src/packages/Clarabel.md]
 Google.Latin = NO
 
+[docs/src/packages/CONOPT.md]
+Google.Latin = NO
+Google.OxfordComma = NO
+
 [docs/src/packages/CoolPDLP.md]
 Google.OptionalPlurals = NO
 

--- a/.vale.ini
+++ b/.vale.ini
@@ -39,10 +39,6 @@ Vale.Spelling = NO
 [docs/src/packages/Clarabel.md]
 Google.Latin = NO
 
-[docs/src/packages/CONOPT.md]
-Google.Latin = NO
-Google.OxfordComma = NO
-
 [docs/src/packages/CoolPDLP.md]
 Google.OptionalPlurals = NO
 

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -149,7 +149,7 @@
     rev = "v0.1.1"
 [CONOPT]
     user = "GAMS-dev"
-    rev = "93efb3badb311fcbf03806c475ec7075df3ed851"
+    rev = "9dc9a6c04897c56ac0f956899cc3e50643193ea3"
 [COPT]
     user = "COPT-Public"
     rev = "v1.1.33"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -147,6 +147,9 @@
 [CoolPDLP]
     user = "JuliaDecisionFocusedLearning"
     rev = "v0.1.1"
+[CONOPT]
+    user = "GAMS-dev"
+    rev = "93efb3badb311fcbf03806c475ec7075df3ed851"
 [COPT]
     user = "COPT-Public"
     rev = "v1.1.33"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -149,7 +149,7 @@
     rev = "v0.1.1"
 [CONOPT]
     user = "GAMS-dev"
-    rev = "9dc9a6c04897c56ac0f956899cc3e50643193ea3"
+    rev = "v0.1.0"
 [COPT]
     user = "COPT-Public"
     rev = "v1.1.33"

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -118,6 +118,7 @@ The link in the `Solver` column is the corresponding Julia package.
 | [CDD](https://github.com/cddlib/cddlib)                                        | [CDDLib.jl](https://github.com/JuliaPolyhedra/CDDLib.jl)                         |        | GPL      | LP                        |
 | [Clarabel.jl](https://github.com/oxfordcontrol/Clarabel.jl)                    |                                                                                  |        | Apache   | LP, QP, SOCP, SDP         |
 | [Clp](https://github.com/coin-or/Clp)                                          | [Clp.jl](https://github.com/jump-dev/Clp.jl)                                     |        | EPL      | LP                        |
+| [CONOPT](https://conopt.gams.com/)                                             | [CONOPT.jl](https://github.com/GAMS-dev/CONOPT.jl)                               | Manual | Comm.    | LP, QP, NLP               |
 | [CoolPDLP.jl](https://github.com/JuliaDecisionFocusedLearning/CoolPDLP.jl)     |                                                                                  |        | MIT      | LP                        |
 | [COPT](https://www.shanshu.ai/copt)                                            | [COPT.jl](https://github.com/COPT-Public/COPT.jl)                                |        | Comm.    | (MI)LP, SOCP, SDP         |
 | [COSMO.jl](https://github.com/oxfordcontrol/COSMO.jl)                          |                                                                                  |        | Apache   | LP, QP, SOCP, SDP         |


### PR DESCRIPTION
Adding the CONOPT.jl package to the solvers documentation.

We would like to discuss the possibility of bringing CONOPT.jl under the JuMP-dev organisation, similar to KNITRO.jl. The intention would be for us to continue the maintenance of CONOPT.jl as part of the JuMP community. We would include the line "Contact GAMS Software if you encounter any problem with this interface or the solver." in the documentation, as is the case for KNITRO.jl.

## Basic

 - [x] Check that the solver is a registered Julia package
 - [x] Check that the solver supports the long-term support release of Julia
 - [x] Check that the solver has a MathOptInterface wrapper
 - [x] Check that the tests call `MOI.Test.runtests`. Some test excludes are
       permissible, but the reason for skipping a particular test should be
       documented.
 - [x] Check that the README and/or documentation provides an example of how to
       use the solver with JuMP

## Documentation

 - [x] Add a new row to the table in `docs/src/installation.md`

## Optional

 - [x] Add package metadata to `docs/packages.toml`