### PR TITLE
[docs] drop GitHub owner from solvers and extensions

### DIFF
--- a/docs/make_utilities.jl
+++ b/docs/make_utilities.jl
@@ -432,7 +432,7 @@ function list_of_solvers_and_extensions()
     _LIST_OF_EXTENSIONS =
         Pair{String,String}["DimensionalData.jl"=>"extensions/DimensionalData.md",]
     for (solver, data) in TOML.parsefile(joinpath(@__DIR__, "packages.toml"))
-        repo = string(solver, get(data, "ext", ".jl")=)
+        repo = string(solver, get(data, "ext", ".jl"))
         if get(data, "extension", false)
             push!(_LIST_OF_EXTENSIONS, repo => "packages/$solver.md")
         else

--- a/docs/make_utilities.jl
+++ b/docs/make_utilities.jl
@@ -430,19 +430,18 @@ end
 function list_of_solvers_and_extensions()
     _LIST_OF_SOLVERS = Pair{String,String}[]
     _LIST_OF_EXTENSIONS =
-        Pair{String,String}["rafaqz/DimensionalData.jl"=>"extensions/DimensionalData.md",]
+        Pair{String,String}["DimensionalData.jl"=>"extensions/DimensionalData.md",]
     for (solver, data) in TOML.parsefile(joinpath(@__DIR__, "packages.toml"))
-        user = get(data, "user", "jump-dev")
-        user_repo = string(user, "/", solver, get(data, "ext", ".jl"))
+        repo = string(solver, get(data, "ext", ".jl")=)
         if get(data, "extension", false)
-            push!(_LIST_OF_EXTENSIONS, user_repo => "packages/$solver.md")
+            push!(_LIST_OF_EXTENSIONS, repo => "packages/$solver.md")
         else
-            push!(_LIST_OF_SOLVERS, user_repo => "packages/$solver.md")
+            push!(_LIST_OF_SOLVERS, repo => "packages/$solver.md")
         end
     end
     # Sort, with jump-dev repos at the start.
-    sort!(_LIST_OF_SOLVERS; by = x -> (!startswith(x[1], "jump-dev/"), x[1]))
-    sort!(_LIST_OF_EXTENSIONS; by = x -> (!startswith(x[1], "jump-dev/"), x[1]))
+    sort!(_LIST_OF_SOLVERS; by = first)
+    sort!(_LIST_OF_EXTENSIONS; by = first)
     pushfirst!(_LIST_OF_SOLVERS, "Introduction" => "packages/solvers.md")
     pushfirst!(
         _LIST_OF_EXTENSIONS,

--- a/docs/src/developers/checklists.md
+++ b/docs/src/developers/checklists.md
@@ -63,7 +63,7 @@ done in the same commit, or separately. The last commit should have the message
 Use the following checklist when adding a new solver to the JuMP documentation.
 
 ````
-## Basic
+## Check the upstream package
 
  - [ ] Check that the solver is a registered Julia package
  - [ ] Check that the solver supports the long-term support release of Julia
@@ -74,13 +74,21 @@ Use the following checklist when adding a new solver to the JuMP documentation.
  - [ ] Check that the README and/or documentation provides an example of how to
        use the solver with JuMP
 
-## Documentation
+## Add the package to the supported solvers table
 
  - [ ] Add a new row to the table in `docs/src/installation.md`
 
-## Optional
+## Add the package to the `/solvers` section of the JuMP documentation
+
+This section is optional.
 
  - [ ] Add package metadata to `docs/packages.toml`
+ - [ ] Check that the README has an `## Affiliation` section describing who
+       develops and maintains the package
+ - [ ] Check that the README has a `## Getting help` section describing where
+       the user should ask for help
+ - [ ] Check that the README has an `## Installation` section describing how to
+       install the package
 ````
 
 ## Adding a new shape

--- a/docs/src/extensions/introduction.md
+++ b/docs/src/extensions/introduction.md
@@ -5,15 +5,6 @@ JuMP extensions. The list of extensions is not exhaustive, but instead is
 intended to help you discover popular JuMP extensions, and to give you an
 overview of the types of extensions that are possible to write with JuMP.
 
-## Affiliation
-
-Packages beginning with `jump-dev/` are developed and maintained by the
-JuMP developers.
-
-Packages that do not begin with `jump-dev/` are developed independently. The
-developers of these packages requested or consented to the inclusion of their
-README contents in the JuMP documentation for the benefit of users.
-
 ## Adding new extensions
 
 Written an extension? Add it to this section of the JuMP documentation by making

--- a/docs/src/packages/solvers.md
+++ b/docs/src/packages/solvers.md
@@ -7,20 +7,6 @@ is intended to help you discover commonly used solvers.
 !!! tip
     [Supported solvers](@ref) lists all solvers supported by JuMP.
 
-## Affiliation
-
-Packages beginning with `jump-dev/` are developed and maintained by the
-JuMP developers. In many cases, these packages wrap external solvers that are
-not developed by the JuMP developers and, while the Julia packages are all
-open-source, in some cases the solvers themselves are closed source commercial
-products.
-
-Packages that do not begin with `jump-dev/` are developed independently. The
-developers of these packages requested or consented to the inclusion of their
-README contents in the JuMP documentation for the benefit of users.
-
 ## Adding new solvers
 
-Written a solver? Add it to this section of the JuMP documentation by making
-a pull request to the [`docs/packages.toml`](https://github.com/jump-dev/JuMP.jl/blob/master/docs/packages.toml)
-file.
+Written a solver? See the checklist [Adding a new solver to the documentation](@ref).


### PR DESCRIPTION
All packages are first-class. Belonging to jump-dev does not convey any importance from the perspective of a user. The jump-dev org exists to simplify maintenance and permissions of packages that the JuMP core contributors work on.

x-ref https://github.com/jump-dev/JuMP.jl/pull/4193

I'll put a preview link here when the docs run: https://jump.dev/JuMP.jl/previews/PR4195/packages/solvers/