### PR TITLE
Revert #4032 because it is subject to hash collisions

### DIFF
--- a/src/jump_moi_function.jl
+++ b/src/jump_moi_function.jl
@@ -167,10 +167,10 @@ end
 moi_function_type(::Type{<:GenericNonlinearExpr}) = MOI.ScalarNonlinearFunction
 
 function moi_function(model::GenericModel, f::GenericNonlinearExpr{V}) where {V}
-    key = objectid(f)
-    if haskey(model.subexpressions, key)
-        return model.subexpressions[key]
-    end
+    # key = objectid(f)
+    # if haskey(model.subexpressions, key)
+    #     return model.subexpressions[key]
+    # end
     ret = MOI.ScalarNonlinearFunction(f.head, similar(f.args))
     stack = Tuple{MOI.ScalarNonlinearFunction,Int,GenericNonlinearExpr{V}}[]
     for i in length(f.args):-1:1
@@ -182,11 +182,11 @@ function moi_function(model::GenericModel, f::GenericNonlinearExpr{V}) where {V}
     end
     while !isempty(stack)
         parent, i, arg = pop!(stack)
-        arg_key = objectid(arg)
-        if haskey(model.subexpressions, arg_key)
-            parent.args[i] = model.subexpressions[arg_key]
-            continue
-        end
+        # arg_key = objectid(arg)
+        # if haskey(model.subexpressions, arg_key)
+        #     parent.args[i] = model.subexpressions[arg_key]
+        #     continue
+        # end
         child = MOI.ScalarNonlinearFunction(arg.head, similar(arg.args))
         parent.args[i] = child
         for j in length(arg.args):-1:1
@@ -196,9 +196,9 @@ function moi_function(model::GenericModel, f::GenericNonlinearExpr{V}) where {V}
                 child.args[j] = moi_function(model, arg.args[j])
             end
         end
-        model.subexpressions[arg_key] = child
+        # model.subexpressions[arg_key] = child
     end
-    model.subexpressions[key] = ret
+    # model.subexpressions[key] = ret
     return ret
 end
 

--- a/test/test_nlp_expr.jl
+++ b/test/test_nlp_expr.jl
@@ -1390,38 +1390,38 @@ function test_custom_array()
     return
 end
 
-function test_scalar_nonlinear_moi_function()
-    model = Model()
-    @variable(model, x)
-    y1 = atan(x, 2)
-    y1_moi = MOI.ScalarNonlinearFunction(:atan, Any[index(x), 2])
-    y2 = y1 + y1
-    y2_moi = MOI.ScalarNonlinearFunction(:+, Any[y1_moi, y1_moi])
-    y3 = exp(y2)
-    y3_moi = MOI.ScalarNonlinearFunction(:exp, Any[y2_moi])
-    # Test y1
-    @test isapprox(moi_function(y1), y1_moi)
-    @test length(model.subexpressions) == 1
-    @test isapprox(moi_function(model, y1), y1_moi)
-    @test length(model.subexpressions) == 1
-    @test isapprox(model.subexpressions[objectid(y1)], y1_moi)
-    # Test y2
-    @test isapprox(moi_function(y2), y2_moi)
-    @test length(model.subexpressions) == 2
-    @test isapprox(moi_function(model, y2), y2_moi)
-    @test length(model.subexpressions) == 2
-    @test isapprox(model.subexpressions[objectid(y1)], y1_moi)
-    @test isapprox(model.subexpressions[objectid(y2)], y2_moi)
-    # Test y3
-    @test isapprox(moi_function(y3), y3_moi)
-    @test length(model.subexpressions) == 3
-    @test isapprox(moi_function(model, y3), y3_moi)
-    @test length(model.subexpressions) == 3
-    @test isapprox(model.subexpressions[objectid(y1)], y1_moi)
-    @test isapprox(model.subexpressions[objectid(y2)], y2_moi)
-    @test isapprox(model.subexpressions[objectid(y3)], y3_moi)
-    return
-end
+# function test_scalar_nonlinear_moi_function()
+#     model = Model()
+#     @variable(model, x)
+#     y1 = atan(x, 2)
+#     y1_moi = MOI.ScalarNonlinearFunction(:atan, Any[index(x), 2])
+#     y2 = y1 + y1
+#     y2_moi = MOI.ScalarNonlinearFunction(:+, Any[y1_moi, y1_moi])
+#     y3 = exp(y2)
+#     y3_moi = MOI.ScalarNonlinearFunction(:exp, Any[y2_moi])
+#     # Test y1
+#     @test isapprox(moi_function(y1), y1_moi)
+#     @test length(model.subexpressions) == 1
+#     @test isapprox(moi_function(model, y1), y1_moi)
+#     @test length(model.subexpressions) == 1
+#     @test isapprox(model.subexpressions[objectid(y1)], y1_moi)
+#     # Test y2
+#     @test isapprox(moi_function(y2), y2_moi)
+#     @test length(model.subexpressions) == 2
+#     @test isapprox(moi_function(model, y2), y2_moi)
+#     @test length(model.subexpressions) == 2
+#     @test isapprox(model.subexpressions[objectid(y1)], y1_moi)
+#     @test isapprox(model.subexpressions[objectid(y2)], y2_moi)
+#     # Test y3
+#     @test isapprox(moi_function(y3), y3_moi)
+#     @test length(model.subexpressions) == 3
+#     @test isapprox(moi_function(model, y3), y3_moi)
+#     @test length(model.subexpressions) == 3
+#     @test isapprox(model.subexpressions[objectid(y1)], y1_moi)
+#     @test isapprox(model.subexpressions[objectid(y2)], y2_moi)
+#     @test isapprox(model.subexpressions[objectid(y3)], y3_moi)
+#     return
+# end
 
 function test_addition_with_zero_Base_sum()
     model = Model()


### PR DESCRIPTION
x-ref #4203

This is a serious correctness issue, so while we discuss what _should_ happen, I'm going to temporarily disable the feature and issue a patch release.